### PR TITLE
Pass string value to a formatBalance filter

### DIFF
--- a/dashboard/src/components/shared/format/Money.vue
+++ b/dashboard/src/components/shared/format/Money.vue
@@ -4,7 +4,7 @@
       {{ value | formatBalance(decimals, unit) }}
     </span>
     <span v-if="fiatValue">
-      / {{ fiatValue | formatBalance(decimals, showFiatValue.toUpperCase()) }}
+      / {{ fiatValue.toString() | formatBalance(decimals, showFiatValue.toUpperCase()) }}
     </span>
   </div>
 </template>


### PR DESCRIPTION
Fixes #239

Looks like formatBalance doesn't work with bigger numbers

There is and error `Error in render: "Error: Assertion failed"` when the price in USD is >= 10 000

However it works well with string values so I've just added `.toString()` and it works