### PR TITLE
feat: use simple text instead of b-message warning

### DIFF
--- a/components/rmrk/Create/SimpleMint.vue
+++ b/components/rmrk/Create/SimpleMint.vue
@@ -77,19 +77,12 @@
             @input="updateMeta"
             label="Price"
             expanded />
-          <b-message
-            v-if="price"
-            icon="exclamation-triangle"
-            class="mt-3"
-            title="Additional transaction"
-            type="is-primary"
-            has-icon
-            aria-close-label="Close message">
-            <span class="has-text-primary"
-              >Setting the price now requires making an additional
-              transaction.</span
-            >
-          </b-message>
+          <div class="content mt-3">
+            <p>
+              Hint: Setting the price now requires making an additional
+              transaction.
+            </p>
+          </div>
 
           <b-field>
             <PasswordInput v-model="password" :account="accountId" />


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

<img width="678" alt="Screenshot 2022-01-30 at 15 19 36" src="https://user-images.githubusercontent.com/17953978/151703697-68343e20-5e38-4fa4-b126-4414c878d9bb.png">

### What's new?

- [x] PR closes #2115
- [x] use simple text instead of anxiety-inducing warning message 🥵 

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
