### PR TITLE
⚒️  border on galleryItem

### DIFF
--- a/components/rmrk/Gallery/GalleryItem.vue
+++ b/components/rmrk/Gallery/GalleryItem.vue
@@ -119,7 +119,7 @@
               is-flex is-flex-direction-column is-justify-content-space-between
             "
           >
-            <div class="card card-actions mb-4" aria-id="contentIdForA11y3">
+            <div class="card bordered mb-4" aria-id="contentIdForA11y3">
               <div class="card-content">
                 <template v-if="hasPrice">
                   <div class="label">
@@ -581,23 +581,6 @@ hr.comment-divider {
       opacity: 0.6;
       color: $dark;
       margin: 0;
-    }
-  }
-
-  .card-actions {
-    border-radius: 0 !important;
-    box-shadow: none;
-    border: 2px solid $primary;
-
-    &-content {
-      padding-left: 1rem;
-      padding-top: 1rem;
-    }
-
-    &-footer {
-      &-item {
-        padding: 0.75rem !important;
-      }
     }
   }
 

--- a/components/rmrk/Gallery/History.vue
+++ b/components/rmrk/Gallery/History.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="block">
-    <b-collapse :open="isOpen" class="card" animation="slide" aria-id="contentIdForHistory">
+    <b-collapse :open="isOpen" class="card bordered" animation="slide" aria-id="contentIdForHistory">
       <template #trigger="props">
         <div
           class="card-header"

--- a/components/rmrk/Gallery/PriceChart.vue
+++ b/components/rmrk/Gallery/PriceChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-collapse :open="isOpen" class="card" animation="slide" aria-id="contentIdForHistory">
+  <b-collapse :open="isOpen" class="card bordered" animation="slide" aria-id="contentIdForHistory">
     <template #trigger="props">
       <div
         class="card-header"

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -167,3 +167,20 @@ body {
 .page-leave-active {
   opacity: 0
 }
+
+.card.bordered {
+    border-radius: 0 !important;
+    box-shadow: none;
+    border: 2px solid $primary;
+
+    &-content {
+        padding-left: 1rem;
+        padding-top: 1rem;
+    }
+
+    &-footer {
+        &-item {
+        padding: 0.75rem !important;
+        }
+    }
+}


### PR DESCRIPTION
I'm the one to blame, continue #1100 & #1631
gallery-item page is supercharging some default css

### PR type
- [x] Bugfix

### Screenshot
#### before
![Screenshot 2021-12-30 at 14-08-16 nft-gallery-nuxt](https://user-images.githubusercontent.com/9987732/147754919-e0652b64-a6a0-4fc0-bbb7-6593b7b6fec2.png)

#### after
![Screenshot 2021-12-30 at 14-09-21 nft-gallery-nuxt](https://user-images.githubusercontent.com/9987732/147754924-8a0078c9-b371-4126-b025-d7079c8685f5.png)

