### PR TITLE
fix: block navigation if certain elements are being focused

### DIFF
--- a/components/rmrk/Gallery/Item/Navigation.vue
+++ b/components/rmrk/Gallery/Item/Navigation.vue
@@ -55,6 +55,16 @@ export default class Navigation extends Vue {
   }
 
   public handleKeyEvent(event) {
+    // block navigation to next or prev NFT if any of the following elements is being focused
+    const activeElement = document.activeElement
+    const inputs = ['input', 'select', 'button', 'textarea']
+    if (
+      activeElement &&
+      inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1
+    ) {
+      return
+    }
+
     if (event.key === 'ArrowLeft') {
       return this.gotoNextItem(true)
     }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

https://user-images.githubusercontent.com/17953978/152405384-f06ad148-8dcd-4b57-8684-1412d2a9ef99.mov

### What's new?

- [x] PR closes #2196
- [x] Check if currently focused element is one of the following `['input', 'select', 'button', 'textarea']` and block NFT navigation if that is the case

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/gallery/11034169-7cf9daa38281a57331-BSS-LB_SPACESHIP_329-0000000000000329>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
