### PR TITLE
fix: circumvent opengraph namespace caching

### DIFF
--- a/pages/carbonless.vue
+++ b/pages/carbonless.vue
@@ -114,6 +114,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
     const title = 'KodaDot cares about environmental impact'
     const metaData = {
       title,
+      type: 'article',
       url: `${this.$config.baseUrl}/carbonless`,
       image: `${this.$config.baseUrl}/k_card_mint.png`,
     }

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -14,6 +14,7 @@ import Contact from '@/components/landing/Contact.vue'
     const title = 'KodaDot cares about environmental impact'
     const metaData = {
       title,
+      type: 'article',
       url: `${this.$config.baseUrl}/contact`,
       image: `${this.$config.baseUrl}/k_card_mint.png`,
     }

--- a/pages/partnership.vue
+++ b/pages/partnership.vue
@@ -15,6 +15,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
     const title = 'KodaDot cares about environmental impact'
     const metaData = {
       title,
+      type: 'article',
       url: `${this.$config.baseUrl}/partnership`,
       image: `${this.$config.baseUrl}/k_card_mint.png`,
     }

--- a/pages/permafrost/create.vue
+++ b/pages/permafrost/create.vue
@@ -195,6 +195,7 @@ const components = {
     const title = 'KodaDot | Low fees and low carbon minting'
     const metaData = {
       title,
+      type: 'article',
       description: 'Create carbonless NFTs with low on-chain fees',
       url: '/permafrost/create',
       image: `${this.$config.baseUrl}/k_card_mint.png`,

--- a/pages/rmrk/admin.vue
+++ b/pages/rmrk/admin.vue
@@ -14,6 +14,7 @@ import AdminPanel from '@/components/rmrk/Create/Admin/AdminPanel.vue'
     const title = 'KodaDot | Low fees and low carbon minting'
     const metaData = {
       title,
+      type: 'profile',
       description: 'Create carbonless NFTs with low on-chain fees',
       url: '/rmrk/admin',
       image: `${this.$config.baseUrl}/k_card_mint.png`,

--- a/pages/rmrk/collection/_id.vue
+++ b/pages/rmrk/collection/_id.vue
@@ -20,6 +20,7 @@ import CollectionItem from '@/components/rmrk/Gallery/CollectionItem.vue'
     const title = this.currentlyViewedCollection.name
     const metaData = {
       title,
+      type: 'profile',
       description: this.currentlyViewedCollection.description,
       url: this.$route.path,
       image: image,

--- a/pages/rmrk/collections.vue
+++ b/pages/rmrk/collections.vue
@@ -77,6 +77,7 @@ const components = {
     const title = 'Low minting fees and carbonless NFTs'
     const metaData = {
       title,
+      type: 'profile',
       description: 'Buy Carbonless NFTs on Kusama',
       url: '/rmrk/collections',
       image: `${this.$config.baseUrl}/k_card_collections.png`,

--- a/pages/rmrk/detail/_id.vue
+++ b/pages/rmrk/detail/_id.vue
@@ -17,6 +17,7 @@ import { generateNftImage } from '@/utils/seoImageGenerator'
     const title = this.currentlyViewedItem.title
     const metaData = {
       title,
+      type: 'profile',
       description: this.currentlyViewedItem.description,
       url: this.$route.path,
       image: this.image,

--- a/pages/rmrk/gallery/_id.vue
+++ b/pages/rmrk/gallery/_id.vue
@@ -17,6 +17,7 @@ import { generateNftImage } from '@/utils/seoImageGenerator'
     const title = this.currentlyViewedItem.name
     const metaData = {
       title,
+      type: 'profile',
       description: this.currentlyViewedItem.description,
       url: this.$route.path,
       image: this.image,

--- a/pages/rmrk/gallery/index.vue
+++ b/pages/rmrk/gallery/index.vue
@@ -10,6 +10,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
     const title = 'Low minting fees and carbonless NFTs'
     const metaData = {
       title,
+      type: 'profile',
       description: 'Buy Carbonless NFTs on Kusama',
       url: '/rmrk/gallery',
       image: `${this.$config.baseUrl}/k_card_gallery.png`,

--- a/pages/rmrk/mint.vue
+++ b/pages/rmrk/mint.vue
@@ -14,6 +14,7 @@ import SimpleMint from '@/components/rmrk/Create/SimpleMint.vue'
     const title = 'KodaDot | Low fees and low carbon minting'
     const metaData = {
       title,
+      type: 'article',
       description: 'Create carbonless NFTs with low on-chain fees',
       url: '/mint',
       image: `${this.$config.baseUrl}/k_card_mint.png`,

--- a/pages/rmrk/u/_id.vue
+++ b/pages/rmrk/u/_id.vue
@@ -178,6 +178,7 @@ const eq = (tab: string) => (el: string) => tab === el
     const title = 'NFT Artist Profile on KodaDot'
     const metaData = {
       title,
+      type: 'profile',
       description: this.firstNFTData.description || 'Find more NFTs from this creator',
       url: `/westmint/u/${this.id}`,
       image: this.firstNFTData.image || this.defaultNFTImage,

--- a/pages/series-insight.vue
+++ b/pages/series-insight.vue
@@ -14,6 +14,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
     const title = 'NFT artist rank'
     const metaData = {
       title,
+      type: 'profile',
       description: 'Discover new artists based on ranking',
       url: '/series-insight',
       image: `${this.$config.baseUrl}/k_card_series.png`,

--- a/pages/spotlight.vue
+++ b/pages/spotlight.vue
@@ -15,6 +15,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
     const title = 'NFT artist rank'
     const metaData = {
       title,
+      type: 'profile',
       description: 'Discover new artists based on ranking',
       url: '/spotlight',
       image: `${this.$config.baseUrl}/k_card_spotlight.png`,

--- a/pages/statemine/collections.vue
+++ b/pages/statemine/collections.vue
@@ -14,6 +14,7 @@ import Collections from '@/components/rmrk/Gallery/Collections.vue'
     const title = 'Low minting fees and carbonless NFTs'
     const metaData = {
       title,
+      type: 'profile',
       description: 'Buy Carbonless NFTs on Kusama',
       url: '/rmrk/collections',
       image: `${this.$config.baseUrl}/k_card_collections.png`,

--- a/pages/statemine/create.vue
+++ b/pages/statemine/create.vue
@@ -34,6 +34,7 @@ const components = { Collection, NFT }
     const title = 'KodaDot | Low fees and low carbon minting'
     const metaData = {
       title,
+      type: 'article',
       description: 'Create carbonless NFTs with low on-chain fees',
       url: '/statemine/create',
       image: `${this.$config.baseUrl}/k_card_mint.png`,

--- a/pages/statemine/u/_id.vue
+++ b/pages/statemine/u/_id.vue
@@ -159,6 +159,7 @@ const eq = (tab: string) => (el: string) => tab === el
     const title = 'NFT Artist Profile on KodaDot'
     const metaData = {
       title,
+      type: 'profile',
       description: this.firstNFTData.description || 'Find more NFTs from this creator',
       url: `/statemine/u/${this.id}`,
       image: this.firstNFTData.image || this.defaultNFTImage

--- a/pages/sustainability.vue
+++ b/pages/sustainability.vue
@@ -87,6 +87,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
 @Component<Sustainibility>({
   head() {
     const metaData = {
+      type: 'article',
       description: 'KodaDot: Sustainibility mission',
       url: '/sustainibility',
       image: `${this.$config.baseUrl}/k_card_mint.png`,

--- a/pages/westmint/collections.vue
+++ b/pages/westmint/collections.vue
@@ -14,6 +14,7 @@ import Collections from '@/components/rmrk/Gallery/Collections.vue'
     const title = 'Low minting fees and carbonless NFTs'
     const metaData = {
       title,
+      type: 'profile',
       description: 'Buy Carbonless NFTs on Kusama',
       url: '/rmrk/collections',
       image: `${this.$config.baseUrl}/k_card_collections.png`,

--- a/pages/westmint/create.vue
+++ b/pages/westmint/create.vue
@@ -34,6 +34,7 @@ const components = { Collection, NFT }
     const title = 'KodaDot | Low fees and low carbon minting'
     const metaData = {
       title,
+      type: 'article',
       description: 'Create carbonless NFTs with low on-chain fees',
       url: '/westmint/create',
       image: `${this.$config.baseUrl}/k_card_mint.png`,

--- a/pages/westmint/u/_id.vue
+++ b/pages/westmint/u/_id.vue
@@ -159,6 +159,7 @@ const eq = (tab: string) => (el: string) => tab === el
     const title = 'NFT Artist Profile on KodaDot'
     const metaData = {
       title,
+      type: 'profile',
       description: this.firstNFTData.description || 'Find more NFTs from this creator',
       url: `/westmint/u/${this.id}`,
       image: this.firstNFTData.image || this.defaultNFTImage,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇  _ Do a quick check before the merge.

### PR type
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?
- [x] PR closes #1790
- [x] Let's see if this works. according to https://ogp.me/#type_website fb will only consider image of root page when og:type is same on all the subpages. I therefore changed them to `profile` or `article` which doesn't 100% reflect content but as you can see there aren't that many types available and these seem to be the closest

### Before submitting Pull Request, please make sure:
- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main-nuxt** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional
- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label ?
- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main-nuxt/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation
- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
- [ ] My fix has changed **something** on UI, a screenshot is best to understand changes for others.
