### PR TITLE
#1486 fix: turn off skeleton while paginating on collection

### DIFF
--- a/components/rmrk/Gallery/CollectionItem.vue
+++ b/components/rmrk/Gallery/CollectionItem.vue
@@ -11,17 +11,16 @@
           />
         </div>
         <h1 class="title is-2">
-          <template v-if="!isLoading">
+          <template>
             {{ name }}
           </template>
-          <b-skeleton :active="isLoading" size="is-medium"></b-skeleton>
         </h1>
       </div>
     </div>
 
     <div class="columns is-align-items-center">
       <div class="column">
-        <div v-if="!isLoading">
+        <div>
           <div class="label">
             {{ $t('creator') }}
           </div>
@@ -29,16 +28,6 @@
             <ProfileLink :address="issuer" inline showTwitter />
           </div>
         </div>
-        <b-skeleton
-          :active="isLoading"
-          width="40%"
-          size="is-small"
-        ></b-skeleton>
-        <b-skeleton
-          :active="isLoading"
-          width="60%"
-          size="is-small"
-        ></b-skeleton>
       </div>
 
       <div class="column is-6-tablet is-7-desktop is-8-widescreen">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main-nuxt** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it at `/rmrk/collection/c87323333f9ce3e831-DAAW`
- [x] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [x] PR closes #1486 
- [x] Turned off loader that's showing whenever the user navigates through the pages

### Had issue bounty label ?
- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=F2zKdNM77s17cmtdgqCooGVphz8UFv4jUEuFJ366VVAb53G)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [x] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.

**Browser's cache has been cleared**


https://user-images.githubusercontent.com/17470909/145608750-81f11029-8c0f-45f7-b72c-2564941285c7.mp4



