### PR TITLE
⚒️ unused css & logo padding desktop

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -173,14 +173,6 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
     }
   }
 
-  .logo {
-    padding: 0.5rem 0.75rem;
-
-    @include desktop {
-      padding-left: 0;
-    }
-  }
-
   .navbar-item {
     text-transform: uppercase;
     font-weight: 500;


### PR DESCRIPTION
see preview

### PR type
- [x] Bugfix

### Screenshot
#### before
![Screenshot 2021-12-30 at 16-46-30 nft-gallery-nuxt](https://user-images.githubusercontent.com/9987732/147766874-faa06d90-adb0-4e02-aa3b-5162317ff934.png)

#### after
![Screenshot 2021-12-30 at 16-46-42 nft-gallery-nuxt](https://user-images.githubusercontent.com/9987732/147766892-45d1809d-4a1a-4365-80c7-2b8ec55c3d5d.png)

