### PR TITLE
Fixed whitespace between twitter icon and name

### DIFF
--- a/components/shared/format/Identity.vue
+++ b/components/shared/format/Identity.vue
@@ -151,7 +151,7 @@ export default class Identity extends mixins(InlineMixin) {
 
 .twitter-link .icon {
   vertical-align: middle;
-  margin: auto .5em auto 0;
+  margin: auto 0 auto 0;
 }
 
 .overflowWrap {


### PR DESCRIPTION

![Screen Shot 2021-12-04 at 8 28 51 AM](https://user-images.githubusercontent.com/55772762/144717058-7fc04e01-9d9b-4fae-a856-3d1bfad3cccf.png)


**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring

### Before submitting Pull Request, please make sure:
- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried respect high code quality standards
- [X] I've didn't break any original functionality
- [X] I've posted screenshot of demonstrated change in this PR

### Optional
- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [X] PR closes #1388
- [X] Fixes extra whitespace in twitter icon

### Had issue bounty label ?
- [ ] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=<My_Kusama_Address>)

### Community participation
- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [ ] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.
