### PR TITLE
1628 set new default interface settings

### DIFF
--- a/store/preferences.ts
+++ b/store/preferences.ts
@@ -12,8 +12,8 @@ export const state = (): {
 }  => ({
   layoutClass: 'is-one-third-desktop is-one-third-tablet',
   advancedUI: false,
-  theatreView: 'default',
-  compactGalleryItem: false,
+  theatreView: 'theatre',
+  compactGalleryItem: true,
   compactCollection: false,
   galleryItemsPerPage: 12,
   collectionsPerPage: 9,
@@ -39,8 +39,8 @@ export const mutations: MutationTree<PreferencesState> = {
     // if set to false reset state back to default
     if(!data) {
       state.layoutClass = 'is-one-third-desktop is-one-third-tablet',
-      state.theatreView = 'default'
-      state.compactGalleryItem = false
+      state.theatreView = 'theatre'
+      state.compactGalleryItem = true
       state.compactCollection = false
       state.galleryItemsPerPage = 12
       state.collectionsPerPage = 9


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇  _ Do a quick check before the merge. 

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
<img width="877" alt="default-settings" src="https://user-images.githubusercontent.com/17953978/147595373-5a77c078-481d-4a2b-986e-07fe25664dfe.png">
<img width="1422" alt="folded-price-and-history" src="https://user-images.githubusercontent.com/17953978/147595391-23e66ac4-116b-4ae7-901f-53c6ccdb63e5.png">

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [x] I've tested it at </rmrk/gallery/10719544-06ea5e9291a7e86837-CLWNY-CLOWNIE0074-0000000000000075>
- [ ] I've tested PR on mobile and everything works
- [ ] I found edge cases

### What's new?
- [x] PR closes #1628
- [x] changed default nft image view to "theatre" and price and history is now folded on default

### Had issue bounty label ?
- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [x] My fix has changed **something** on UI, a screenshot for others, is best to understand changes.
