### PR TITLE
Load collection detail chart data when activity tab is clicked

### DIFF
--- a/components/rmrk/Gallery/CollectionItem.vue
+++ b/components/rmrk/Gallery/CollectionItem.vue
@@ -198,6 +198,7 @@ export default class CollectionItem extends mixins(ChainMixin, PrefixMixin) {
   protected total = 0
   protected stats: NFT[] = []
   protected priceData: any = []
+  private statsLoaded = false
 
   get isLoading(): boolean {
     return this.$apollo.queries.collection.loading
@@ -256,7 +257,6 @@ export default class CollectionItem extends mixins(ChainMixin, PrefixMixin) {
   public created(): void {
     this.checkId()
     this.checkActiveTab()
-    this.loadStats()
     this.$apollo.addSmartQuery('collection', {
       query: collectionById,
       client: this.urlPrefix,
@@ -297,6 +297,7 @@ export default class CollectionItem extends mixins(ChainMixin, PrefixMixin) {
       .then(({ data }) => data?.nFTEntities?.nodes || [])
       .then((nfts) => {
         this.stats = nfts
+        this.statsLoaded = true
         this.loadPriceData()
       })
   }
@@ -353,11 +354,18 @@ export default class CollectionItem extends mixins(ChainMixin, PrefixMixin) {
 
   @Watch('activeTab')
   protected onTabChange(val: string, oldVal: string): void {
-    if (shouldUpdate(val, oldVal)) {
+    let queryTab = this.$route.query.tab
+
+    if (shouldUpdate(val, oldVal) && (queryTab !== val)) {
       this.$router.replace({
         path: String(this.$route.path),
         query: { tab: val },
       })
+    }
+
+    // Load chart data once when clicked on activity tab for the first time.
+    if (val === 'activity' && !this.statsLoaded) {
+      this.loadStats()
     }
   }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇  _ Do a quick check before the merge.

### PR type
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?
- [x] PR closes #1754
- [x] Load stats only when tab is clicked
- [x] Fix duplicate navigation warning

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main-nuxt** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted screenshot of demonstrated change in this PR

### Optional
- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label ?
- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=CeBWgisygADqqxGk7ju8aMNEKz1K2WkxMKC3G8HsMnm119n)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [ ] My fix has changed **something** on UI, a screenshot is best to understand changes for others.
