### PR TITLE
fix: focus input element after keyevent

### DIFF
--- a/components/rmrk/Gallery/AvailableActions.vue
+++ b/components/rmrk/Gallery/AvailableActions.vue
@@ -23,11 +23,16 @@
         {{ action === 'BUY' && replaceBuyNowWithYolo ? 'YOLO' : action }}
       </b-button>
     </div>
-    <component
-      :is="showMeta"
-      v-if="showMeta"
+    <BalanceInput
+      v-show="selectedAction === 'LIST'"
+      ref="balanceInput"
       class="mb-4"
       empty-on-error
+      @input="updateMeta" />
+    <AddressInput
+      v-show="selectedAction === 'SEND'"
+      ref="addressInput"
+      class="mb-4"
       @input="updateMeta" />
     <b-button
       v-if="showSubmit"
@@ -40,7 +45,7 @@
 </template>
 
 <script lang="ts">
-import { Component, mixins, Prop, Watch } from 'nuxt-property-decorator'
+import { Component, mixins, Prop, Ref, Watch } from 'nuxt-property-decorator'
 import Connector from '@kodadot1/sub-api'
 import exec, { execResultValue, txCb } from '@/utils/transactionExecutor'
 import { notificationTypes, showNotification } from '@/utils/notification'
@@ -61,11 +66,6 @@ type IdentityFields = Record<string, string>
 
 const ownerActions = ['SEND', 'CONSUME', 'LIST']
 const buyActions = ['BUY']
-
-const needMeta: Record<string, string> = {
-  SEND: 'AddressInput',
-  LIST: 'BalanceInput',
-}
 
 type DescriptionTuple = [string, string] | [string]
 const iconResolver: Record<string, DescriptionTuple> = {
@@ -103,6 +103,9 @@ export default class AvailableActions extends mixins(
   private identity: IdentityFields = emptyObject<IdentityFields>()
   private ownerIdentity: IdentityFields = emptyObject<IdentityFields>()
 
+  @Ref('balanceInput') readonly balanceInput
+  @Ref('addressInput') readonly addressInput
+
   public created() {
     this.initKeyboardEventHandler({
       a: this.bindActionEvents,
@@ -116,6 +119,8 @@ export default class AvailableActions extends mixins(
       c: 'CONSUME',
       l: 'LIST',
     }
+
+    event.preventDefault()
 
     this.handleAction(mappings[event.key])
   }
@@ -139,7 +144,7 @@ export default class AvailableActions extends mixins(
   }
 
   get showMeta() {
-    return needMeta[this.selectedAction]
+    return ['SEND', 'LIST'].includes(this.selectedAction)
   }
 
   get replaceBuyNowWithYolo(): boolean {
@@ -161,8 +166,18 @@ export default class AvailableActions extends mixins(
   protected handleAction(action: Action) {
     if (shouldUpdate(action, this.selectedAction)) {
       this.selectedAction = action
-      if (action === 'BUY') {
-        this.submit()
+      switch (action) {
+        case 'BUY':
+          this.submit()
+          break
+        case 'LIST':
+          this.balanceInput?.focusInput()
+          break
+        case 'SEND':
+          this.addressInput?.focusInput()
+          break
+        default:
+          break
       }
     } else {
       this.selectedAction = ''

--- a/components/shared/AddressInput.vue
+++ b/components/shared/AddressInput.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-field :type="type" :message="err" :label="$t(label)">
-      <b-input v-model="inputValue" @input="handleInput" />
+      <b-input ref="address" v-model="inputValue" @input="handleInput" />
     </b-field>
   </div>
 </template>
@@ -10,7 +10,7 @@
 import correctFormat from '@/utils/ss58Format'
 import { checkAddress, isAddress } from '@polkadot/util-crypto'
 import { Debounce } from 'vue-debounce-decorator'
-import { Component, Emit, Prop, Vue } from 'nuxt-property-decorator'
+import { Component, Emit, Prop, Ref, Vue } from 'nuxt-property-decorator'
 
 @Component({})
 export default class AddressInput extends Vue {
@@ -19,6 +19,8 @@ export default class AddressInput extends Vue {
   @Prop({ type: String, default: 'insert address' }) public label!: string
   @Prop(Boolean) public emptyOnError!: boolean
   @Prop({ type: Boolean, default: true }) public strict!: boolean
+
+  @Ref('address') readonly address
 
   get inputValue(): string {
     return this.value
@@ -30,6 +32,10 @@ export default class AddressInput extends Vue {
 
   get type(): string {
     return this.err ? 'is-danger' : ''
+  }
+
+  public focusInput(): void {
+    this.address?.focus()
   }
 
   @Debounce(500)

--- a/components/shared/BalanceInput.vue
+++ b/components/shared/BalanceInput.vue
@@ -2,6 +2,7 @@
   <div class="arguments-wrapper">
     <b-field :label="$t(label)" class="balance">
       <b-input
+        ref="balance"
         v-model="inputValue"
         type="number"
         :step="step"
@@ -23,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Emit, mixins } from 'nuxt-property-decorator'
+import { Component, Prop, Emit, Ref, mixins } from 'nuxt-property-decorator'
 import { units as defaultUnits } from '@/params/constants'
 import { Unit } from '@/params/types'
 import { Debounce } from 'vue-debounce-decorator'
@@ -39,12 +40,18 @@ export default class BalanceInput extends mixins(ChainMixin) {
   protected units: Unit[] = defaultUnits
   private selectedUnit = 1
 
+  @Ref('balance') readonly balance
+
   get inputValue(): number {
     return this.value
   }
 
   set inputValue(value: number) {
     this.handleInput(value)
+  }
+
+  public focusInput(): void {
+    this.balance?.focus()
   }
 
   formatSelectedValue(value: number): number {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

https://user-images.githubusercontent.com/17953978/153437783-4f39198b-7d72-4f79-bca5-6ebe0ccbd4c7.mov


### What's new?

- [x] PR closes #2317
- [x] WHY I DID WHAT I DID:

1.  use Refs to access child methods
2. Refs cant be used with dynamic components -> since its only 2 cases just write them plain in template -> **better readability and code comprehension anyways** (not the case if it would be 3+ components i think
3. Refs can't be used with v-if (DOM elements dont exist on component init) -> use v-show instead
4. also prevent second key from shortcut from being handled (as it would fill the focused element with 2nd key stroke from shortcut)

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
