### PR TITLE
fix(coingecko): move api call to Transfer page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,6 @@ import keyring from '@polkadot/ui-keyring'
 import Navbar from './components/Navbar.vue'
 import Footer from './components/Footer.vue'
 import isShareMode from '@/utils/isShareMode'
-import coingecko from '@/coingecko'
 import correctFormat from '@/utils/ss58Format'
 import checkIndexer from '@/queries/checkIndexer.graphql'
 import { showNotification } from './utils/notification'
@@ -70,25 +69,9 @@ export default class Dashboard extends Vue {
     this.$store.commit('keyringLoaded')
   }
 
-  public async getKsmPrice(): Promise<void> {
-    try {
-      const { data } = await coingecko.get('/simple/price', {
-        params: {
-          ids: 'kusama',
-          vs_currencies: 'usd'
-        }
-      })
-
-      this.$store.dispatch('setFiatPrice', data)
-    } catch (error) {
-      console.log(error)
-    }
-  }
-
   public mounted(): void {
     this.mountWasmCrypto()
     this.fetchIndexer()
-    this.getKsmPrice()
   }
 
   private async fetchIndexer() {

--- a/src/coingecko.ts
+++ b/src/coingecko.ts
@@ -20,7 +20,6 @@ export const getKsmPrice = async (): Promise<void> => {
     })
 
     return data
-    // this.$store.dispatch('setFiatPrice', data)
   } catch (error) {
     console.log(error)
   }

--- a/src/coingecko.ts
+++ b/src/coingecko.ts
@@ -10,6 +10,21 @@ const api = Axios.create({
   withCredentials: false
 })
 
+export const getKsmPrice = async (): Promise<void> => {
+  try {
+    const { data } = await api.get('/simple/price', {
+      params: {
+        ids: 'kusama',
+        vs_currencies: 'usd'
+      }
+    })
+
+    return data
+    // this.$store.dispatch('setFiatPrice', data)
+  } catch (error) {
+    console.log(error)
+  }
+}
 
 export const getKSMUSD = async (): Promise<number> => {
   const coinId = 'kusama'

--- a/src/components/transfer/Transfer.vue
+++ b/src/components/transfer/Transfer.vue
@@ -115,6 +115,7 @@ import correctFormat from '@/utils/ss58Format'
 import { checkAddress, decodeAddress, encodeAddress, isAddress } from '@polkadot/util-crypto'
 import { urlBuilderTransaction } from '@/utils/explorerGuide'
 import { calculateUsdFromKsm, calculateKsmFromUsd } from '@/utils/calculation'
+import coingecko from '@/coingecko'
 @Component({
   components: {
     Auth: () => import('@/components/shared/Auth.vue'),
@@ -154,7 +155,23 @@ export default class Transfer extends Mixins(
     return this.hasAddress ? encodeAddress(this.destinationAddress, correctFormat(this.ss58Format)) : ''
   }
 
+  public async getKsmPrice(): Promise<void> {
+    try {
+      const { data } = await coingecko.get('/simple/price', {
+        params: {
+          ids: 'kusama',
+          vs_currencies: 'usd'
+        }
+      })
+
+      this.$store.dispatch('setFiatPrice', data)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
   protected created() {
+    this.getKsmPrice()
     this.checkQueryParams()
   }
 

--- a/src/components/transfer/Transfer.vue
+++ b/src/components/transfer/Transfer.vue
@@ -115,7 +115,6 @@ import correctFormat from '@/utils/ss58Format'
 import { checkAddress, decodeAddress, encodeAddress, isAddress } from '@polkadot/util-crypto'
 import { urlBuilderTransaction } from '@/utils/explorerGuide'
 import { calculateUsdFromKsm, calculateKsmFromUsd } from '@/utils/calculation'
-import coingecko from '@/coingecko'
 @Component({
   components: {
     Auth: () => import('@/components/shared/Auth.vue'),
@@ -155,23 +154,8 @@ export default class Transfer extends Mixins(
     return this.hasAddress ? encodeAddress(this.destinationAddress, correctFormat(this.ss58Format)) : ''
   }
 
-  public async getKsmPrice(): Promise<void> {
-    try {
-      const { data } = await coingecko.get('/simple/price', {
-        params: {
-          ids: 'kusama',
-          vs_currencies: 'usd'
-        }
-      })
-
-      this.$store.dispatch('setFiatPrice', data)
-    } catch (error) {
-      console.log(error)
-    }
-  }
-
   protected created() {
-    this.getKsmPrice()
+    this.$store.dispatch('fetchFiatPrice')
     this.checkQueryParams()
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import Vuex from 'vuex'
+import Vuex, { Commit } from 'vuex'
 import VuexPersist from 'vuex-persist'
 import SettingModule from '@vue-polkadot/vue-settings'
 import Connector from '@vue-polkadot/vue-api'
@@ -225,17 +225,17 @@ export default new Vuex.Store({
     },
   },
   actions: {
-    async fetchFiatPrice({ commit }: any) {
+    async fetchFiatPrice({ commit }: { commit: Commit }) {
       const ksmPrice = await getKsmPrice()
       commit('setFiatPrice', ksmPrice)
     },
-    setFiatPrice({ commit }: any, data) {
+    setFiatPrice({ commit }: { commit: Commit }, data) {
       commit('setFiatPrice', data)
     },
-    upateIndexerStatus({ commit }: any, data) {
+    upateIndexerStatus({ commit }: { commit: Commit }, data) {
       commit('setIndexerStatus', data)
     },
-    setLayoutClass({ commit }: any, data) {
+    setLayoutClass({ commit }: { commit: Commit }, data) {
       commit('setLayoutClass', data)
     },
   },

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,6 +5,7 @@ import SettingModule from '@vue-polkadot/vue-settings'
 import Connector from '@vue-polkadot/vue-api'
 import IdentityModule from './vuex/IdentityModule'
 import correctFormat from './utils/ss58Format'
+import { getKsmPrice } from '@/coingecko'
 
 const vuexLocalStorage = new VuexPersist({
   key: 'vuex',
@@ -224,6 +225,10 @@ export default new Vuex.Store({
     },
   },
   actions: {
+    async fetchFiatPrice({ commit }: any) {
+      const ksmPrice = await getKsmPrice()
+      commit('setFiatPrice', ksmPrice)
+    },
     setFiatPrice({ commit }: any, data) {
       commit('setFiatPrice', data)
     },


### PR DESCRIPTION
in the future we could move coingecko api calls to a new vuex module

### PR type
- [x] Refactoring

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality

### What's new?
- [x] PR closes #1194 
- [x] move coingecko api call from all routes to only Transfer route where it's needed

### Screenshot
- refactoring code
