### PR TITLE
966 Transform URL from other galleries into kodadot

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -86,6 +86,11 @@
           </b-navbar-item>
           <b-navbar-item
             tag="router-link"
+            :to="{ name: 'transform'}">
+            {{ $t('Transform') }}
+          </b-navbar-item>
+          <b-navbar-item
+            tag="router-link"
             :to="{ name: 'settings'}">
             {{ $t('Settings') }}
           </b-navbar-item>

--- a/src/components/shared/DisabledInput.vue
+++ b/src/components/shared/DisabledInput.vue
@@ -1,6 +1,6 @@
 <template>
   <b-field :label="label" :expanded="expanded">
-    <b-input :value="value" disabled ></b-input>
+    <b-input :value="value" :readonly="readonly" disabled ></b-input>
   </b-field>
 </template>
 <script lang="ts">
@@ -11,5 +11,7 @@ export default class DisabledInput extends Vue {
   @Prop({ type: String, required: true }) public label!: string;
   @Prop({ type: String, required: true }) public value!: string;
   @Prop({ type: Boolean, default: false}) public expanded!: boolean;
+  @Prop({ type: Boolean, default: false}) public readonly!: boolean;
+
 }
 </script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -337,7 +337,8 @@
     "clickToCreate": "Click here to create collection",
     "urlToTransform": {
       "label": "URL to transform",
-      "placeholder": "singular.rmrk.app/collectibles/"
+      "placeholder": "singular.rmrk.app/collectibles/",
+      "copy": "Kodadot link successfuly copied"
     }
   },
   "action": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -327,7 +327,8 @@
     "balance": "Balance",
     "submit": "Submit",
     "remove": "Remove",
-    "correctAddress": "Correct address format"
+    "correctAddress": "Correct address format",
+    "copyUrl": "Copy URL"
   },
   "helper": {
     "noCollections": "You have no collections",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -333,7 +333,11 @@
     "noCollections": "You have no collections",
     "noInfinityCollections": "You have no collections with unlimited NFTs",
     "indexerReadOnly": "App is in read only mode, try reload app or visit Discord",
-    "clickToCreate": "Click here to create collection"
+    "clickToCreate": "Click here to create collection",
+    "urlToTransform": {
+      "label": "URL to transform",
+      "placeholder": "singular.rmrk.app/collectibles/"
+    }
   },
   "action": {
     "admin": "Admin panel",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -22,6 +22,7 @@ const FourZeroFour = () => import('@/components/FourZeroFour.vue')
 const Error = () => import('@/components/Error.vue')
 const Series = () => import('@/components/landing/Series.vue')
 const Jobs = () => import('@/components/landing/Jobs.vue')
+const Transform = () => import('@/views/Transform.vue')
 
 export default new Router({
   mode: 'history',
@@ -99,6 +100,11 @@ export default new Router({
       path: '/tutorials',
       name: 'tutorials',
       component: Tutorials,
+    },
+    {
+      path: '/transform',
+      name: 'transform',
+      component: Transform,
     },
     {
       path: '/grants',

--- a/src/utils/urlTransformer.ts
+++ b/src/utils/urlTransformer.ts
@@ -1,26 +1,28 @@
-
-
 type URLParams = string[]
 type TransformFunction = (params: URLParams) => string
 type Transformer = Record<string, TransformFunction>
 
 function transform(url: string): string {
-  const value = new URL(url)
+  try {
+    const value = new URL(url)
 
-  const transformer = getTransformer(value)
+    const transformer = getTransformer(value)
 
-  if (!isTransformer(transformer)) {
-    return url
+    if (!isTransformer(transformer)) {
+      return url
+    }
+
+    const params = getParams(value)
+    const fn = transformer[params[0]] // TODO: only works for singular
+
+    if (!fn) {
+      return url
+    }
+
+    return fn(params)
+  } catch (e) {
+    return ''
   }
-
-  const params = getParams(value)
-  const fn = transformer[params[0]] // TODO: only works for singular
-
-  if (!fn) {
-    return url
-  }
-
-  return fn(params)
 }
 
 function getParams(url: URL): string[] {
@@ -44,9 +46,7 @@ const singularTransformer: Transformer = {
 }
 
 const availableTranformers: Record<string, Transformer> = {
-  'singular.rmrk.app': singularTransformer
+  'singular.rmrk.app': singularTransformer,
 }
 
-
 export default transform
-

--- a/src/utils/urlTransformer.ts
+++ b/src/utils/urlTransformer.ts
@@ -1,0 +1,52 @@
+
+
+type URLParams = string[]
+type TransformFunction = (params: URLParams) => string
+type Transformer = Record<string, TransformFunction>
+
+function transform(url: string): string {
+  const value = new URL(url)
+
+  const transformer = getTransformer(value)
+
+  if (!isTransformer(transformer)) {
+    return url
+  }
+
+  const params = getParams(value)
+  const fn = transformer[params[0]] // TODO: only works for singular
+
+  if (!fn) {
+    return url
+  }
+
+  return fn(params)
+}
+
+function getParams(url: URL): string[] {
+  return url.pathname.split('/').filter(Boolean)
+}
+
+const getTransformer = (url: URL): Transformer => {
+  return availableTranformers[url.host]
+}
+
+const isTransformer = (transformer?: any): boolean => transformer !== undefined
+
+function lastParam(params: URLParams): string {
+  return params[params.length - 1]
+}
+
+const singularTransformer: Transformer = {
+  space: (params: URLParams) => `/rmrk/u/${lastParam(params)}`,
+  collections: (params: URLParams) => `/rmrk/collection/${lastParam(params)}`,
+  collectibles: (params: URLParams) => `/rmrk/detail/${lastParam(params)}`,
+}
+
+const availableTranformers: Record<string, Transformer> = {
+  'singular.rmrk.app': singularTransformer
+}
+
+
+export default transform
+

--- a/src/views/Transform.vue
+++ b/src/views/Transform.vue
@@ -2,7 +2,6 @@
   <div class="columns mb-6">
     <div class="column is-6 is-offset-3">
       <section>
-        <br />
         <p class="title is-size-3">
             Transform
         </p>

--- a/src/views/Transform.vue
+++ b/src/views/Transform.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="columns mb-6">
+    <div class="column is-6 is-offset-3">
+      <section>
+        <br />
+        <BasicInput
+          v-model="url"
+          :label="$t('mint.collection.symbol.label')"
+          :message="$t('mint.collection.symbol.message')"
+          :placeholder="$t('mint.collection.symbol.placeholder')"
+          @keydown.native.space.prevent
+        />
+        <DisabledInput label="hex input data" value="isHexAddress" />
+        <b-button
+          type="is-primary"
+          icon-left="paper-plane"
+          outlined
+        >
+          {{ $t('general.open') }}
+        </b-button>
+        <b-button
+          type="is-primary"
+          icon-left="paper-plane"
+          outlined
+        >
+          {{ $t('general.copy') }}
+        </b-button>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+
+@Component({
+  components: {
+    BasicInput: () => import('@/components/shared/form/BasicInput.vue'),
+    DisabledInput: () => import('@/components/shared/DisabledInput.vue'),
+  },
+})
+export default class Transfer extends Vue {
+  protected url = ''
+
+  get transformedUrl() {
+    return this.url
+  }
+}
+</script>

--- a/src/views/Transform.vue
+++ b/src/views/Transform.vue
@@ -3,7 +3,7 @@
     <div class="column is-6 is-offset-3">
       <section>
         <p class="title is-size-3">
-            $t('Transform')
+          {{ $t('Transform') }}
         </p>
         <BasicInput
           v-model="url"

--- a/src/views/Transform.vue
+++ b/src/views/Transform.vue
@@ -3,7 +3,7 @@
     <div class="column is-6 is-offset-3">
       <section>
         <p class="title is-size-3">
-            Transform
+            $t('Transform')
         </p>
         <BasicInput
           v-model="url"

--- a/src/views/Transform.vue
+++ b/src/views/Transform.vue
@@ -5,23 +5,17 @@
         <br />
         <BasicInput
           v-model="url"
-          :label="$t('mint.collection.symbol.label')"
-          :message="$t('mint.collection.symbol.message')"
-          :placeholder="$t('mint.collection.symbol.placeholder')"
+          :label="$t('helper.urlToTransform.label')"
+          :placeholder="$t('helper.urlToTransform.placeholder')"
           @keydown.native.space.prevent
         />
-        <DisabledInput label="hex input data" value="isHexAddress" />
+        <DisabledInput v-show="!disabled" label="KodaDot URL" :value="fullUrl" />
         <b-button
-          type="is-primary"
-          icon-left="paper-plane"
+          type="is-success"
+          icon-left="copy"
+          v-clipboard:copy="transformedUrl"
           outlined
-        >
-          {{ $t('general.open') }}
-        </b-button>
-        <b-button
-          type="is-primary"
-          icon-left="paper-plane"
-          outlined
+          :disabled="disabled"
         >
           {{ $t('general.copy') }}
         </b-button>
@@ -32,6 +26,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
+import transform from '@/utils/urlTransformer'
 
 @Component({
   components: {
@@ -39,11 +34,19 @@ import { Component, Vue } from 'vue-property-decorator'
     DisabledInput: () => import('@/components/shared/DisabledInput.vue'),
   },
 })
-export default class Transfer extends Vue {
+export default class Transform extends Vue {
   protected url = ''
 
-  get transformedUrl() {
-    return this.url
+  get transformedUrl(): string {
+    return transform(this.url)
+  }
+
+  get fullUrl(): string {
+    return `${window.location.origin}${this.transformedUrl}`
+  }
+
+  get disabled(): boolean {
+    return this.transformedUrl === ''
   }
 }
 </script>

--- a/src/views/Transform.vue
+++ b/src/views/Transform.vue
@@ -14,10 +14,11 @@
         />
         <DisabledInput v-show="!disabled" label="KodaDot URL" :value="fullUrl" />
         <b-button
-          type="is-success"
+          type="is-primary"
           icon-left="copy"
-          v-clipboard:copy="transformedUrl"
+          v-clipboard:copy="fullUrl"
           outlined
+          @click="toast"
           :disabled="disabled"
         >
           {{ $t('general.copyUrl') }}
@@ -30,6 +31,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import transform from '@/utils/urlTransformer'
+import { exist } from '@/components/rmrk/Gallery/Search/exist'
 
 @Component({
   components: {
@@ -39,6 +41,10 @@ import transform from '@/utils/urlTransformer'
 })
 export default class Transform extends Vue {
   protected url = ''
+
+  public mounted(): void {
+    exist(this.$route.query.url, (value) => this.url = value)
+  }
 
   get transformedUrl(): string {
     return transform(this.url)
@@ -50,6 +56,11 @@ export default class Transform extends Vue {
 
   get disabled(): boolean {
     return this.transformedUrl === ''
+  }
+
+  private toast(): void {
+    const message = this.$t('helper.urlToTransform.copy').toString()
+    this.$buefy.toast.open(message)
   }
 }
 </script>

--- a/src/views/Transform.vue
+++ b/src/views/Transform.vue
@@ -3,6 +3,9 @@
     <div class="column is-6 is-offset-3">
       <section>
         <br />
+        <p class="title is-size-3">
+            Transform
+        </p>
         <BasicInput
           v-model="url"
           :label="$t('helper.urlToTransform.label')"
@@ -17,7 +20,7 @@
           outlined
           :disabled="disabled"
         >
-          {{ $t('general.copy') }}
+          {{ $t('general.copyUrl') }}
         </b-button>
       </section>
     </div>

--- a/tests/unit/urlTransform.spec.ts
+++ b/tests/unit/urlTransform.spec.ts
@@ -21,6 +21,18 @@ describe('URL TRANSFORMER TEST', (): void => {
       const transformed = transform(collection)
       expect(transformed).to.equal('/rmrk/collection/FC77C33AB229A2056A-BTFLSUZANN')
     })
+
+    it('can correctly handle empty URL', () => {
+      const collection = ''
+      const transformed = transform(collection)
+      expect(transformed).to.equal('')
+    })
+
+    it('should return empty string when the value is not correct', () => {
+      const collection = 'kkdot'
+      const transformed = transform(collection)
+      expect(transformed).to.equal('')
+    })
   })
 
 

--- a/tests/unit/urlTransform.spec.ts
+++ b/tests/unit/urlTransform.spec.ts
@@ -1,0 +1,27 @@
+import transform from '@/utils/urlTransformer'
+import { expect } from 'chai'
+
+describe('URL TRANSFORMER TEST', (): void => {
+  describe('For Singular', (): void => {
+
+    it('can correctly transform profile', () => {
+      const profile = 'https://singular.rmrk.app/space/JHMAL5CyvxWc3Ud42QxRUTpSnUa4m56mRSzPK69d1TU8NG7'
+      const transformed = transform(profile)
+      expect(transformed).to.equal('/rmrk/u/JHMAL5CyvxWc3Ud42QxRUTpSnUa4m56mRSzPK69d1TU8NG7')
+    })
+
+    it('can correctly transform nft', () => {
+      const nft = 'https://singular.rmrk.app/collectibles/10249854-FC77C33AB229A2056A-BTFLSUZANN-BEAUTIFUL_SUZANNE_13-0000000000000013'
+      const transformed = transform(nft)
+      expect(transformed).to.equal('/rmrk/detail/10249854-FC77C33AB229A2056A-BTFLSUZANN-BEAUTIFUL_SUZANNE_13-0000000000000013')
+    })
+
+    it('can correctly transform collection', () => {
+      const collection = 'https://singular.rmrk.app/collections/FC77C33AB229A2056A-BTFLSUZANN'
+      const transformed = transform(collection)
+      expect(transformed).to.equal('/rmrk/collection/FC77C33AB229A2056A-BTFLSUZANN')
+    })
+  })
+
+
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,15 +3680,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001237"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
-  integrity sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==
-
-caniuse-lite@^1.0.30001251:
-  version "1.0.30001252"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz#cb16e4e3dafe948fc4a9bb3307aea054b912019a"
-  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001251:
+  version "1.0.30001283"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz"
+  integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
 
 canvas-renderer@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- :top: updated can-i-use
- :tada: url transformer is working correclty
- :white_check_mark: updated tests for url transformer
- :lipstick: Disabled input can accept readonly prop
- :rocket: added Tranform component
- :earth_americas: added translation for the transform
- :zap: added translations, added transform to navbar, added ?url param

Thank you for your contribution to the KodaDot NFT gallery, 
we really appreciate your contribution!

### PR type
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### Before submitting this PR, please make sure:
- [x] Your code builds clean without any erros or warnigns
- [x] You've posted screenshot of demonstrated change in this PR
- [x] Merged recent default branch, **main** and you have no conflicts
- [x] Didn't break any original functionality 

### Optional
- [ ] You've tested it on mobile
- [ ] Are there any edge cases? Name if any 

### What's new? (may be part of changelog)
- closes #966


<img width="844" alt="Screenshot 2021-11-29 at 17 08 29" src="https://user-images.githubusercontent.com/22471030/143903090-8eb82abf-4dd3-428b-ad82-400b2c7f5c41.png">

