### PR TITLE
feature(collection): ui changes

### DIFF
--- a/src/components/rmrk/Gallery/CollectionActivity.vue
+++ b/src/components/rmrk/Gallery/CollectionActivity.vue
@@ -9,7 +9,7 @@
 			</div>
 			<div class="level-item has-text-centered">
 				<div>
-					<p class="heading">Owners</p>
+					<p class="heading">Owned</p>
 					<p class="title">{{ collectionSoldedNFT }}</p>
 				</div>
 			</div>

--- a/src/components/rmrk/Gallery/CollectionActivity.vue
+++ b/src/components/rmrk/Gallery/CollectionActivity.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<div class="level mb-4" v-if="nfts">
+		<div class="level m-4" v-if="nfts">
 			<div class="level-item has-text-centered">
 				<div>
 					<p class="heading">Items</p>

--- a/src/components/rmrk/Gallery/CollectionItem.vue
+++ b/src/components/rmrk/Gallery/CollectionItem.vue
@@ -3,7 +3,7 @@
     <div class="columns is-centered">
       <div class="column is-half has-text-centered">
         <figure class="image container is-128x128">
-          <img class="is-rounded" :src="meta.image">
+          <img class="is-rounded" :src="image">
         </figure>
         <h1 class="title is-2 mt-2">
           {{ name }}
@@ -32,7 +32,7 @@
     <div class="columns is-centered">
       <div class="column is-8 has-text-centered">
         <p class="content">
-          {{meta.description}}
+          {{ description }}
         </p>
       </div>
     </div>
@@ -81,6 +81,14 @@ export default class CollectionItem extends Vue {
   private collection: CollectionWithMeta = emptyObject<CollectionWithMeta>();
   private isLoading: boolean = false;
   public meta: CollectionMetadata = emptyObject<CollectionMetadata>();
+
+  get image() {
+    return this.meta.image || ''
+  }
+
+  get description() {
+    return this.meta.description || ''
+  }
 
 	get name() {
     return this.collection.name || this.id

--- a/src/components/rmrk/Gallery/CollectionItem.vue
+++ b/src/components/rmrk/Gallery/CollectionItem.vue
@@ -1,11 +1,17 @@
 <template>
   <div class="pack-item-wrapper container">
-    <div class="columns">
-      <div class="column">
-        <h1 class="title">
-          Collection {{ name }}
+    <div class="columns is-centered">
+      <div class="column is-half has-text-centered">
+        <figure class="image container is-128x128">
+          <img class="is-rounded" :src="meta.image">
+        </figure>
+        <h1 class="title is-2 mt-2">
+          {{ name }}
         </h1>
       </div>
+    </div>
+
+    <div class="columns">
       <div class="column">
         <p class="subtitle">
           Creator <ProfileLink :address="issuer" :inline="true" :showTwitter="true"/>
@@ -22,6 +28,14 @@
     </div>
 
     <CollectionActivity :nfts="collection.nfts" />
+
+    <div class="columns is-centered">
+      <div class="column is-8 has-text-centered">
+        <p class="content">
+          {{meta.description}}
+        </p>
+      </div>
+    </div>
 
     <GalleryCardList :items="collection.nfts" />
 


### PR DESCRIPTION
Small PR before diving back to /rankings

### PR type
- [x] Feature

### Before submitting this PR, please make sure:
- [x] Code builds clean without any errors or warnings
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it on mobile and everything works

### What's new? (may be part of changelog)
- This PR closes #738 
- changed "Owners" to "Owned" : 

> The numbers of owners isn't displaying properly. It displays total NFT in wallets that have been sold but doesn't register owners with multiple NFT's.

### Screenshot
![Screenshot 2021-09-17 at 13-47-20 Kitty Paradise](https://user-images.githubusercontent.com/9987732/133778063-22847754-82ec-4fc0-955d-3afbd02cd1a5.png)

