### PR TITLE
Generate social cards on the fly with NFT name, price and KodaDot branding

### DIFF
--- a/dashboard/src/components/rmrk/Gallery/GalleryItem.vue
+++ b/dashboard/src/components/rmrk/Gallery/GalleryItem.vue
@@ -85,6 +85,7 @@ import 'markdown-it-vue/dist/markdown-it-vue-light.css'
 import { NFTWithMeta, NFT } from '../service/scheme';
 import { sanitizeIpfsUrl } from '../utils';
 import { emptyObject } from '@/utils/empty';
+import { formatBalance } from '@polkadot/util';
 
 import AvailableActions from './AvailableActions.vue';
 import { notificationTypes, showNotification } from '@/utils/notification';
@@ -104,6 +105,7 @@ type NFTType =  NFTWithMeta;
 
 @Component<GalleryItem>({
   metaInfo() {
+    const image = `https://og-image-green-seven.vercel.app/${encodeURIComponent(this.nft.name as string)}.png?price=${this.nft.price ? Vue.filter('formatBalance')(this.nft.price, 12, 'KSM') : ''}&image=${(this.nft.image as string)}`;
     return {
       meta: [
         {
@@ -114,13 +116,13 @@ type NFTType =  NFTWithMeta;
         { property: 'og:type', content: 'website'},
         { property: 'og:title', content: (this.nft.name as string) },
         { property: 'og:description', content: (this.nft.description as string) },
-        { property: 'og:image', content: (`https://og-image-green-seven.vercel.app/${encodeURIComponent(this.nft.name as string)}.png?price=${this.nft.price}&image=${(this.nft.image as string)}`)},
+        { property: 'og:image', content: (image)},
         { property: 'og:video', content: (this.nft.image as string) },
         { property: 'twitter:card', content: 'summary_large_image' },
         { property: 'twitter:site', content: '@KodaDot' },
         { property: 'twitter:title', content: (this.nft.name as string) },
         { property: 'twitter:description', content: (this.nft.description as string) },
-        { property: 'twitter:image', content: (`https://og-image-green-seven.vercel.app/${encodeURIComponent(this.nft.name as string)}.png?price=${this.nft.price}&image=${(this.nft.image as string)}`)},
+        { property: 'twitter:image', content: (image)},
       ]
     }
   },

--- a/dashboard/src/components/rmrk/Gallery/GalleryItem.vue
+++ b/dashboard/src/components/rmrk/Gallery/GalleryItem.vue
@@ -114,13 +114,13 @@ type NFTType =  NFTWithMeta;
         { property: 'og:type', content: 'website'},
         { property: 'og:title', content: (this.nft.name as string) },
         { property: 'og:description', content: (this.nft.description as string) },
-        { property: 'og:image', content: (this.nft.image as string) },
+        { property: 'og:image', content: (`https://og-image-green-seven.vercel.app/${encodeURIComponent(this.nft.name as string)}.png?price=${this.nft.price}&image=${(this.nft.image as string)}`)},
         { property: 'og:video', content: (this.nft.image as string) },
         { property: 'twitter:card', content: 'summary_large_image' },
         { property: 'twitter:site', content: '@KodaDot' },
         { property: 'twitter:title', content: (this.nft.name as string) },
         { property: 'twitter:description', content: (this.nft.description as string) },
-        { property: 'twitter:image', content: (this.nft.image as string) },
+        { property: 'twitter:image', content: (`https://og-image-green-seven.vercel.app/${encodeURIComponent(this.nft.name as string)}.png?price=${this.nft.price}&image=${(this.nft.image as string)}`)},
       ]
     }
   },


### PR DESCRIPTION
Here image preview should already work. 
But to make it really nice, I will require some help, probably from @vikiival 

1. How can I get `nft.price` in the same view as <money> component returns but I need only value as string.
2. Is it possible to get `width` and `height` attributes for images? This will allow me to build previews based on image sizes and not with fixed dimensions.