### PR TITLE
Image preview size

### DIFF
--- a/pages/rmrk/collection/_id.vue
+++ b/pages/rmrk/collection/_id.vue
@@ -14,7 +14,7 @@ import CollectionItem from '@/components/rmrk/Gallery/CollectionItem.vue'
   head() {
     const image = `https://og-image-green-seven.vercel.app/${encodeURIComponent(
       this.currentlyViewedCollection.name as string
-    )}.png?price=Items:${this.currentlyViewedCollection.numberOfItems}&image=${
+    )}.jpeg?price=Items:${this.currentlyViewedCollection.numberOfItems}&image=${
       this.currentlyViewedCollection.image as string
     }`
     const title = this.currentlyViewedCollection.name

--- a/utils/seoImageGenerator.ts
+++ b/utils/seoImageGenerator.ts
@@ -6,5 +6,5 @@ export const generateNftImage = (
 ): string => {
   return `https://og-image-green-seven.vercel.app/${encodeURIComponent(
     name
-  )}.png?price=${price}&image=${image}&mime=${mimeType}`
+  )}.jpeg?price=${price}&image=${image}&mime=${mimeType}`
 }


### PR DESCRIPTION
Refactoring of og:image. 
Added image sizes as recommended by FB.
Changed verbal generated image format to jpeg. (smaller file)
Related to issue #1766 