### PR TITLE
fix: only fetch nftstats once address is fully loaded

### DIFF
--- a/components/shared/IdentityPopover.vue
+++ b/components/shared/IdentityPopover.vue
@@ -99,7 +99,7 @@ export default class IdentityPopover extends mixins(PrefixMixin) {
 
   // only fetch stats once address is successfully propagated from parent
   @Watch('identity.address')
-  onAddressLoaded(newVal) {
+  protected onAddressLoaded(newVal: string): void {
     if(newVal) {
       this.fetchNFTStats()
     }

--- a/components/shared/IdentityPopover.vue
+++ b/components/shared/IdentityPopover.vue
@@ -75,6 +75,7 @@ type IdentityFields = Record<string, string>;
 })
 export default class IdentityPopover extends mixins(PrefixMixin) {
   @Prop() public identity!: IdentityFields
+  @Prop() public fetched!: boolean
 
   protected totalCreated = 0
   protected totalCollected = 0
@@ -97,9 +98,9 @@ export default class IdentityPopover extends mixins(PrefixMixin) {
     return this.firstMintDate ? formatDistanceToNow(new Date(this.firstMintDate), { addSuffix: true }) : ''
   }
 
-  // only fetch stats once address is successfully propagated from parent
-  @Watch('identity.address')
-  protected onAddressLoaded(newVal: string): void {
+  // only fetch stats once identity is fetched and successfully propagated from parent
+  @Watch('fetched')
+  protected onFetchedSuccessfully(newVal: string): void {
     if(newVal) {
       this.fetchNFTStats()
     }

--- a/components/shared/IdentityPopover.vue
+++ b/components/shared/IdentityPopover.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="ts" >
-import { Component, mixins, Prop } from 'nuxt-property-decorator'
+import { Component, mixins, Prop, Watch } from 'nuxt-property-decorator'
 import {formatDistanceToNow} from 'date-fns'
 import { notificationTypes, showNotification } from '@/utils/notification'
 import shortAddress from '@/utils/shortAddress'
@@ -97,8 +97,12 @@ export default class IdentityPopover extends mixins(PrefixMixin) {
     return this.firstMintDate ? formatDistanceToNow(new Date(this.firstMintDate), { addSuffix: true }) : ''
   }
 
-  public async mounted() {
-    await this.fetchNFTStats()
+  // only fetch stats once address is successfully propagated from parent
+  @Watch('identity.address')
+  onAddressLoaded(newVal) {
+    if(newVal) {
+      this.fetchNFTStats()
+    }
   }
 
   protected async fetchNFTStats() {

--- a/components/shared/format/Identity.vue
+++ b/components/shared/format/Identity.vue
@@ -91,8 +91,8 @@ export default class Identity extends mixins(InlineMixin) {
     if (shouldUpdate(newAddress, oldAddress)) {
       const id = await this.identityOf(newAddress)
       this.identity = id
+      this.successfullyFetched = true
     }
-    this.successfullyFetched = true
   }
 
   public async identityOf(account: Address): Promise<IdentityFields> {

--- a/components/shared/format/Identity.vue
+++ b/components/shared/format/Identity.vue
@@ -30,7 +30,7 @@
         </template>
       </span>
       <span v-else>
-        <IdentityPopover :identity="{ ...identity, address }">
+        <IdentityPopover :identity="{ ...identity, address }" :fetched="successfullyFetched">
           <template #trigger>
             {{ name | toString }}
           </template>
@@ -70,6 +70,7 @@ export default class Identity extends mixins(InlineMixin) {
   @Prop(Boolean) public showOnchainIdentity!: boolean
   private identity: IdentityFields = emptyObject<IdentityFields>()
   private isFetchingIdentity = false
+  private successfullyFetched = false
 
   get shortenedAddress(): Address {
     return shortAddress(this.resolveAddress(this.address))
@@ -88,8 +89,10 @@ export default class Identity extends mixins(InlineMixin) {
   @Watch('address', { immediate: true })
   async watchAddress(newAddress: Address,  oldAddress: Address) {
     if (shouldUpdate(newAddress, oldAddress)) {
-      this.identityOf(newAddress).then(id => this.identity = id)
+      const id = await this.identityOf(newAddress)
+      this.identity = id
     }
+    this.successfullyFetched = true
   }
 
   public async identityOf(account: Address): Promise<IdentityFields> {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇  _ Do a quick check before the merge.

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?
- [x] PR closes #1756
- [x] shouldn't be fetched automatically in `mounted`, but once address is loaded in parent component
<img width="640" alt="Screenshot 2022-01-10 at 20 16 22" src="https://user-images.githubusercontent.com/17953978/148827089-2ad0ba0a-0a27-441b-91b7-f276702f0188.png">

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main-nuxt** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label ?
- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [ ] My fix has changed **something** on UI, a screenshot is best to understand changes for others.
