### PR TITLE
Add vue-social-sharing plugin

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -51,6 +51,7 @@
     "vue-meta": "^2.4.0",
     "vue-property-decorator": "^8.4.0",
     "vue-router": "^3.1.5",
+    "vue-social-sharing": "^3.0.7",
     "vuex": "^3.1.2",
     "vuex-persist": "^2.2.0"
   },

--- a/dashboard/src/colors.scss
+++ b/dashboard/src/colors.scss
@@ -2,4 +2,5 @@ $primary: #d32e79;
 $primary-invert: findColorInvert($primary);
 $dark: rgba(0,0,0,0.74);
 $dark-invert: findColorInvert($dark);
-$less-white: #fcfcfc
+$less-white: #fcfcfc;
+$white: #fff;

--- a/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
+++ b/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
@@ -1,93 +1,116 @@
 <template>
-  <div class="card">
+  <div class="card share">
     <footer class="card-footer">
-      <p class="card-footer-item">
-        <span>
-          <a :href="twitterUri"
-              target="_blank">
-            <b-icon
-              size="is-large"
-              pack="fab"
-              icon="twitter">
-            </b-icon>
-          </a>
-        </span>
-      </p>
-      <p class="card-footer-item">
-        <span>
-          <a :href="telegramUri"
-              target="_blank">
-            <b-icon
-              size="is-large"
-              pack="fab"
-              icon="telegram">
-            </b-icon>
-          </a>
-        </span>
-      </p>
-      <p class="card-footer-item">
-        <ShareNetwork
-          network="facebook"
-          :url="realworldFullPath"
-          title="Check this cool NFT on Kusama Network"
-          hashtags="kodadot"
+      <div class="card-footer-item">
+        <b-button
+          size="is-medium"
+          v-clipboard:copy="realworldFullPathShare"
+          @click="toast('URL copied to clipboard')"
+          class="share__button"
         >
           <b-icon
-            size="is-large"
-            pack="fab"
-            icon="facebook">
+            size="is-medium"
+            pack="fas"
+            icon="link">
           </b-icon>
-        </ShareNetwork>
-      </p>
-      <p class="card-footer-item">
-        <span>
-          <a :href="linemeUri"
-              target="_blank">
+        </b-button>
+      </div>
+      <div class="card-footer-item">
+        <b-button
+          size="is-medium"
+          v-clipboard:copy="iframeUri"
+          @click="toast('Code copied to clipboard')"
+          class="share__button"
+        >
+          <b-icon
+            size="is-medium"
+            pack="fas"
+            icon="code">
+          </b-icon>
+        </b-button>
+      </div>
+      <div class="card-footer-item">
+        <b-tooltip
+          type="is-light"
+          class="share__tooltip"
+          :triggers="['click']"
+          :auto-close="['outside', 'escape']"
+        >
+          <template v-slot:content>
+            <ShareNetwork
+              network="twitter"
+              :url="realworldFullPath"
+              :title="label"
+              twitter-user="KodaDot"
+            >
+              <b-icon
+                size="is-large"
+                pack="fab"
+                icon="twitter"
+              >
+              </b-icon>
+            </ShareNetwork>
+            <ShareNetwork
+              network="telegram"
+              :url="realworldFullPath"
+              :title="label"
+            >
+              <b-icon
+                size="is-large"
+                pack="fab"
+                icon="telegram"
+              >
+              </b-icon>
+            </ShareNetwork>
+            <ShareNetwork
+              network="line"
+              :url="realworldFullPath"
+              :title="label"
+            >
+              <b-icon
+                size="is-large"
+                pack="fab"
+                icon="line"
+              >
+              </b-icon>
+            </ShareNetwork>
+            <ShareNetwork
+              network="facebook"
+              :url="realworldFullPath"
+              :title="label"
+            >
+              <b-icon
+                size="is-large"
+                pack="fab"
+                icon="facebook"
+              >
+              </b-icon>
+            </ShareNetwork>
+          </template>
+          <b-button
+            class="share__button"
+            size="is-medium"
+          >
             <b-icon
               size="is-large"
-              pack="fab"
-              icon="line">
-            </b-icon>
-          </a>
-        </span>
-      </p>
-      <p class="card-footer-item">
-        <span>
-          <a
-            v-clipboard:copy="realworldFullPathShare"
-            @click="toast('URL copied to clipboard')">
-            <b-icon
-              size="is-medium"
               pack="fas"
-              icon="link">
+              icon="share-alt"
+            >
             </b-icon>
-          </a>
-        </span>
-      </p>
-      <p class="card-footer-item">
-        <span>
-          <a
-            v-clipboard:copy="iframeUri"
-            @click="toast('Code copied to clipboard')">
-            <b-icon
-              size="is-medium"
-              pack="fas"
-              icon="code">
-            </b-icon>
-          </a>
-        </span>
-      </p>
+          </b-button>
+        </b-tooltip>
+      </div>
     </footer>
   </div>
 </template>
 
 <script lang="ts" >
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue } from 'vue-property-decorator';
 import { IFrame, emptyIframe } from '../../types';
 
 @Component({})
 export default class Sharing extends Vue {
-  @Prop({ default: 'Check this cool NFT on %23KusamaNetwork %23kodadot' }) label!: string;
+  @Prop({ default: 'Check this cool NFT on #KusamaNetwork #KodaDot' }) label!: string;
   @Prop({ default: () => emptyIframe }) iframe!: IFrame;
 
   get helloText() {
@@ -143,3 +166,21 @@ export default class Sharing extends Vue {
   }
 }
 </script>
+
+<style lang="scss">
+  @import "@/colors";
+
+  .share {
+    &__button {
+      color: $primary;
+      border: none;
+    }
+
+    &__tooltip {
+      .tooltip-content {
+        display: flex;
+        flex-direction: column;
+      }
+    }
+  }
+</style>

--- a/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
+++ b/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
@@ -26,6 +26,20 @@
         </span>
       </p>
       <p class="card-footer-item">
+        <ShareNetwork
+          network="facebook"
+          :url="realworldFullPath"
+          title="Check this cool NFT on Kusama Network"
+          hashtags="kodadot"
+        >
+          <b-icon
+            size="is-large"
+            pack="fab"
+            icon="facebook">
+          </b-icon>
+        </ShareNetwork>
+      </p>
+      <p class="card-footer-item">
         <span>
           <a :href="linemeUri"
               target="_blank">

--- a/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
+++ b/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
@@ -16,20 +16,6 @@
         </b-button>
       </div>
       <div class="card-footer-item">
-        <b-button
-          size="is-medium"
-          v-clipboard:copy="iframeUri"
-          @click="toast('Code copied to clipboard')"
-          class="share__button"
-        >
-          <b-icon
-            size="is-medium"
-            pack="fas"
-            icon="code">
-          </b-icon>
-        </b-button>
-      </div>
-      <div class="card-footer-item">
         <b-tooltip
           type="is-light"
           class="share__tooltip"
@@ -38,6 +24,8 @@
         >
           <template v-slot:content>
             <ShareNetwork
+              tag="button"
+              class="button share__button is-medium"
               network="twitter"
               :url="realworldFullPath"
               :title="label"
@@ -51,6 +39,8 @@
               </b-icon>
             </ShareNetwork>
             <ShareNetwork
+              tag="button"
+              class="button share__button is-medium"
               network="telegram"
               :url="realworldFullPath"
               :title="label"
@@ -63,6 +53,8 @@
               </b-icon>
             </ShareNetwork>
             <ShareNetwork
+              tag="button"
+              class="button share__button is-medium"
               network="line"
               :url="realworldFullPath"
               :title="label"
@@ -75,6 +67,8 @@
               </b-icon>
             </ShareNetwork>
             <ShareNetwork
+              tag="button"
+              class="button share__button is-medium"
               network="facebook"
               :url="realworldFullPath"
               :title="label"
@@ -86,6 +80,18 @@
               >
               </b-icon>
             </ShareNetwork>
+            <b-button
+              size="is-medium"
+              v-clipboard:copy="iframeUri"
+              @click="toast('Code copied to clipboard')"
+              class="share__button"
+            >
+              <b-icon
+                size="is-medium"
+                pack="fas"
+                icon="code">
+              </b-icon>
+            </b-button>
           </template>
           <b-button
             class="share__button"
@@ -173,13 +179,35 @@ export default class Sharing extends Vue {
   .share {
     &__button {
       color: $primary;
+      background: transparent;
       border: none;
+
+      &:hover,
+      &:focus {
+        &:not(:active) {
+          box-shadow: none;
+        }
+      }
     }
 
     &__tooltip {
       .tooltip-content {
         display: flex;
         flex-direction: column;
+
+        &:before {
+          display: none;
+        }
+
+        @media screen and (min-width: 1024px) {
+          flex-direction: row;
+        }
+      }
+
+      &.is-light  {
+        .tooltip-content {
+          background-color: $white;
+        }
       }
     }
   }

--- a/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
+++ b/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
@@ -21,6 +21,7 @@
           class="share__tooltip"
           :triggers="['click']"
           :auto-close="['outside', 'escape']"
+          :active="active"
         >
           <template v-slot:content>
             <ShareNetwork
@@ -96,6 +97,7 @@
           <b-button
             class="share__button"
             size="is-medium"
+            @click="active = !active"
           >
             <b-icon
               size="is-large"
@@ -118,6 +120,8 @@ import { IFrame, emptyIframe } from '../../types';
 export default class Sharing extends Vue {
   @Prop({ default: 'Check this cool NFT on #KusamaNetwork #KodaDot' }) label!: string;
   @Prop({ default: () => emptyIframe }) iframe!: IFrame;
+
+  private active: boolean = false;
 
   get helloText() {
     return this.label;
@@ -165,8 +169,6 @@ export default class Sharing extends Vue {
     `
   }
 
-
-
   public toast(message: string): void {
     this.$buefy.toast.open(message);
   }
@@ -187,6 +189,11 @@ export default class Sharing extends Vue {
         &:not(:active) {
           box-shadow: none;
         }
+      }
+
+      & > span {
+        display: flex;
+        align-items: center;
       }
     }
 

--- a/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
+++ b/dashboard/src/components/rmrk/Gallery/Item/Sharing.vue
@@ -98,6 +98,7 @@
             class="share__button"
             size="is-medium"
             @click="active = !active"
+            @focusout="active = !active"
           >
             <b-icon
               size="is-large"

--- a/dashboard/src/icons.ts
+++ b/dashboard/src/icons.ts
@@ -25,7 +25,7 @@ import {
   faQuestion, faPrint,
   faMagic, faEye, faCommentAlt,
   faGhost, faCode, faLeaf,
-  faFlask, faCameraRetro, faTag
+  faFlask, faCameraRetro, faTag, faShareAlt
 } from '@fortawesome/free-solid-svg-icons';
 
 // throws error, idk why
@@ -75,7 +75,7 @@ library.add(
   faCommentDots, faGhost, faCode,
   faWpexplorer,
   faRedditAlien, faCameraRetro,
-  faTag
+  faTag, faShareAlt
   );
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';

--- a/dashboard/src/icons.ts
+++ b/dashboard/src/icons.ts
@@ -32,7 +32,7 @@ import {
 import { faCommentDots } from '@fortawesome/free-regular-svg-icons';
 
 import {
-  faTwitter, faLine, faTelegram,
+  faTwitter, faLine, faTelegram, faFacebook,
   faTelegramPlane, faMedium,
   faWpexplorer,
   faRedditAlien
@@ -70,7 +70,7 @@ library.add(
   faPrint, faCommentAlt, faMagic,
   faLeaf, faFlask,
 
-  faTwitter, faTelegram, faMedium,
+  faTwitter, faTelegram, faFacebook, faMedium,
   faLine, faTelegramPlane,
   faCommentDots, faGhost, faCode,
   faWpexplorer,

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -15,9 +15,11 @@ import router from './router';
 
 import MetaInfo from 'vue-meta';
 import AudioVisual from 'vue-audio-visual'
+import VueSocialSharing from 'vue-social-sharing'
 
 Vue.use(MetaInfo)
 Vue.use(AudioVisual)
+Vue.use(VueSocialSharing)
 import Connector from '@vue-polkadot/vue-api';
 import { client, keyInfo } from '@/textile'
 import { createInstance, getInstance, migrateCollection, migrateNFT } from '@/components/rmrk/service/RmrkService'

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -10509,6 +10509,11 @@ vue-router@^3.1.5:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.1.6.tgz#45f5a3a3843e31702c061dd829393554e4328f89"
   integrity sha512-GYhn2ynaZlysZMkFE5oCHRUTqE8BWs/a9YbKpNLi0i7xD6KG1EzDqpHQmv1F5gXjr8kL5iIVS8EOtRaVUEXTqA==
 
+vue-social-sharing@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/vue-social-sharing/-/vue-social-sharing-3.0.7.tgz#8dee6a955ce72d0391481204dcb306804373c9f9"
+  integrity sha512-6FS+9t9qJQXY/Km0oyfpJv7rtjhqvrQodpVc/cbBc6TvQdhXc64pHi4yoqa3Jv797veNAlFuLztYyir9jONhBg==
+
 vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"


### PR DESCRIPTION
Related to #161

My proposition is to add vue-social-sharing package. I've added `ShareNetwork` component which helps share link to a facebook.
Twitter, Telegram, Line can be added too. With this plugin you can share content without leaving kodadot page.

More details here: https://github.com/nicolasbeauvais/vue-social-sharing

You can see new facebook icon in the nft detail page
![alt text](https://i.imgur.com/iC9Kjv4.png)
