### PR TITLE
fix(mint): ToS switch

### DIFF
--- a/src/components/rmrk/Create/SimpleMint.vue
+++ b/src/components/rmrk/Create/SimpleMint.vue
@@ -147,6 +147,12 @@
             />
           </b-field>
           <ArweaveUploadSwitch  v-model="arweaveUpload" />
+          <b-field>
+            <b-switch v-model="hasToS"
+              :rounded="false">
+              I confirm that I hold full copyright ownership of the submitted digital asset (or have sufficient permission by the owner to use the asset)
+            </b-switch>
+          </b-field>
         </div>
       </section>
     </div>
@@ -251,6 +257,7 @@ export default class SimpleMint extends Mixins(
   private secondFile: Blob | null = null;
   private isLoading: boolean = false;
   private password: string = '';
+  private hasToS: boolean = false;
   private hasSupport: boolean = true;
   private nsfw: boolean = false;
   private price: number = 0;
@@ -289,7 +296,7 @@ export default class SimpleMint extends Mixins(
 
   get disabled(): boolean {
     const { name, symbol, max } = this.rmrkMint;
-    return !(name && symbol && max && this.accountId && this.file);
+    return !(name && symbol && max && this.hasToS && this.accountId && this.file);
   }
 
   protected async estimateTx() {

--- a/src/components/rmrk/Create/SimpleMint.vue
+++ b/src/components/rmrk/Create/SimpleMint.vue
@@ -150,7 +150,7 @@
           <b-field>
             <b-switch v-model="hasToS"
               :rounded="false">
-              I confirm that I hold full copyright ownership of the submitted digital asset (or have sufficient permission by the owner to use the asset)
+              {{ $t("termOfService.accept") }}
             </b-switch>
           </b-field>
         </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -169,5 +169,8 @@
   "arweave": {
     "uploadYes": "Upload NFT image to Arweave",
     "uploadNo": "Do not use Arweave"
+  },
+  "termOfService" : {
+    "accept": "I confirm that I hold full copyright ownership of the submitted digital asset (or have sufficient permission by the owner to use the asset)"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -130,5 +130,8 @@
   },
   "nft": {
     "carbonless": "Ce NFT est sans carbone"
+  },
+  "termOfService" : {
+    "accept": "Je confirme que je détiens tous les droits d'auteur sur le bien numérique soumis (ou que j'ai l'autorisation suffisante du propriétaire pour utiliser le bien)"
   }
 }


### PR DESCRIPTION
closes #477 

Button "CLICK TO CREATE NFT(s)" is disabled when ToS is unchecked.
Maybe it need something to tell user which are required fields.

### Before submitting this PR, please make sure:
- [x] Code builds clean without any erros or warnings
- [x] Merged recent default branch -- **main** and I've no conflicts
- [x] Didn't break any original functionality

### Optional
- [ ] I've tested it on mobile and everything works

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### Screenshot

![Screenshot 2021-06-28 at 15-20-24 KodaDot Low fees and low carbon minting](https://user-images.githubusercontent.com/9987732/123643581-d215d300-d824-11eb-8496-f21007ef0ea8.png)

