### PR TITLE
🤖 remove cypress tests from test workflow

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/(?!@kodadot1|@polkadot|@babel/runtime/helpers/esm/)',
   ],
+  testPathIgnorePatterns: ['<rootDir>/tests/cypress/'],
   moduleFileExtensions: [
     'ts', // if using TypeScript
     'js',


### PR DESCRIPTION
Fixed test workflow with `testPathIgnorePatterns` so Jest won't try and run the Cypress spec files.

### PR type

- [x] Bugfix

