### PR TITLE
fix(searchBarCollection): remove filter toggle for now & align content

### DIFF
--- a/src/components/rmrk/Gallery/Search/SearchBarCollection.vue
+++ b/src/components/rmrk/Gallery/Search/SearchBarCollection.vue
@@ -1,17 +1,12 @@
 <template>
-  <div class="box mb-3 mt-5">
-    <b-field grouped>
-      <b-field>
-        <b-button
-          aria-controls="contentIdForA11y1"
-          label="Filter"
-          icon-left="filter"
-          type="is-primary"
-          expanded
-          @click="isVisible = !isVisible"
-        />
-      </b-field>
-      <b-field expanded>
+  <div class="content">
+    <b-field grouped group-multiline>
+      <Sort
+        class="control"
+        :value="sortBy"
+        @input="updateSortBy"
+      />
+      <b-field expanded class="control">
         <b-input
           placeholder="Search..."
           type="search"
@@ -22,22 +17,13 @@
         </b-input>
       </b-field>
       <BasicSwitch
-        class="is-flex"
+        class="is-flex control"
         v-model="vListed"
         label="sort.listed"
         size="is-medium"
       />
     </b-field>
     <slot />
-
-    <transition name="fade">
-      <div v-if="isVisible">
-        <Sort
-          :value="sortBy"
-          @input="updateSortBy"
-        />
-      </div>
-    </transition>
   </div>
 </template>
 


### PR DESCRIPTION

### PR type
- [x] Bugfix
- [x] Refactoring

### Before submitting this PR, please make sure:
- [x] Code builds clean without any errors or warnings
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it on mobile and everything works

### What's new? (may be part of changelog)
- remove "filter" button 
- align searchbarCollection with content
- fix responsive searchbarCollection on mobile

### Screenshot
#### Before
![Screenshot 2021-10-26 at 14-33-23 C H E L](https://user-images.githubusercontent.com/9987732/138879802-e43ab0ea-44d0-4115-8348-61401490d9ff.png)

#### After
![Screenshot 2021-10-26 at 14-30-57 C H E L](https://user-images.githubusercontent.com/9987732/138879373-c5653d5f-11af-41be-83c9-23ddcbf43ad2.png)


