### PR TITLE
⚒️ increase nfts displayed in collection

### DIFF
--- a/components/rmrk/Gallery/CollectionItem.vue
+++ b/components/rmrk/Gallery/CollectionItem.vue
@@ -153,7 +153,7 @@ export default class CollectionItem extends mixins(ChainMixin, PrefixMixin) {
   }
   public activeTab = 'collection'
   private currentValue = 1
-  private first = 15
+  private first = 16
   protected total = 0
   protected totalListed = 0
   protected stats: NFT[] = []


### PR DESCRIPTION
I find it annoying to have an empty box

### PR type

- [x] Bugfix

### What's new?

- [x] Increase number of nfts displayed in `/collection/:id` by 1

### Screenshot (same for 2 column)

#### before
![Screenshot 2022-02-14 at 15-21-13 Kitty Paradise](https://user-images.githubusercontent.com/9987732/153881834-7eb7497a-e587-47a8-838e-f601621b094c.png)

#### after
![Screenshot 2022-02-14 at 15-21-01 Kitty Paradise](https://user-images.githubusercontent.com/9987732/153881853-b7ea637f-5a8b-42f8-b6c6-f3c8dd90dfca.png)

