### PR TITLE
1460 fix: center preloader status text

### DIFF
--- a/components/shared/Loader.vue
+++ b/components/shared/Loader.vue
@@ -90,5 +90,6 @@ export default class Loader extends Vue {
   position: relative;
   max-width: 200px;
   text-align: center;
+  margin: 0 auto;
 }
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [x] PR closes #1460
- [x] status text now center again (issue with margin)

### Had issue bounty label ?
- [ ] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=<My_Kusama_Address>)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [ ] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.
