### PR TITLE
fix(pricechart): hideoverlapping label on x axis

### DIFF
--- a/src/components/rmrk/Gallery/PriceChart.vue
+++ b/src/components/rmrk/Gallery/PriceChart.vue
@@ -80,7 +80,7 @@ export default class PriceChart extends Vue {
 				axisLabel: {
 					fontFamily: 'Fira Code',
 					color: '#fff',
-          hideOverlap: true
+          hideOverlap: true,
 				},
 			},
 			yAxis: {

--- a/src/components/rmrk/Gallery/PriceChart.vue
+++ b/src/components/rmrk/Gallery/PriceChart.vue
@@ -80,6 +80,7 @@ export default class PriceChart extends Vue {
 				axisLabel: {
 					fontFamily: 'Fira Code',
 					color: '#fff',
+          hideOverlap: true
 				},
 			},
 			yAxis: {


### PR DESCRIPTION
This quickfix will hide overlapping label on x axis in price chart

### PR type
- [x] Bugfix

### Before submitting this PR, please make sure:
- [x] Code builds clean without any errors or warnings
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've didn't break any original functionality

### What's new? (may be part of changelog)
- This PR closes #811

### Screenshot
#### Before
![image](https://user-images.githubusercontent.com/9987732/135090331-33162d99-3b51-4b69-b37e-20c32156da2a.png)

#### After
![Screenshot 2021-09-28 at 14-50-20 Kusamagen #160](https://user-images.githubusercontent.com/9987732/135090212-735559d8-a0c7-4067-bcdb-80be7de9c85f.png)

