### PR TITLE
1683 Centering Buy now button

### DIFF
--- a/components/rmrk/Gallery/Search/SearchBarCollection.vue
+++ b/components/rmrk/Gallery/Search/SearchBarCollection.vue
@@ -16,15 +16,14 @@
         >
         </b-input>
       </b-field>
-      <b-tooltip :label="$i18n.t('tooltip.buy')">
-        <BasicSwitch
-         class="is-flex control mb-5"
-         v-model="vListed"
-         :label="!replaceBuyNowWithYolo ? 'sort.listed' : 'YOLO'"
-         size="is-medium"
-         labelColor="is-success"
-        />
-      </b-tooltip>
+      <BasicSwitch
+        class="is-flex control mb-5"
+        v-model="vListed"
+        :label="!replaceBuyNowWithYolo ? 'sort.listed' : 'YOLO'"
+        size="is-medium"
+        labelColor="is-success"
+        :message="$i18n.t('tooltip.buy')"
+      />
       <slot />
     </b-field>
   </div>

--- a/components/shared/form/BasicSwitch.vue
+++ b/components/shared/form/BasicSwitch.vue
@@ -6,7 +6,9 @@
       :size="size"
       :class="labelColor"
     >
-      {{ properLabel }}
+      <component :is="componentName" :label="message">
+        {{ properLabel }}
+      </component>
     </b-switch>
   </b-field>
 </template>
@@ -22,6 +24,11 @@ export default class BasicSwitch extends Vue {
   @Prop({ type: String }) offLabel!: string
   @Prop({ type: String }) size!: string
   @Prop({ type: String }) labelColor!: string
+  @Prop({ type: String }) message!: string
+
+  get componentName(): string {
+    return this.message ? 'b-tooltip' : 'span'
+  }
 
   get properLabel(): TranslateResult {
     const offLabel = this.offLabel || this.label


### PR DESCRIPTION
Close #1683

- :zap: BasicSwitch now takes tooltip as parameter
- :bug: Buy now is correctly centered in searchbar collection

Thank you for your contribution to the KodaDot NFT gallery, 
we really appreciate your contribution!

### PR type
- [x] Bugfix
- [ ] Feature
- [x] Refactoring

### Before submitting this PR, please make sure:
- [x] Your code builds clean without any erros or warnigns
- [x] You've posted screenshot of demonstrated change in this PR
- [x] Merged recent default branch, **main** and you have no conflicts
- [ ] Didn't break any original functionality 

### Optional
- [ ] You've tested it on mobile
- [ ] Are there any edge cases? Name if any 

<img width="1425" alt="Screenshot 2022-01-04 at 09 54 37" src="https://user-images.githubusercontent.com/22471030/148033797-2325af9b-647f-4cf6-8d96-390b619382cd.png">

