### PR TITLE
#2341 - Navbar transformation during scrolling

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -1,5 +1,10 @@
 <template>
-  <b-navbar fixed-top spaced wrapper-class="container" close-on-click>
+  <b-navbar
+    fixed-top
+    spaced
+    wrapper-class="container"
+    close-on-click
+    :class="{ 'navbar-shrink': !showNavbar }">
     <template #brand>
       <b-navbar-item tag="nuxt-link" :to="{ path: '/' }" class="logo">
         <img
@@ -10,6 +15,7 @@
     </template>
     <template #start>
       <Search
+        :class="{ 'nav-search-shrink': !showNavbar }"
         hideFilter
         class="search-navbar"
         searchColumnClass="is-flex-grow-1" />
@@ -87,8 +93,31 @@ import PrefixMixin from '~/utils/mixins/prefixMixin'
   },
 })
 export default class NavbarMenu extends mixins(PrefixMixin) {
+  private showNavbar = true
+  private lastScrollPosition = 0
+
   get isRmrk(): boolean {
     return this.urlPrefix === 'rmrk' || this.urlPrefix === 'westend'
+  }
+
+  onScroll() {
+    const currentScrollPosition = document.documentElement.scrollTop
+    if (currentScrollPosition < 0) {
+      return
+    }
+    if (Math.abs(currentScrollPosition - this.lastScrollPosition) < 60) {
+      return
+    }
+    this.showNavbar = currentScrollPosition < this.lastScrollPosition
+    this.lastScrollPosition = currentScrollPosition
+  }
+
+  mounted() {
+    window.addEventListener('scroll', this.onScroll)
+  }
+
+  beforeDestroy() {
+    window.removeEventListener('scroll', this.onScroll)
   }
 }
 </script>
@@ -96,7 +125,20 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
 <style lang="scss">
 @import '@/styles/variables';
 
+@media (min-width: 1024px) {
+  .navbar-shrink {
+    box-shadow: none;
+    max-height: 70px;
+    padding-top: 6px !important;
+    padding-bottom: 6px !important;
+  }
+  .nav-search-shrink {
+    padding-bottom: 0 !important;
+  }
+}
 .navbar {
+  transition: 0.3s ease;
+  -webkit-transition: 0.3s ease;
   &.is-spaced {
     & > .container {
       .navbar-menu {
@@ -152,7 +194,7 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
   }
   .search-navbar {
     flex-grow: 1;
-    margin: 0rem 1rem;
+    margin: 0 1rem;
     input {
       border: inherit;
       background-color: #29292f;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2341
- [x] - I've added shrinking navbar after you scroll 60px down, while on screen larger than 1024px. Can adjust both of those parameters based on preference @yangwao. Your specific request about trying to make this without any JS is outside of my competence, but I've also asked around and searched the whole internet for answer. Couldn't find anything useful. I've heared @roiLeo is CSS Wizard, so maybe he could chip in and let me know if there's a way to do this without JS.  

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=FNyt7T1xdbhN7dagf7yGYCRJuE3R45VmTCE3tjzy1rKxa7y)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

https://user-images.githubusercontent.com/73316633/155882716-fdafa04d-1603-4e07-968d-b801a2fbe7c2.mp4


