### PR TITLE
fix: add on-chain identity after destination address

### DIFF
--- a/components/shared/format/Identity.vue
+++ b/components/shared/format/Identity.vue
@@ -56,7 +56,9 @@ export default class Identity extends mixins(InlineMixin) {
 
   get name(): Address {
     const name = this.identity.display
-    return name as string || shortAddress(this.resolveAddress(this.address))
+    return name
+      ? `${shortAddress(this.resolveAddress(this.address))} (${name})`
+      : shortAddress(this.resolveAddress(this.address))
   }
 
   get twitter(): Address {

--- a/pages/transfer.vue
+++ b/pages/transfer.vue
@@ -45,6 +45,7 @@
             ref="identity"
             :address="$route.query.target"
             inline
+            show-onchain-identity
           />
         </a>
       </div>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it at `/transfer`
- [ ] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [x] PR closes #1317
- [x] Added the receiver's on-chain identity after the destination address

### Had issue bounty label ?
- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=F2zKdNM77s17cmtdgqCooGVphz8UFv4jUEuFJ366VVAb53G)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [x] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.

---------------

## Receiver with on-chain identity
![image](https://user-images.githubusercontent.com/17470909/144707055-fb326f48-9e63-41a5-b0bf-cfdc94ece3ed.png)

## Receiver without on-chain identity
![image](https://user-images.githubusercontent.com/17470909/144746945-3d7ded5a-d6b9-43e8-a06b-6bb85804f202.png)

