### PR TITLE
fix(gallery): align pagination right

### DIFF
--- a/src/components/rmrk/Gallery/Gallery.vue
+++ b/src/components/rmrk/Gallery/Gallery.vue
@@ -4,7 +4,7 @@
     <!-- TODO: Make it work with graphql -->
     <Search v-bind.sync="searchQuery">
       <b-field class="column is-4 mb-0 is-offset-2 is-narrow">
-        <Pagination simple :total="total" v-model="currentValue" replace />
+        <Pagination simple :total="total" v-model="currentValue" replace class="is-pulled-right" />
       </b-field>
     </Search>
     <!-- <b-button @click="first += 1">Show {{ first }}</b-button> -->


### PR DESCRIPTION
This small change align pagination in gallery to the right.

### Screenshot
![Screenshot 2021-08-23 at 18-44-42 Low minting fees and carbonless NFTs](https://user-images.githubusercontent.com/9987732/130485422-c576ecc6-4288-49fc-9621-494a5c80701f.png)

