### PR TITLE
fix: remove scoped for now to restore old searchbar

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -93,7 +93,7 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
 }
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
 @import '@/styles/variables';
 
 .navbar {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

<img width="1035" alt="Screenshot 2022-02-19 at 13 07 22" src="https://user-images.githubusercontent.com/17953978/154800120-b717fa36-4def-488c-9013-311e12577649.png">



### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2405
- [x] i am removing scoped for now. will investigate further in the future why it breaks searchbar layout

### Before submitting Pull Request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
