### PR TITLE
⚒️  video gallery wrapper

### DIFF
--- a/components/rmrk/Media/VideoMedia.vue
+++ b/components/rmrk/Media/VideoMedia.vue
@@ -1,18 +1,23 @@
 <template>
-  <video
-    :controls="controls"
-    playsinline
-    loop
-    autoplay
-    :muted="preview"
-    :src="src"
-    :poster="poster"
-    :type="mimeType"
-    controlslist="nodownload" />
+  <div class="video__wrapper">
+    <div class="video__overflow"></div>
+    <video
+      class="video__component"
+      :controls="controls"
+      playsinline
+      loop
+      autoplay
+      :muted="preview"
+      :src="src"
+      :poster="poster"
+      :type="mimeType"
+      controlslist="nodownload" />
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'nuxt-property-decorator'
+
 @Component({})
 export default class VideoMedia extends Vue {
   @Prop(String) public src!: string
@@ -25,3 +30,36 @@ export default class VideoMedia extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.video {
+  &__wrapper {
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    min-width: 0;
+    position: relative;
+    box-sizing: border-box;
+  }
+
+  &__overflow {
+    height: 0;
+    width: 100%;
+    padding-bottom: 100%;
+  }
+
+  &__component {
+    inset: 0;
+    min-width: 0;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    position: absolute;
+    box-sizing: border-box;
+    -moz-box-align: center;
+    -moz-box-pack: center;
+    justify-content: center;
+  }
+}
+</style>


### PR DESCRIPTION
We'll need to verify how are audio and object displayed in `/galley` 

### PR type

- [x] Bugfix

### What's new?

- [x] PR closes #2184 
- [x] same stuff I've added on ModelMedia, it could be interesting to do a refactoring

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=DVYy1qnocE8t6ZvUfPx3rEjG829khNRXx3YrCGVHHj19Lcb)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot
![Screenshot 2022-02-03 at 08-35-13 Low minting fees and carbonless NFTs](https://user-images.githubusercontent.com/9987732/152300605-210228a3-dbf6-4fd9-9f43-1e5eeef8c942.png)

