### PR TITLE
⚒️ gallery link in card text

### DIFF
--- a/components/rmrk/Gallery/Gallery.vue
+++ b/components/rmrk/Gallery/Gallery.vue
@@ -38,24 +38,12 @@
                   :title="nft.name"
                 >
                   <nuxt-link
-                    v-if="nft.count < 2"
                     :to="`/${urlPrefix}/gallery/${nft.id}`"
-                  >
-                    <div>
-                      <div class="has-text-overflow-ellipsis middle">
-                        {{ nft.name }}
-                      </div>
-                    </div>
-                  </nuxt-link>
-                  <nuxt-link
-                    v-else
-                    :to="`/${urlPrefix}/collection/${nft.collectionId}`"
                   >
                     <div class="has-text-overflow-ellipsis">
                       {{ nft.name }}
                     </div>
                   </nuxt-link>
-
                   <p
                     v-if="nft.count > 2"
                     :title="`${nft.count} items available in collection`"


### PR DESCRIPTION
We don't need to link to `/collection` as we introduce in user preferences to show a certain amount of nfts in page.

### PR type
- [x] Bugfix

### What's new?
- [x] PR closes #1109 