### PR TITLE
#675 Open ksm transaction and view current price of KSM

### DIFF
--- a/src/components/transfer/Transfer.vue
+++ b/src/components/transfer/Transfer.vue
@@ -5,9 +5,12 @@
         <br />
         <Loader v-model="isLoading" :status="status" />
         <div class="box">
-          <p class="title is-size-3">
+          <div class="info">
+            <p class="title is-size-3">
             Transfer {{ unit }}
-          </p>
+            </p>
+            <span class="info--currentPrice" title='Current price'>${{this.$store.getters.getCurrentKSMValue}} </span>
+          </div>
 
           <b-field>
             <Auth />
@@ -37,6 +40,16 @@
             >
               {{ $t("general.submit") }}
             </b-button>
+             <b-button
+              v-if="transactionValue"
+              type="is-success"
+              class="tx"
+              icon-left="external-link-alt"
+              @click="getExplorerUrl"
+              outlined
+            >
+              {{ $t("View Transaction") }}
+            </b-button>
           </b-field>
         </div>
       </section>
@@ -57,6 +70,7 @@ import { AccountInfo, DispatchError } from '@polkadot/types/interfaces';
 import { calculateBalance } from '@/utils/formatBalance';
 import correctFormat from '@/utils/ss58Format';
 import { checkAddress } from '@polkadot/util-crypto';
+import { urlBuilderTransaction } from '@/utils/explorerGuide';
 
 @Component({
   components: {
@@ -74,6 +88,7 @@ export default class Transfer extends Mixins(
 ) {
   protected balance: string = '0';
   protected destinationAddress: string = '';
+  protected transactionValue: string = '';
   protected price: number = 0;
 
   get disabled(): boolean {
@@ -129,6 +144,7 @@ export default class Transfer extends Mixins(
             this.$router.push(this.$route.path);
 
             this.isLoading = false;
+            this.transactionValue = blockHash.toHex();
           },
           dispatchError => {
             execResultValue(tx);
@@ -165,6 +181,12 @@ export default class Transfer extends Mixins(
     this.isLoading = false;
   }
 
+  protected getExplorerUrl() {
+    const url =  urlBuilderTransaction(this.transactionValue,
+      this.$store.getters.getCurrentChain, 'subscan');
+    window.open(url, '_blank');
+  }
+
   @Watch('accountId', { immediate: true })
   hasAccount(value: string, oldVal: string) {
     if (shouldUpdate(value, oldVal)) {
@@ -192,5 +214,20 @@ export default class Transfer extends Mixins(
 }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '@/styles/variables';
+   .info {
+     display: flex;
+     align-items: center;
+     &--currentPrice {
+        margin-bottom: 1.5rem;
+        margin-left: 1.5rem;
+        color: $primary;
+        font-size: 1.5rem;
+        font-weight: 600;
+     }
+    }
+    .tx {
+       margin-left: 1rem;
+    }
 </style>

--- a/src/components/transfer/Transfer.vue
+++ b/src/components/transfer/Transfer.vue
@@ -48,7 +48,7 @@
               @click="getExplorerUrl"
               outlined
             >
-              {{ $t("View Transaction") }}
+              {{ $t("View Transaction")}} {{transactionValue.substring(0,6)}}{{'...'}}
             </b-button>
           </b-field>
         </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -217,8 +217,10 @@ export default new Vuex.Store({
     }
   },
   getters: {
-    getChainProperties: ({chainProperties}) => chainProperties,
-    getUserLang: ({ language }) => language.userLang || 'en'
+    getChainProperties: ({ chainProperties }) => chainProperties,
+    getUserLang: ({ language }) => language.userLang || 'en',
+    getCurrentKSMValue: ({ fiatPrice }) => fiatPrice['kusama']['usd'],
+    getCurrentChain: ({ explorer }) => explorer.chain
   },
   modules: {
     setting: SettingModule,


### PR DESCRIPTION
**Thank you for your contribution** to the KodaDot NFT gallery.
Let's do a quick check before the merge.
Your contribution will be an eternal part of the community codebase

### Before submitting this PR, please make sure:
- [x] Code builds clean without any errors or warnings
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I didn't break any original functionality

### Optional
- [ ] I've tested it on mobile and everything works

### PR type
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new? (maybe part of changelog)
- closes #675 -  For opening ksm transactions, I have added a button and have found the transaction id using `blockHash.toHex();`
For showing current price of KSM, have used state variable `fiatPrice`. 

### If issue contains bounty label ($,$$,$$$)
- Your KSM address: EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU

### Community participation
- [x] Are you at KodaDot Discord? If no, [let's join us - https://discord.gg/35hzy2dXXh](https://discord.gg/35hzy2dXXh)

### Screenshot
- [x] Whenever your fix will change **something** on UI, a screenshot is more than welcome


<img width="802" alt="Screenshot 2021-09-03 at 9 16 46 PM" src="https://user-images.githubusercontent.com/39299315/132032777-5505f9f0-5df2-4313-8033-b3bcf536719c.png">

