### PR TITLE
#2053 Unify collection detail and collections view with $primary

### DIFF
--- a/components/rmrk/Gallery/Search/SearchBarCollection.vue
+++ b/components/rmrk/Gallery/Search/SearchBarCollection.vue
@@ -8,7 +8,8 @@
           type="search"
           v-model="searchQuery"
           icon="search"
-          expanded>
+          expanded
+          class="input-search">
         </b-input>
       </b-field>
       <BasicSwitch
@@ -144,11 +145,18 @@ export default class SearchBar extends Vue {
 </style>
 
 <style lang="scss">
+@import '@/styles/variables';
+
 .field-group-container {
   .is-grouped-multiline {
     flex-wrap: initial !important;
     @media screen and (max-width: 768px) {
       flex-wrap: wrap !important;
+    }
+  }
+  .input-search {
+    input {
+      border: 1px solid $primary!important;
     }
   }
 }

--- a/components/rmrk/Gallery/Search/SearchSortDropdown.vue
+++ b/components/rmrk/Gallery/Search/SearchSortDropdown.vue
@@ -33,8 +33,13 @@ export default class SearchSortDropdown extends Vue {
 }
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
+@import '@/styles/variables';
+
 .select-dropdown {
+  select {
+    border: 1px solid $primary!important;
+  }
   @media screen and (max-width: 1216px) and (min-width: 768px) {
     width: 200px;
   }

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -100,8 +100,6 @@ $box-shadow: none;
 $tabs-link-hover-color: $primary;
 $tabs-boxed-link-focus-border-bottom-color: $primary;
 $tabs-boxed-link-focus-background-color: lightpink;
-$tabs-link-active-border-bottom-color: $white;
-$tabs-border-bottom-color	: $primary;
 // $tabs-boxed-link-focus-active-background-color: $primary;
 
 //  these somehow doesn't work for profile, idk why, maybe fix whenever you spot this

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -100,6 +100,8 @@ $box-shadow: none;
 $tabs-link-hover-color: $primary;
 $tabs-boxed-link-focus-border-bottom-color: $primary;
 $tabs-boxed-link-focus-background-color: lightpink;
+$tabs-link-active-border-bottom-color: $white;
+$tabs-border-bottom-color	: $primary;
 // $tabs-boxed-link-focus-active-background-color: $primary;
 
 //  these somehow doesn't work for profile, idk why, maybe fix whenever you spot this


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Do a quick check before the merge.

### PR type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #2053
- [x] Since it is common, this also got applied to artist profile

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label ?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI, a screenshot is best to understand changes for others.
<img width="1428" alt="Screenshot 2022-01-26 at 2 56 56 PM" src="https://user-images.githubusercontent.com/39299315/151137376-67f71207-a11b-4c09-bc2e-aeb3c25eba65.png">
<img width="1406" alt="Screenshot 2022-01-26 at 2 57 09 PM" src="https://user-images.githubusercontent.com/39299315/151137410-3836cc9e-b6e0-4fb7-a207-18cdda0df435.png">

