### PR TITLE
set aspect ratio to be consistent when changing browser size

### DIFF
--- a/src/components/rmrk/Gallery/GalleryItem.vue
+++ b/src/components/rmrk/Gallery/GalleryItem.vue
@@ -358,8 +358,9 @@ hr.comment-divider {
 
         img.fullscreen-image {
           display: block;
-          width: auto !important;
-          height: 100% !important;
+          width: 100% !important;
+          height: auto !important;
+          overflow:auto;
           position: absolute;
           top: 0;
           left: 50%;


### PR DESCRIPTION
- [x ] Code builds clean without any erros or warnings
- [ x] Merged recent default branch -- **main** and I've no conflicts
- [ x] Didn't break any original functionality

### PR type
- [x ] Bugfix

### What's new? (may be part of changelog)
- closes #445  - Changed the width to 100% and set the height to auto to keep the aspect ratio of the original image.

Small window:
![aspect-ratio-sm](https://user-images.githubusercontent.com/47400839/124264372-3a94d680-dae9-11eb-9081-346f8c642948.png)

Medium window:
![aspect-ratio-med](https://user-images.githubusercontent.com/47400839/124264375-3b2d6d00-dae9-11eb-9bd8-e3c5a86fc5ba.png)

Large window (1920x1080):
![aspect-ratio-1920x1080](https://user-images.githubusercontent.com/47400839/124264376-3bc60380-dae9-11eb-9223-2ad72bc1e854.png)

