### PR TITLE
fix: set sorting to desc by default on spotlight and series

### DIFF
--- a/components/series/SeriesTable.vue
+++ b/components/series/SeriesTable.vue
@@ -44,6 +44,7 @@
     <b-table
       :data="data"
       :default-sort="[sortBy.field, sortBy.value]"
+      default-sort-direction="desc"
       backend-sorting
       hoverable
       @sort="onSort">

--- a/components/spotlight/SpotlightTable.vue
+++ b/components/spotlight/SpotlightTable.vue
@@ -5,6 +5,7 @@
       :data="toggleUsersWithIdentity ? usersWithIdentity : data"
       :current-page="currentPage ? currentPage : 1"
       :default-sort="[sortBy.field, sortBy.value]"
+      default-sort-direction="desc"
       hoverable
       detailed
       paginated
@@ -138,7 +139,7 @@
 <script lang="ts">
 import { Component, Prop, mixins } from 'nuxt-property-decorator'
 import { Column, Row } from './types'
-import { columns, nftFn } from './utils'
+import { columns } from './utils'
 import collectionSpotlightList from '@/queries/rmrk/subsquid/collectionSpotlightList.graphql'
 
 import TransactionMixin from '@/utils/mixins/txMixin'


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

https://user-images.githubusercontent.com/17953978/153388974-56932d2f-3c03-4f87-9a39-057f3743ac35.mov

### What's new?

- [x] PR closes #1807
- [x] table sorting now descending by default

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
