### PR TITLE
Show transaction fees denomination in KSM and dollars without clicking

### DIFF
--- a/components/rmrk/Create/SimpleMint.vue
+++ b/components/rmrk/Create/SimpleMint.vue
@@ -72,7 +72,11 @@
             v-model="rmrkMint.tags"
             placeholder="Get discovered easier through tags" />
 
-          <BalanceInput @input="updateMeta" label="Price" expanded />
+          <BalanceInput
+            :step="0.1"
+            @input="updateMeta"
+            label="Price"
+            expanded />
           <b-message
             v-if="price"
             icon="exclamation-triangle"
@@ -124,23 +128,6 @@
               <BasicSwitch v-model="postfix" label="mint.expert.postfix" />
             </CollapseWrapper>
           </b-field>
-          <b-field>
-            <b-button
-              type="is-text"
-              icon-left="calculator"
-              @click="estimateTx"
-              :disabled="disabled"
-              :loading="isLoading"
-              outlined>
-              <template v-if="!estimated">
-                {{ $t('mint.estimate') }}
-              </template>
-              <template v-else>
-                {{ $t('mint.estimated') }}
-                <Money :value="estimated" inline />
-              </template>
-            </b-button>
-          </b-field>
           <BasicSwitch v-model="nsfw" label="mint.nfsw" />
           <b-field>
             <b-switch v-model="hasToS" :rounded="false">
@@ -158,6 +145,14 @@
               {{ $t('mint.submit') }}
             </b-button>
           </b-field>
+          <b-field v-if="price">
+            <template>
+              <b-icon icon="calculator" />
+              <span class="pr-2">{{ $t('mint.estimated') }}</span>
+              <Money :value="estimated" inline />
+              <span class="pl-2"> ({{ getUsdFromKsm().toFixed(2) }} USD) </span>
+            </template>
+          </b-field>
         </div>
       </section>
     </div>
@@ -165,7 +160,7 @@
 </template>
 
 <script lang="ts">
-import { Component, mixins } from 'nuxt-property-decorator'
+import { Component, mixins, Watch } from 'nuxt-property-decorator'
 import { MediaType } from '../types'
 import { emptyObject } from '@/utils/empty'
 import Support from '@/components/shared/Support.vue'
@@ -253,6 +248,10 @@ export default class SimpleMint extends mixins(
 
   protected updateMeta(value: number): void {
     this.price = value
+
+    if (this.canCalculateTransactionFees) {
+      this.estimateTx()
+    }
   }
 
   get fileType(): MediaType {
@@ -272,6 +271,11 @@ export default class SimpleMint extends mixins(
 
   get rmrkId(): string {
     return generateId(this.accountId, this.rmrkMint?.symbol || '')
+  }
+
+  get canCalculateTransactionFees(): boolean {
+    const { name, symbol, max } = this.rmrkMint
+    return !!(this.price && name && symbol && max)
   }
 
   get disabled(): boolean {
@@ -300,7 +304,6 @@ export default class SimpleMint extends mixins(
   }
 
   protected async estimateTx() {
-    this.isLoading = true
     const { accountId, version } = this
     const { api } = Connector.getInstance()
 
@@ -321,8 +324,6 @@ export default class SimpleMint extends mixins(
         ]
 
     this.estimated = await estimate(this.accountId, cb, [args])
-
-    this.isLoading = false
   }
 
   get enoughTokens(): boolean {
@@ -721,6 +722,23 @@ export default class SimpleMint extends mixins(
         query: { message: 'congrats' },
       })
     setTimeout(go, 2000)
+  }
+
+  protected getUsdFromKsm() {
+    let KSMVal = formatBalance(this.estimated, {
+      decimals: this.decimals,
+      withUnit: false,
+      forceUnit: '-',
+    })
+
+    return this.$store.getters['fiat/getCurrentKSMValue'] * Number(KSMVal)
+  }
+
+  @Watch('rmrkMint', { deep: true })
+  rmrkMintObjectChanged(): void {
+    if (this.canCalculateTransactionFees) {
+      this.estimateTx()
+    }
   }
 }
 </script>

--- a/components/shared/BalanceInput.vue
+++ b/components/shared/BalanceInput.vue
@@ -4,7 +4,7 @@
       <b-input
         v-model="inputValue"
         type="number"
-        step="0.001"
+        :step="step"
         min="0"
         :expanded="expanded"
         @input="handleInput" />
@@ -35,6 +35,7 @@ export default class BalanceInput extends mixins(ChainMixin) {
   @Prop({ default: 'balance' }) public label!: string
   @Prop({ default: true }) public calculate!: boolean
   @Prop(Boolean) public expanded!: boolean
+  @Prop({ default: 0.001 }) public step!: number
   protected units: Unit[] = defaultUnits
   private selectedUnit = 1
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Do a quick check before the merge.

### PR type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #2022 
- [x] show transaction fees denomination in KSM and dollars without clicking
- [x] add 0.1 steps into the price
- [x] move transaction fees label under button [click to create nfts]

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label ?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=CeBWgisygADqqxGk7ju8aMNEKz1K2WkxMKC3G8HsMnm119n

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI, a screenshot is best to understand changes for others.
