### PR TITLE
#2156 Remove KSM from Spotlight & Series insight

### DIFF
--- a/components/series/SeriesTable.vue
+++ b/components/series/SeriesTable.vue
@@ -84,19 +84,6 @@
 
       <b-table-column
         v-slot="props"
-        field="volume"
-        :label="$t('series.volume')"
-        sortable
-        numeric
-        cell-class="is-vcentered">
-        <template v-if="!isLoading">
-          <Money :value="props.row.volume" inline />
-        </template>
-        <b-skeleton :active="isLoading" />
-      </b-table-column>
-
-      <b-table-column
-        v-slot="props"
         field="dailyVolume"
         label="24h %"
         numeric
@@ -172,19 +159,6 @@
               )
             }}
           </div>
-        </template>
-        <b-skeleton :active="isLoading" />
-      </b-table-column>
-
-      <b-table-column
-        v-slot="props"
-        field="floor_price"
-        :label="$t('series.floorprice')"
-        numeric
-        cell-class="is-vcentered"
-        sortable>
-        <template v-if="!isLoading">
-          <Money :value="props.row.floorPrice" inline />
         </template>
         <b-skeleton :active="isLoading" />
       </b-table-column>

--- a/components/spotlight/SpotlightTable.vue
+++ b/components/spotlight/SpotlightTable.vue
@@ -101,13 +101,6 @@
         <b-skeleton :active="isLoading"> </b-skeleton>
       </b-table-column>
 
-      <b-table-column field="volume" label="Volume" v-slot="props" sortable>
-        <template v-if="!isLoading"
-          ><Money :value="props.row.volume" inline
-        /></template>
-        <b-skeleton :active="isLoading"> </b-skeleton>
-      </b-table-column>
-
       <b-table-column field="rank" :label="$t('spotlight.score')" numeric>
         <template v-slot:header="{ column }">
           <b-tooltip label="sold * (unique / total)" append-to-body dashed>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #2156
- [ ] 
Cleanup from series table:
Volume 
Floor Price

Cleanup from spotlight table:
Volume



### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="1440" alt="Screenshot 2022-02-01 at 8 23 52 PM" src="https://user-images.githubusercontent.com/39299315/151991724-ca9966d7-6c43-4d5b-b939-fd090e93d066.png">
<img width="1440" alt="Screenshot 2022-02-01 at 8 23 56 PM" src="https://user-images.githubusercontent.com/39299315/151991763-c2890c25-11e1-4c7e-b1f8-efb0afc80fa9.png">
