### PR TITLE
#2094-rework-actions-B

### DIFF
--- a/components/rmrk/Gallery/GalleryItem.vue
+++ b/components/rmrk/Gallery/GalleryItem.vue
@@ -116,7 +116,7 @@
           <div
             class="column is-flex is-flex-direction-column is-justify-content-space-between">
             <div class="card bordered mb-4" aria-id="contentIdForA11y3">
-              <div class="card-content money-cursor">
+              <div :class="{ 'money-cursor': hasPrice }" class="card-content">
                 <template v-if="hasPrice">
                   <div class="label">
                     {{ $t('price') }}
@@ -151,11 +151,14 @@
                         ]"
                         @change="handleAction" />
                     </IndexerGuard>
-                    <Auth />
+                    <Auth v-if="hasPrice" />
+                    <Sharing
+                      v-if="!hasPrice"
+                      class="pb-4 is-flex is-justify-content-center" />
                   </p>
                 </div>
 
-                <Sharing class="mb-4" />
+                <Sharing v-if="hasPrice" class="mb-4" />
               </div>
             </div>
           </div>
@@ -225,8 +228,6 @@ import PrefixMixin from '~/utils/mixins/prefixMixin'
 })
 export default class GalleryItem extends mixins(PrefixMixin) {
   private id = ''
-  // private accountId: string = '';
-  private passsword = ''
   private nft: NFT = emptyObject<NFT>()
   private nftsFromSameCollection: NFT[] = []
   private imageVisible = true
@@ -563,23 +564,23 @@ hr.comment-divider {
   }
 
   .message-box {
-    background: $dark!important;
+    background: $dark !important;
     border: 2px solid $primary;
     box-shadow: $dropdown-content-shadow;
     .subtitle-text {
       color: $lightpink;
     }
     section {
-      border: none!important;
+      border: none !important;
     }
   }
 }
 </style>
 
 <style lang="scss">
-  .message-box {
-     .message-body {
-      border: none;
-   }
+.message-box {
+  .message-body {
+    border: none;
   }
+}
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2094 
- [x] second attempt at reverted https://github.com/kodadot/nft-gallery/pull/2105 

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases

### Had issue bounty label?

- [x] Fill up your KSM address: already paid, thank you

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
A) -> bought NFT view
![image](https://user-images.githubusercontent.com/73316633/152027559-5ee62a86-d543-408d-b3d9-ab4f38937e7f.png)
B) -> listed NFT view
![image](https://user-images.githubusercontent.com/73316633/152027695-a4909737-5845-4024-ac70-fd9f98946925.png)
C -> unlisted NFT view
![image](https://user-images.githubusercontent.com/73316633/152027781-31865c7b-3f3b-4206-870a-9adaf8a1eb3f.png)


