### PR TITLE
fix(spotlight): tooltip on column score

### DIFF
--- a/src/components/spotlight/SpotlightTable.vue
+++ b/src/components/spotlight/SpotlightTable.vue
@@ -77,10 +77,15 @@
       <b-table-column
         field="rank"
         :label="$t('spotlight.score')"
-        v-slot="props"
         sortable
+        numeric
       >
-        <template v-if="!isLoading">{{ Math.ceil(props.row.rank * 100) / 100 }}</template>
+        <template v-slot:header="{column}">
+          <b-tooltip label="sold * (unique / total)" append-to-body dashed>
+            {{column.label}}
+          </b-tooltip>
+        </template>
+        <template v-slot="props" v-if="!isLoading">{{ Math.ceil(props.row.rank * 100) / 100 }}</template>
         <b-skeleton :active="isLoading"> </b-skeleton>
       </b-table-column>
 


### PR DESCRIPTION
### PR type
- [x] Bugfix

### Before submitting this PR, please make sure:
- [x] Code builds clean without any errors or warnings
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've didn't break any original functionality

### Optional
- [x] I've tested it on mobile and everything works

### What's new? (may be part of changelog)
- This PR closes #824 
- "Score" now align right in table