### PR TITLE
:zap: Replacing Pinata with Estuary

### DIFF
--- a/components/rmrk/Create/CreateCollection.vue
+++ b/components/rmrk/Create/CreateCollection.vue
@@ -101,13 +101,13 @@ import SubscribeMixin from '@/utils/mixins/subscribeMixin'
 import RmrkVersionMixin from '@/utils/mixins/rmrkVersionMixin'
 import { Collection, CollectionMetadata } from '../service/scheme'
 import { unSanitizeIpfsUrl } from '@/utils/ipfs'
-import { pinJson, pinFileDirect } from '@/utils/proxy'
 import { decodeAddress } from '@polkadot/keyring'
 import { u8aToHex } from '@polkadot/util'
 import { generateId } from '@/components/rmrk/service/Consolidator'
 import { supportTx, calculateCost } from '@/utils/support'
 import NFTUtils from '../service/NftUtils'
 import TransactionMixin from '@/utils/mixins/txMixin'
+import { pinFileToIPFS, pinJson, PinningKey } from '@/utils/pinning'
 
 const components = {
   Auth: () => import('@/components/shared/Auth.vue'),
@@ -178,17 +178,19 @@ export default class CreateCollection extends mixins(
       throw new ReferenceError('No file found!')
     }
 
+    const pinningKey: PinningKey = await this.$store.dispatch('pinning/fetchPinningKey', this.accountId)
+
     this.meta = {
       ...this.meta,
       attributes: [],
-      external_url: 'https://nft.kodadot.xyz',
+      external_url: 'https://kodadot.xyz',
     }
 
     // TODO: upload image to IPFS
-    const imageHash = await pinFileDirect(this.image)
+    const imageHash = await pinFileToIPFS(this.image, pinningKey.token)
     this.meta.image = unSanitizeIpfsUrl(imageHash)
     // TODO: upload meta to IPFS
-    const metaHash = await pinJson(this.meta)
+    const metaHash = await pinJson(this.meta, imageHash)
 
     return unSanitizeIpfsUrl(metaHash)
   }

--- a/components/rmrk/Create/CreateToken.vue
+++ b/components/rmrk/Create/CreateToken.vue
@@ -380,7 +380,7 @@ export default class CreateToken extends mixins(
         ...nsfwAttribute(this.nft.nsfw),
         ...offsetAttribute(this.hasCarbonOffset),
       ],
-      external_url: 'https://nft.kodadot.xyz',
+      external_url: 'https://kodadot.xyz',
       type: this.nft.file.type,
     }
 

--- a/components/rmrk/Create/CreateToken.vue
+++ b/components/rmrk/Create/CreateToken.vue
@@ -137,8 +137,7 @@ import exec, {
 } from '@/utils/transactionExecutor'
 import { notificationTypes, showNotification } from '@/utils/notification'
 import { NFT, NFTMetadata, MintNFT, getNftId } from '../service/scheme'
-import { pinJson, getKey, revokeKey } from '@/utils/proxy'
-import { unSanitizeIpfsUrl, ipfsToArweave } from '@/utils/ipfs'
+import { unSanitizeIpfsUrl, ipfsToArweave, extractCid } from '@/utils/ipfs'
 import PasswordInput from '@/components/shared/PasswordInput.vue'
 import NFTUtils, { basicUpdateFunction } from '../service/NftUtils'
 import RmrkVersionMixin from '@/utils/mixins/rmrkVersionMixin'
@@ -154,8 +153,8 @@ import {
 } from './mintUtils'
 import { formatBalance } from '@polkadot/util'
 import { DispatchError } from '@polkadot/types/interfaces'
-import { APIKeys, pinFileToIPFS } from '@/utils/pinata'
 import PrefixMixin from '~/utils/mixins/prefixMixin'
+import { PinningKey, pinFileToIPFS, pinJson } from '@/utils/pinning'
 
 interface NFTAndMeta extends NFT {
   meta: NFTMetadata
@@ -385,8 +384,8 @@ export default class CreateToken extends mixins(
     }
 
     try {
-      const keys: APIKeys = await getKey(this.accountId)
-      const fileHash = await pinFileToIPFS(this.nft.file, keys)
+      const { token }: PinningKey = await this.$store.dispatch('pinning/fetchPinningKey', this.accountId)
+      const fileHash = await pinFileToIPFS(this.nft.file, token)
 
       if (!secondaryFileVisible(this.nft.file)) {
         meta.image = unSanitizeIpfsUrl(fileHash)
@@ -394,15 +393,14 @@ export default class CreateToken extends mixins(
       } else {
         meta.animation_url = unSanitizeIpfsUrl(fileHash)
         if (this.nft.secondFile) {
-          const coverImageHash = await pinFileToIPFS(this.nft.secondFile, keys)
+          const coverImageHash = await pinFileToIPFS(this.nft.secondFile, token)
           meta.image = unSanitizeIpfsUrl(coverImageHash)
         }
       }
 
-      revokeKey(keys.pinata_api_key).then(console.log, console.warn)
-
       // TODO: upload meta to IPFS
-      const metaHash = await pinJson(meta)
+      const metaHash = await pinJson(meta, extractCid(meta.image))
+      // const metaHash = await pinJson(meta)
       return unSanitizeIpfsUrl(metaHash)
     } catch (e) {
       throw new ReferenceError((e as Error).message)

--- a/store/pinning.ts
+++ b/store/pinning.ts
@@ -1,0 +1,44 @@
+import { GetterTree, ActionTree, MutationTree, Commit } from 'vuex'
+import { PinningKey, getKey as getPinningKey } from '@/utils/pinning'
+import { emptyObject, isEmpty } from '@/utils/empty'
+
+type PinningState = {
+  pinningKey: PinningKey,
+}
+
+export const state = (): PinningState => ({
+  pinningKey: emptyObject<PinningKey>(),
+})
+
+
+export const getters: GetterTree<PinningState, PinningState> = {
+  getPinningKey: (state) => state.pinningKey?.token,
+  isKeyValid: (state) => !!state.pinningKey?.expiry && new Date(state.pinningKey.expiry).getTime() < Date.now(),
+}
+
+export const mutations: MutationTree<PinningState> = {
+  SET_PINNING_KEY(state, data: PinningKey) {
+    state.pinningKey = Object.assign({}, state.pinningKey, data)
+  },
+}
+
+export const actions: ActionTree<PinningState, PinningState> = {
+  async fetchPinningKey({ commit, state }: { commit: Commit, state: PinningState }, address: string): Promise<PinningKey> {
+    if (isEmpty(state.pinningKey) || isExpired(state.pinningKey)) {
+      const pinningKey = await getPinningKey(address)
+      commit('SET_PINNING_KEY', pinningKey)
+      return pinningKey
+    }
+
+    return state.pinningKey
+  },
+}
+
+const isExpired = (pinningKey: PinningKey) => {
+  if (pinningKey.expiry) {
+    const expiry = new Date(pinningKey.expiry)
+    return expiry.getTime() < Date.now()
+  }
+
+  return false
+}

--- a/utils/empty.ts
+++ b/utils/empty.ts
@@ -5,3 +5,10 @@ export function emptyObject<T>(): T {
 export function emptyArray<T>(): T[] {
   return [] as T[]
 }
+
+export function isEmpty(obj: Record<string, any>) {
+  for (const _ in obj) {
+    return false
+  }
+  return true
+}

--- a/utils/pinning.ts
+++ b/utils/pinning.ts
@@ -23,6 +23,8 @@ export const pinJson = async (object: Record<string, any>, name: string) => {
     console.log('[PINNING] Pin JSON', status)
     if (status < 400) {
       return data.cid
+    } else {
+      throw new Error(`[PINNING] Unable to PIN JSON for reasons ${status} ${data}`)
     }
   } catch (e) {
     console.warn(e)
@@ -60,7 +62,7 @@ export const pinFileToIPFS = async (file: Blob, token: string): Promise<string> 
     if (status < 400) {
       return data.cid
     } else {
-      throw new Error('Unable to PIN for reasons')
+      throw new Error(`[PINNING] Unable to PIN Image for reasons ${status} ${data}`)
     }
   } catch (e) {
     console.warn(e)

--- a/utils/pinning.ts
+++ b/utils/pinning.ts
@@ -19,10 +19,10 @@ type EstuaryApiResponse = {
 
 export const pinJson = async (object: Record<string, any>, name: string) => {
   try {
-    const { status, data } = await api.post(`pinJson/${name}`, object)
-    console.log('[PROXY] Pin JSON', status, data)
+    const { status, data } = await api.post<EstuaryApiResponse>(`pinJson/${name}`, object)
+    console.log('[PINNING] Pin JSON', status)
     if (status < 400) {
-      return data.IpfsHash
+      return data.cid
     }
   } catch (e) {
     console.warn(e)
@@ -34,7 +34,7 @@ export const pinJson = async (object: Record<string, any>, name: string) => {
 export const getKey = async (address: string): Promise<PinningKey> => {
   try {
     const { status, data } = await api.get<PinningKey>(`getKey/${address}`)
-    console.log('[PROXY] Obtain', status)
+    console.log('[PINNING] Obtain', status)
     return data
   } catch (e) {
     console.warn(e)
@@ -56,7 +56,7 @@ export const pinFileToIPFS = async (file: Blob, token: string): Promise<string> 
         'Authorization': `Bearer ${token}`
       },
     })
-    console.log('[ESTUARY] Pin Image', status, data)
+    console.log('[ESTUARY] Pin Image', status)
     if (status < 400) {
       return data.cid
     } else {

--- a/utils/pinning.ts
+++ b/utils/pinning.ts
@@ -1,0 +1,73 @@
+import Axios from 'axios'
+
+export const BASE_URL = 'https://pinning.kodadot.workers.dev/'
+
+const api = Axios.create({
+  baseURL: BASE_URL,
+})
+
+export type PinningKey = {
+	expiry: string,
+	token: string,
+}
+
+type EstuaryApiResponse = {
+  cid: string,
+  estuaryId: number
+  providers: string[]
+}
+
+export const pinJson = async (object: Record<string, any>, name: string) => {
+  try {
+    const { status, data } = await api.post(`pinJson/${name}`, object)
+    console.log('[PROXY] Pin JSON', status, data)
+    if (status < 400) {
+      return data.IpfsHash
+    }
+  } catch (e) {
+    console.warn(e)
+    throw e
+  }
+}
+
+
+export const getKey = async (address: string): Promise<PinningKey> => {
+  try {
+    const { status, data } = await api.get<PinningKey>(`getKey/${address}`)
+    console.log('[PROXY] Obtain', status)
+    return data
+  } catch (e) {
+    console.warn(e)
+    throw e
+  }
+}
+
+// TODO: implement revokeKey
+
+
+export const pinFileToIPFS = async (file: Blob, token: string): Promise<string> => {
+  const formData = new FormData()
+  formData.append('data', file)
+
+  try {
+    const { status, data } = await Axios.post<EstuaryApiResponse>('https://shuttle-4.estuary.tech/content/add', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data;',
+        'Authorization': `Bearer ${token}`
+      },
+    })
+    console.log('[ESTUARY] Pin Image', status, data)
+    if (status < 400) {
+      return data.cid
+    } else {
+      throw new Error('Unable to PIN for reasons')
+    }
+  } catch (e) {
+    console.warn(e)
+    throw e
+  }
+}
+
+
+export default api
+// QmYt2FydonvVMsEqe2q3hvm38WDq21xM8Z5ZSHZw19PwjF;


### PR DESCRIPTION
- :zap: added utils for pinning using worker
- store
- :mute: updated logs for pinning
- :zap: CreateToken is now using estuary
- :mute: more meaningful logst for pinning service

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Do a quick check before the merge.

### PR type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring

### What's new?

- [x] Closes #963
- [x] Closes #1889
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label ?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI, a screenshot is best to understand changes for others.
