### PR TITLE
1618 galleryitem in collection tab should link to collection

### DIFF
--- a/components/rmrk/Gallery/Item/Sharing.vue
+++ b/components/rmrk/Gallery/Item/Sharing.vue
@@ -126,7 +126,7 @@ export default class Sharing extends Vue {
 
   private active = false
 
-  private hashtags = ['KusamaNetwork', 'KodaDot']
+  private hashtags = 'KusamaNetwork,KodaDot'
 
   get helloText(): string {
     return this.label

--- a/pages/rmrk/u/_id.vue
+++ b/pages/rmrk/u/_id.vue
@@ -92,6 +92,7 @@
           <GalleryCardList
             :items="collections"
             type="collectionDetail"
+            route="/rmrk/collection"
             link="rmrk/collection"
             horizontalLayout
           />
@@ -164,6 +165,7 @@ const components = {
   DonationButton: () => import('@/components/transfer/DonationButton.vue'),
   Avatar: () => import('@/components/shared/Avatar.vue'),
   ProfileLink: () => import('@/components/rmrk/Profile/ProfileLink.vue'),
+  Layout: () => import('@/components/rmrk/Gallery/Layout.vue')
 }
 
 const eq = (tab: string) => (el: string) => tab === el


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

https://user-images.githubusercontent.com/17953978/147501757-7fb501b6-aa6b-49e5-907b-21bd7f8ec29d.mov

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [x] PR closes #1618
- [x] GalleryItem in Collection Tab in User Profile now correctly links to collection. Further fixed import error and hashtags for sharing should be string with comma separated words instead of array

### Had issue bounty label ?
- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [ ] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.
