### PR TITLE
feat: add hints on how to open shortcuts overview

### DIFF
--- a/components/shared/Loader.vue
+++ b/components/shared/Loader.vue
@@ -38,7 +38,7 @@ export default class Loader extends Vue {
       let newRandomNumber = this.randomNumber
       // make sure same quote isn't fetched again
       while (newRandomNumber === this.randomNumber) {
-        newRandomNumber = randomIntegerBetween(1, 33)
+        newRandomNumber = randomIntegerBetween(1, 35)
       }
       this.randomNumber = newRandomNumber
     }
@@ -46,7 +46,7 @@ export default class Loader extends Vue {
 
   protected placeholder = '/preloader.svg'
 
-  protected randomNumber = randomIntegerBetween(1, 33)
+  protected randomNumber = randomIntegerBetween(1, 35)
 
   public interval
 
@@ -68,7 +68,7 @@ export default class Loader extends Vue {
 
   public created(): void {
     setInterval(() => {
-      this.interval = this.randomNumber = randomIntegerBetween(1, 33)
+      this.interval = this.randomNumber = randomIntegerBetween(1, 35)
     }, 8000)
   }
 

--- a/components/shared/modals/ModalWrapper.vue
+++ b/components/shared/modals/ModalWrapper.vue
@@ -19,6 +19,7 @@
           <p class="card-header-title">
             {{ label || title }}
           </p>
+          <slot name="hint" />
         </header>
         <div class="card-content">
           <slot></slot>

--- a/components/shared/modals/keyboardShortcutsModal.vue
+++ b/components/shared/modals/keyboardShortcutsModal.vue
@@ -15,8 +15,7 @@
     </template>
     <template #hint>
       <p class="box has-text-right is-size-7">
-        press <b-tag type="is-primary" rounded>g+?</b-tag> to open shortcuts
-        menu
+        press <b-tag type="is-primary" rounded>?</b-tag> to open shortcuts menu
       </p>
     </template>
   </ModalWrapper>

--- a/components/shared/modals/keyboardShortcutsModal.vue
+++ b/components/shared/modals/keyboardShortcutsModal.vue
@@ -13,6 +13,12 @@
         <b-table :data="data['filters']" :columns="filterColumns"></b-table>
       </div>
     </template>
+    <template #hint>
+      <p class="box has-text-right is-size-7">
+        press <b-tag type="is-primary" rounded>g+?</b-tag> to open shortcuts
+        menu
+      </p>
+    </template>
   </ModalWrapper>
 </template>
 

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -364,7 +364,7 @@
     },
     "35": {
       "heading": "Did you know...",
-      "question": "that you can get an overview of all available shortcuts by pressing g+?"
+      "question": "that you can get an overview of all available shortcuts by pressing '?'"
     }
   },
   "sort": {

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -361,6 +361,10 @@
     "34": {
       "heading": "Did you know...",
       "question": "KodaDot has offset 10,000 kilograms of CO2, which is equivalent to 2,500 cheeseburgers."
+    },
+    "35": {
+      "heading": "Did you know...",
+      "question": "that you can get an overview of all available shortcuts by pressing g+?"
     }
   },
   "sort": {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

<img width="1086" alt="Screenshot 2022-02-20 at 13 54 42" src="https://user-images.githubusercontent.com/17953978/154844039-03e11a99-0fd5-47fb-9b17-6396c42a6cb7.png">

<img width="592" alt="Screenshot 2022-02-20 at 14 01 18" src="https://user-images.githubusercontent.com/17953978/154844030-49f67c67-a59e-45d5-839f-0a4df7dbb4ca.png">

### What's new?

- [x] PR closes #2409
- [x] added funfact and hint in shortcuts overview on how to open it

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
