### PR TITLE
fix(priceChart): remove last point on graph

### DIFF
--- a/src/components/rmrk/Gallery/History.vue
+++ b/src/components/rmrk/Gallery/History.vue
@@ -127,10 +127,6 @@ export default class History extends Vue {
 		}
 
 		this.data = this.data.reverse();
-		this.priceData.push([
-			new Date(),
-			this.formatPrice(this.data[0]['Amount']),
-		]);
 	}
 
 	protected parseDate(date: Date) {


### PR DESCRIPTION
### Quick Brief
Last point on Price Chart is hard coded to show today date and current nft value.

### Solution
Remove it 😄 because it will be the same as the last nft interaction.

### PR type
- [x] Bugfix

### Before submitting this PR, please make sure:
- [x] Code builds clean without any errors or warnings
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it on mobile and everything works

### What's new? (may be part of changelog)
- This PR closes #780 

### Screenshot
![Screenshot 2021-09-25 at 19-56-57 ERR_CONNECTION_TIMED_OUT](https://user-images.githubusercontent.com/9987732/134781403-daaddcbb-f673-48a5-bd1c-01c2f749ec96.png)

