### PR TITLE
fix: reverse order to fetch first nft mint date

### DIFF
--- a/components/shared/IdentityPopover.vue
+++ b/components/shared/IdentityPopover.vue
@@ -44,15 +44,15 @@
 
       <div style="" class="popover-stats-container pt-3">
         <div class="has-text-centered">
-          <p class="has-text-weight-bold is-size-6">{{ totalCollected || '-' }}</p>
+          <p class="has-text-weight-bold is-size-6">{{ totalCollected }}</p>
           <span class="is-size-7">Bought</span>
         </div>
         <div class="has-text-centered">
-          <p class="has-text-weight-bold is-size-6">{{ totalCreated || '-' }}</p>
+          <p class="has-text-weight-bold is-size-6">{{ totalCreated }}</p>
           <span class="is-size-7">Created</span>
         </div>
         <div class="has-text-centered">
-          <p class="has-text-weight-bold is-size-6">{{ totalSold || '-' }}</p>
+          <p class="has-text-weight-bold is-size-6">{{ totalSold }}</p>
           <span class="is-size-7">Sold</span>
         </div>
       </div>

--- a/queries/nftStatsByIssuer.graphql
+++ b/queries/nftStatsByIssuer.graphql
@@ -5,7 +5,7 @@ query nFTStatsByIssuer($account: String!) {
       name: { notLike: "%Kanaria%" }
       burned: { distinctFrom: true }
     }
-    orderBy: BLOCK_NUMBER_DESC
+    orderBy: BLOCK_NUMBER_ASC
     first: 1
   ) {
     nodes {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it at `/rmrk/u/J9cppW5x7akmWG6yTiEMHy5Cx8VVZ9YTQKV3AGfABvFXrFN`
- [ ] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [x] PR closes #1511
- [x] Reverse the orderBy parameters in the graphql query to get the first minted date

### Had issue bounty label ?
- [ ] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=<My_Kusama_Address>)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [x] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.

![image](https://user-images.githubusercontent.com/17470909/145819245-2c19b6ed-fed5-46e2-bd12-6c0769aedfd3.png)
