### PR TITLE
feat: add tooltip to explain switches during minting

### DIFF
--- a/components/rmrk/Create/ArweaveUploadSwitch.vue
+++ b/components/rmrk/Create/ArweaveUploadSwitch.vue
@@ -1,10 +1,12 @@
 <template>
   <b-field>
-    <b-switch
-      v-model="checkedValue"
-      :rounded="false"
-    >
-      {{ checkedValue ? $t('arweave.uploadYes') : $t('arweave.uploadNo') }}
+    <b-switch v-model="checkedValue" :rounded="false">
+      <div class="is-flex is-align-items-center">
+        <span class="mr-2">
+          {{ checkedValue ? $t('arweave.uploadYes') : $t('arweave.uploadNo') }}
+        </span>
+        <slot name="tooltip" />
+      </div>
     </b-switch>
   </b-field>
 </template>

--- a/components/rmrk/Create/CreateCollection.vue
+++ b/components/rmrk/Create/CreateCollection.vue
@@ -79,7 +79,16 @@
         </b-button>
       </b-field>
       <b-field>
-        <Support v-model="hasSupport" :price="filePrice" />
+        <Support v-model="hasSupport" :price="filePrice">
+          <template v-slot:tooltip>
+            <Tooltip
+              :label="$t('support.tooltip')"
+              iconsize="is-small"
+              buttonsize="is-small"
+              tooltipsize="is-medium"
+            />
+          </template>
+        </Support>
       </b-field>
     </div>
   </div>

--- a/components/rmrk/Create/CreateToken.vue
+++ b/components/rmrk/Create/CreateToken.vue
@@ -79,17 +79,48 @@
         </b-button>
       </b-field>
       <b-field>
-        <Support v-model="hasSupport" :price="filePrice" />
+        <Support v-model="hasSupport" :price="filePrice">
+          <template v-slot:tooltip>
+            <Tooltip
+              :label="$t('support.tooltip')"
+              iconsize="is-small"
+              buttonsize="is-small"
+              tooltipsize="is-medium"
+            />
+          </template>
+        </Support>
       </b-field>
       <b-field>
         <Support
           v-model="hasCarbonOffset"
           :price="1"
-          activeMessage="I'm making carbonless NFT"
-          passiveMessage="I don't want to have carbonless NFT"
-        />
+          :activeMessage="$t('carbonOffset.carbonOffsetYes')"
+          :passiveMessage="$t('carbonOffset.carbonOffsetNo')"
+        >
+          <template v-slot:tooltip>
+            <Tooltip
+              iconsize="is-small"
+              buttonsize="is-small"
+              tooltipsize="is-large"
+            >
+              <template v-slot:content>
+                {{ $t('carbonOffset.tooltip') }} 
+                (<a class="has-text-black is-underlined" href='https://kodadot.xyz/carbonless'>https://kodadot.xyz/carbonless</a>)
+              </template>
+            </Tooltip>
+          </template>
+        </Support>
       </b-field>
-      <ArweaveUploadSwitch v-model="arweaveUpload" />
+      <ArweaveUploadSwitch v-model="arweaveUpload">
+        <template v-slot:tooltip>
+          <Tooltip
+            :label="$t('arweave.tooltip')"
+            iconsize="is-small"
+            buttonsize="is-small"
+            tooltipsize="is-medium"
+          />
+        </template>
+      </ArweaveUploadSwitch>
     </div>
   </div>
 </template>

--- a/components/rmrk/Create/SimpleMint.vue
+++ b/components/rmrk/Create/SimpleMint.vue
@@ -161,17 +161,48 @@
           </b-field>
           <BasicSwitch v-model="nsfw" label="mint.nfsw" />
           <b-field>
-            <Support v-model="hasSupport" :price="filePrice" />
+            <Support v-model="hasSupport" :price="filePrice">
+              <template v-slot:tooltip>
+                <Tooltip
+                  :label="$t('support.tooltip')"
+                  iconsize="is-small"
+                  buttonsize="is-small"
+                  tooltipsize="is-medium"
+                />
+              </template>
+            </Support>
           </b-field>
           <b-field>
             <Support
               v-model="hasCarbonOffset"
               :price="1"
-              activeMessage="I'm making carbonless NFT"
-              passiveMessage="I don't want to have carbonless NFT"
-            />
+              :activeMessage="$t('carbonOffset.carbonOffsetYes')"
+              :passiveMessage="$t('carbonOffset.carbonOffsetNo')"
+            >
+              <template v-slot:tooltip>
+                <Tooltip
+                  iconsize="is-small"
+                  buttonsize="is-small"
+                  tooltipsize="is-large"
+                >
+                  <template v-slot:content>
+                    {{ $t('carbonOffset.tooltip') }} 
+                    (<a class="has-text-black is-underlined" href='https://kodadot.xyz/carbonless'>https://kodadot.xyz/carbonless</a>)
+                  </template>
+                </Tooltip>
+              </template>
+            </Support>
           </b-field>
-          <ArweaveUploadSwitch v-model="arweaveUpload" />
+          <ArweaveUploadSwitch v-model="arweaveUpload">
+            <template v-slot:tooltip>
+              <Tooltip
+                :label="$t('arweave.tooltip')"
+                iconsize="is-small"
+                buttonsize="is-small"
+                tooltipsize="is-medium"
+              />
+            </template>
+          </ArweaveUploadSwitch>
           <b-field>
             <b-switch v-model="hasToS" :rounded="false">
               {{ $t('termOfService.accept') }}

--- a/components/shared/Support.vue
+++ b/components/shared/Support.vue
@@ -4,7 +4,12 @@
     :type="type"
     :rounded="false"
   >
-    {{ value ? `${activeMessage} ($ ${rounded})` : `${passiveMessage}` }}
+    <div class="is-flex is-align-items-center">
+      <span class="mr-2">
+        {{ value ? `${activeMessage} ($ ${rounded})` : `${passiveMessage}` }}
+      </span>
+      <slot name="tooltip" />
+    </div>
   </b-switch>
 </template>
 

--- a/components/shared/Tooltip.vue
+++ b/components/shared/Tooltip.vue
@@ -2,28 +2,31 @@
   <p class="control">
     <b-tooltip
       type="is-white"
-      size="is-small"
+      :size="tooltipsize"
       position="is-left"
       :label="label"
       multilined
       square
+      :triggers="['hover', 'click']"
     >
-      <b-button type="is-dark">
-        <b-icon
-          :size="iconsize"
-          icon="info"
-        />
+      <b-button type="is-dark" :size="buttonsize">
+        <b-icon :size="iconsize" icon="info" />
       </b-button>
+      <template v-slot:content>
+        <slot name="content" />
+      </template>
     </b-tooltip>
   </p>
 </template>
 
-<script lang="ts" >
-import { Component, Prop, Vue } from 'nuxt-property-decorator'
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator';
 
 @Component({})
 export default class Tooltip extends Vue {
   @Prop() public label!: string;
   @Prop({ default: 'is-medium' }) public iconsize!: string;
+  @Prop({ default: 'is-medium' }) public buttonsize!: string;
+  @Prop({ default: 'is-small' }) public tooltipsize!: string;
 }
 </script>

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -284,7 +284,16 @@
   },
   "arweave": {
     "uploadYes": "Upload NFT image to Arweave",
-    "uploadNo": "Do not use Arweave"
+    "uploadNo": "Do not use Arweave",
+    "tooltip": "Using Arweave means that you are storing your multimedia forever on Arweave, good for small assets like JPEG."
+  },
+  "carbonOffset": {
+    "carbonOffsetYes": "I'm making carbonless NFT",
+    "carbonOffsetNo": "I don't want to have carbonless NFT",
+    "tooltip": "Carbonless NFT means that you are helping cover costs for carbon credits and planting trees"
+  },
+  "support": {
+    "tooltip": "Cover costs mean that users help to support initial costs for KodaDot which stores your JPEG on your behalf."
   },
   "termOfService": {
     "accept": "I confirm that I hold full copyright ownership of the submitted digital asset (or have sufficient permission by the owner to use the asset)"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it at `/rmrk/mint` and `/rmrk/create`
- [x] I've tested PR on mobile and everything works
- [x] I found edge cases

### What's new?
- [x] PR closes #1234
- [x] Added a info tooltip on the switches during mint and create

### Had issue bounty label ?
- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=5EXNfK2UUkr5MxxSrz29uquVg7htfb6tH6Q9rdm8chGfr54X)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [x] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.

https://user-images.githubusercontent.com/17470909/143064724-f146c99e-260f-4b2f-b82d-35b15335a94f.mp4

-------------

There's an edge case on the carbonless NFT tooltip wherein we have a hyperlink inside but currently we aren't able to click it since the tooltip closes immediately when hovering away from the button. Another solution for this is to make the tooltip trigger on click instead of hover and tracking the active state of the tooltip. What are your thoughts? 