### PR TITLE
✨ fira-code font config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -23,7 +23,10 @@ export default {
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' },
     ],
-    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    link: [
+      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+      { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Fira+Code:wght@600;700&display=swap' },
+    ],
   },
 
   loadingIndicator: {


### PR DESCRIPTION
Fonts have never been loaded...
Instead of loading them from the google cdn we could includes fonts in `assets` directory.
For the moment we load the "bold" (600, 700 font weight) versions because the result is better, let me know if you want to test with ligth version.

### PR type
- [x] Bugfix

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main-nuxt** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### What's new?
- [x] PR closes #1611 

### Screenshot
(bold)
![Screenshot 2022-01-05 at 09-02-37 KodaDot - Polkadot Kusama NFT explorer](https://user-images.githubusercontent.com/9987732/148182022-4702f3f9-9890-489e-a45b-25e8c4de45e9.png)

(medium)
![Screenshot 2022-01-05 at 09-17-45 KodaDot - Polkadot Kusama NFT explorer](https://user-images.githubusercontent.com/9987732/148183752-80e0cc16-159d-4a9c-b48a-be89d2fdd0f7.png)

(normal)
![Screenshot 2022-01-05 at 09-12-29 KodaDot - Polkadot Kusama NFT explorer](https://user-images.githubusercontent.com/9987732/148183080-7a2b179a-f7c8-4fa0-bdaa-a2d4e800fa2a.png)

