### PR TITLE
added link to NFT wiki on home page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -99,6 +99,15 @@
               >
                 Grants
               </b-button>
+              <b-button
+                tag="a"
+                href="https://en.wikipedia.org/wiki/Non-fungible_token"
+                target="_blank"
+                rel="noopener noreferrer"
+                type="is-primary"
+              >
+                What are NFTs?
+              </b-button>
             </div>
           </div>
           <div class="column has-text-right has-text-left-mobile">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring

### Before submitting Pull Request, please make sure:
- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried respect high code quality standards
- [X] I've didn't break any original functionality
- [X] I've posted screenshot of demonstrated change in this PR

### Optional
- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [ ] PR closes #<issue_number>
- [X] <added a button on the home page that takes the user to https://en.wikipedia.org/wiki/Non-fungible_token to teach them about what NFTs are>

### Had issue bounty label ?
- [ ] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=<My_Kusama_Address>)

### Community participation
- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [ []](url) My fix has changed **something** on UI, a screenshot for others, is best to understand changes.

![image](https://user-images.githubusercontent.com/73927889/144734931-00ef1f65-503d-42b9-9f23-8d687848c59a.png)
