### PR TITLE
WIP: Show users with identity in spotlight

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -63,11 +63,6 @@
             {{ $t('Settings') }}
           </b-navbar-item>
       </b-navbar-dropdown>
-      <b-navbar-item
-        tag='router-link'
-        :to="{ name: 'tutorials'}">
-        {{ $t('Tutorial') }}
-      </b-navbar-item>
     </template>
     <template v-slot:end>
       <LocaleChanger />

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -63,6 +63,11 @@
             {{ $t('Settings') }}
           </b-navbar-item>
       </b-navbar-dropdown>
+      <b-navbar-item
+        tag='router-link'
+        :to="{ name: 'tutorials'}">
+        {{ $t('Tutorial') }}
+      </b-navbar-item>
     </template>
     <template v-slot:end>
       <LocaleChanger />

--- a/src/components/spotlight/SpotlightTable.vue
+++ b/src/components/spotlight/SpotlightTable.vue
@@ -92,22 +92,22 @@
 </template>
 
 <script lang="ts" >
-import { Component, Prop, Vue, Mixins, Watch } from 'vue-property-decorator';
-import { Column, Row } from './types';
-import { columns, nftFn } from './utils';
-import collectionIssuerList from '@/queries/collectionIssuerList.graphql';
-import { spotlightAggQuery } from '../rmrk/Gallery/Search/query';
-import TransactionMixin from '@/utils/mixins/txMixin';
-import { denyList } from '@/constants';
+import { Component, Prop, Vue, Mixins, Watch } from "vue-property-decorator";
+import { Column, Row } from "./types";
+import { columns, nftFn } from "./utils";
+import collectionIssuerList from "@/queries/collectionIssuerList.graphql";
+import { spotlightAggQuery } from "../rmrk/Gallery/Search/query";
+import TransactionMixin from "@/utils/mixins/txMixin";
+import { denyList } from "@/constants";
 
-import { GenericAccountId } from '@polkadot/types/generic/AccountId';
-import { get } from 'idb-keyval';
-import { identityStore } from '@/utils/idbStore';
+import { GenericAccountId } from "@polkadot/types/generic/AccountId";
+import { get } from "idb-keyval";
+import { identityStore } from "@/utils/idbStore";
 type Address = string | GenericAccountId | undefined;
 
 const components = {
-	Identity: () => import('@/components/shared/format/Identity.vue'),
-	SpotlightDetail: () => import('./SpotlightDetail.vue'),
+	Identity: () => import("@/components/shared/format/Identity.vue"),
+	SpotlightDetail: () => import("./SpotlightDetail.vue"),
 };
 
 @Component({ components })
@@ -151,7 +151,7 @@ export default class SpotlightTable extends Mixins(TransactionMixin) {
 			const result = await this.identityOf(filterData[index].id);
 
 			if (this.isShowIdentity) {
-				if (result.display) {
+				if (result && Object.keys(result).length !== 0) {
 					this.data[filterIndex++] = filterData[index];
 				}
 			} else {
@@ -176,7 +176,7 @@ export default class SpotlightTable extends Mixins(TransactionMixin) {
 	private resolveAddress(account: Address): string {
 		return account instanceof GenericAccountId
 			? account.toString()
-			: account || '';
+			: account || "";
 	}
 }
 </script>

--- a/src/components/spotlight/SpotlightTable.vue
+++ b/src/components/spotlight/SpotlightTable.vue
@@ -92,17 +92,17 @@
 </template>
 
 <script lang="ts" >
-import { Component, Prop, Vue, Mixins, Watch } from "vue-property-decorator";
-import { Column, Row } from "./types";
-import { columns, nftFn } from "./utils";
-import collectionIssuerList from "@/queries/collectionIssuerList.graphql";
-import { spotlightAggQuery } from "../rmrk/Gallery/Search/query";
-import TransactionMixin from "@/utils/mixins/txMixin";
-import { denyList } from "@/constants";
+import { Component, Prop, Vue, Mixins, Watch } from 'vue-property-decorator';
+import { Column, Row } from './types';
+import { columns, nftFn } from './utils';
+import collectionIssuerList from '@/queries/collectionIssuerList.graphql';
+import { spotlightAggQuery } from '../rmrk/Gallery/Search/query';
+import TransactionMixin from '@/utils/mixins/txMixin';
+import { denyList } from '@/constants';
 
 const components = {
-	Identity: () => import("@/components/shared/format/Identity.vue"),
-	SpotlightDetail: () => import("./SpotlightDetail.vue"),
+	Identity: () => import('@/components/shared/format/Identity.vue'),
+	SpotlightDetail: () => import('./SpotlightDetail.vue'),
 };
 
 @Component({ components })
@@ -141,7 +141,7 @@ export default class SpotlightTable extends Mixins(TransactionMixin) {
 		this.isLoading = false;
 	}
 
-	@Watch("isShowIdentity")
+	@Watch('isShowIdentity')
 	async filterData() {
 		await this.fetchData();
 	}


### PR DESCRIPTION
Right now we are showing accounts that have at least some RMRK went through their account.
Would be good to add a toggle to show only accounts with identity in /spotlight to filter no-names and scammers.