### PR TITLE
single subscribe

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "engines": {
-    "node": "16.13.2"
+    "node": ">= 16.13.2"
   },
   "prettier": {
     "semi": false,

--- a/utils/mixins/singleSubscribeMixin.ts
+++ b/utils/mixins/singleSubscribeMixin.ts
@@ -1,0 +1,28 @@
+import { Component, Vue } from 'nuxt-property-decorator'
+// declare type UnsubscribePromise = Promise<Unsubscribe>;
+declare type Unsubscribe = () => void
+
+/*
+ * refer to https://stackoverflow.com/questions/51873087/unable-to-use-mixins-in-vue-with-typescript
+ * usage import Component, { mixins } from 'vue-class-component';
+ * class ExtendedClass extends mixins(SubscribeMixin) {
+ */
+@Component
+export default class SingleSubscribeMixin extends Vue {
+  private sub: Unsubscribe = () => void 0
+
+  public async singleSubscribe(fn: any, args: any[], callback: any) {
+    this.unsubscribe() // unsubscribe previous subscription
+    fn(...args, callback)
+      .then((sub: Unsubscribe) => (this.sub = sub))
+      .catch(console.error)
+  }
+
+  private unsubscribe(): void {
+    this.sub()
+  }
+
+  public beforeDestroy(): void {
+    this.unsubscribe()
+  }
+}


### PR DESCRIPTION
This feature is needed for #2292 

The base is that when you component need to flexibly subscribe to single subscription with the flexible arguments

- :zap: added singleSubscribe Mixin
- :bug: linter fails if you have newer node than 16.13.2

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

