### PR TITLE
:zap: disable right click on the image in gallery item

### DIFF
--- a/components/shared/gallery/BaseGalleryItem.vue
+++ b/components/shared/gallery/BaseGalleryItem.vue
@@ -19,11 +19,16 @@
             "
             class="image-preview has-text-centered"
             :class="{ fullscreen: isFullScreenView }">
-            <img v-if="isFullScreenView" :src="image" :alt="description" />
+            <img
+              v-if="isFullScreenView"
+              :src="image"
+              :alt="description"
+              @contextmenu.prevent />
             <BasicImage
               v-else-if="imageVisible"
               :src="image"
-              :alt="description" />
+              :alt="description"
+              @contextmenu.native.prevent />
             <div
               v-else
               class="media-container is-flex is-justify-content-center">


### PR DESCRIPTION
## What

App prevents user to do a right click on the image element in the gallery item.
This was raised as a security concern by a community

### PR type

- [x] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2434
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR
