### PR TITLE
#1902 fix preloader height issue

### DIFF
--- a/components/shared/Loader.vue
+++ b/components/shared/Loader.vue
@@ -8,7 +8,7 @@
         <br />
         <div class="pl-4 pr-4">
           <b-icon size="is-large" icon="lightbulb" class="funfact-icon" />
-          <div>{{ randomFunFactQuestion }}</div>
+          <div class="question">{{ randomFunFactQuestion }}</div>
         </div>
       </div>
       <figure>
@@ -86,7 +86,6 @@ export default class Loader extends Vue {
   background: #1a1a1ae0;
   margin: 0rem 1rem;
   width: 450px;
-  height: 400px;
   border: 2px solid $primary-light;
   box-shadow: 13px 14px $primary-dark-transparent;
 }
@@ -105,6 +104,9 @@ export default class Loader extends Vue {
 }
 .funfact-icon {
   color: $primary-light;
+}
+.question {
+  min-height: 70px;
 }
 .loading-text {
   position: relative;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Do a quick check before the merge.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #1902
- [x] added min-height to the fact text, works fine now. However, if the fact is really big like 4-5 lines, the height might increase itself, I have removed the fixed height as the text is dynamic. 

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label ?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI, a screenshot is best to understand changes for others.
