### PR TITLE
I spent whole day trying to find an issue

### DIFF
--- a/components/rmrk/Gallery/Gallery.vue
+++ b/components/rmrk/Gallery/Gallery.vue
@@ -176,11 +176,14 @@ export default class Gallery extends mixins(PrefixMixin) {
 
     const metadataList: string[] = this.nfts.map(
       ({ metadata, collection }: NFTWithCollectionMeta) =>
-        metadata || collection.metadata
+        metadata || collection.metadata || 'x'
     )
-    const storedMetadata = await getMany(metadataList).catch(() => metadataList)
+    const storedMetadata = await getMany(metadataList)
 
     storedMetadata.forEach(async (m, i) => {
+      if (!metadataList[i]) {
+        return
+      }
       if (!m) {
         try {
           const meta = await fetchNFTMetadata(

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -88,7 +88,9 @@ export default {
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [
+    { src: '~/plugins/vuex-persist', mode: 'client' },
     { src: '~/plugins/polkadot', mode: 'client' },
+    { src: '~/plugins/endpoint', mode: 'client' },
     { src: '~/plugins/seoMetaGenerator', mode: 'client' },
     '~/plugins/filters',
     '~/plugins/globalVariables',
@@ -96,7 +98,6 @@ export default {
     '~/plugins/vueAudioVisual',
     '~/plugins/vueClipboard',
     '~/plugins/vueSocialSharing',
-    { src: '~/plugins/vuex-persist', mode: 'client' },
     '~/plugins/vueTippy',
     '~/plugins/vueGtag',
   ],

--- a/plugins/endpoint.ts
+++ b/plugins/endpoint.ts
@@ -1,0 +1,9 @@
+import '@polkadot/api-augment'
+import Connector from '@vue-polkadot/vue-api'
+
+export default ({ store }) => {
+  const endpoint = store.state.setting.apiUrl
+  const { getInstance: Api } = Connector
+  console.log('[API PLUGIN]', endpoint)
+  Api().connect(endpoint)
+}

--- a/plugins/polkadot.ts
+++ b/plugins/polkadot.ts
@@ -1,4 +1,3 @@
-import '@polkadot/api-augment'
 import keyring from '@polkadot/ui-keyring'
 import { cryptoWaitReady } from '@polkadot/util-crypto'
 import correctFormat from '~/utils/ss58Format'

--- a/plugins/vuex-persist.ts
+++ b/plugins/vuex-persist.ts
@@ -12,4 +12,8 @@ export default ({ store }): void => {
     key: 'preferences',
     storage: window.localStorage,
   }).plugin(store)
+  new VuexPersistence({
+    key: 'setting',
+    storage: window.sessionStorage,
+  }).plugin(store)
 }

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,19 +1,14 @@
 import type { ApiPromise } from '@polkadot/api'
-import VuexPersist from 'vuex-persist'
 import Connector from '@vue-polkadot/vue-api'
 import correctFormat from '@/utils/ss58Format'
+import { Store } from 'vuex'
 
-const vuexLocalStorage = new VuexPersist({
-  key: 'vuex',
-  storage: window.sessionStorage,
-})
-
-interface ChangeUrlAction {
+type VuexAction = {
   type: string
   payload: string
 }
 
-const apiPlugin = (store: any): void => {
+const apiPlugin = (store: Store<any>): void => {
   const { getInstance: Api } = Connector
 
   Api().on('connect', async (api: ApiPromise) => {
@@ -46,11 +41,10 @@ const apiPlugin = (store: any): void => {
   })
 }
 
-const myPlugin = (store: any): void => {
+const myPlugin = (store: Store<null>): void => {
   const { getInstance: Api } = Connector
-  Api().connect(store.state.setting.apiUrl)
 
-  store.subscribeAction(({ type, payload }: ChangeUrlAction, _: any) => {
+  store.subscribeAction(({ type, payload }: VuexAction, _: any) => {
     if (type === 'setApiUrl' && payload) {
       store.commit('setLoading', true)
       Api().connect(payload)

--- a/store/index.ts
+++ b/store/index.ts
@@ -79,4 +79,4 @@ export const actions = {}
 
 export const getters = {}
 
-export const plugins = [vuexLocalStorage.plugin, apiPlugin, myPlugin]
+export const plugins = [apiPlugin, myPlugin]

--- a/utils/api/general.ts
+++ b/utils/api/general.ts
@@ -6,9 +6,13 @@ export type ApiCallbackFunction = (api: ApiPromise) => any
 export default function onApiConnect(cb: ApiCallbackFunction): void {
   const { getInstance: Api } = Connector
   if (Api().api) {
-    console.log('API is already connected')
+    console.log('[API] already connected')
     cb(Api().api)
+    return
   }
 
-  Api().on('connect', cb)
+  Api().on('connect', (api: ApiPromise) => {
+    console.log('[API] has been connected')
+    api.isReady.then(cb)
+  })
 }


### PR DESCRIPTION
## What's the hack

We had vuexPersist in the old spa which was resolved incorrectly so it connected by default to Kusama but it showed that settings.apiUrl is statemine. [YOLO]


- Close #2058
- :zap: api will await for readyness
- :bug: forgot to remove vuex plugin from store
- :clown_face: Workaround for unique nfts without metadata

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Do a quick check before the merge.

### PR type

- [x] Bugfix
- [x] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #2058

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

