### PR TITLE
fix: if user is only collector set tab to collected

### DIFF
--- a/components/rmrk/Profile/ProfileDetail.vue
+++ b/components/rmrk/Profile/ProfileDetail.vue
@@ -150,7 +150,7 @@
 </template>
 
 <script lang="ts">
-import { Component, mixins, Vue, Watch } from 'nuxt-property-decorator'
+import { Component, mixins, Watch } from 'nuxt-property-decorator'
 import { notificationTypes, showNotification } from '@/utils/notification'
 import { sanitizeIpfsUrl, fetchNFTMetadata } from '@/components/rmrk/utils'
 import { CollectionWithMeta, Pack } from '@/components/rmrk/service/scheme'
@@ -177,8 +177,6 @@ const components = {
   ProfileLink: () => import('@/components/rmrk/Profile/ProfileLink.vue'),
   Layout: () => import('@/components/rmrk/Gallery/Layout.vue'),
 }
-
-const eq = (tab: string) => (el: string) => tab === el
 
 @Component<Profile>({
   name: 'Profile',
@@ -337,6 +335,12 @@ export default class Profile extends mixins(PrefixMixin) {
     if (data) {
       this.totalCollections = data.collectionEntities.totalCount
       this.collections = data.collectionEntities.nodes
+    }
+    // in case user is only a collector, set tab to collected
+    if (this.totalCollections === 0) {
+      this.$router
+        .replace({ query: { tab: 'collected' } })
+        .catch(console.warn /*Navigation Duplicate err fix later */)
     }
   }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2187
- [x]  if user is only collector (totalCollections has to be 0) set tab to collected

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/u/H7Zt3JeRnPH7AFpJE8UuXo3Ni5aHxCfRAjes4AQe7QfDjDN>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
