### PR TITLE
issue_2467：Use <kbd> tag in KeyboardShortcuts component

### DIFF
--- a/components/settings/KeyboardShortcuts.vue
+++ b/components/settings/KeyboardShortcuts.vue
@@ -22,16 +22,18 @@
         <div class="content">
           <b-table :data="data[collapse.key]">
             <b-table-column field="shortcut" label="Shortcut" v-slot="props">
-              <span
-                v-for="(shortcut, index) in props.row.shortcut.split('+')"
-                :key="shortcut">
-                <kbd class="keyboard-shortcut-kbd">
-                  {{ shortcut }}
-                </kbd>
-                <span v-if="index < props.row.shortcut.split('+').length - 1">
-                  +
+              <div>
+                <span
+                  v-for="(shortcut, index) in props.row.shortcut.split('+')"
+                  :key="shortcut">
+                  <kbd class="keyboard-shortcut-kbd">
+                    {{ shortcut }}
+                  </kbd>
+                  <span v-if="index < props.row.shortcut.split('+').length - 1">
+                    +
+                  </span>
                 </span>
-              </span>
+              </div>
             </b-table-column>
             <b-table-column field="action" label="Action" v-slot="props">
               {{ props.row.action }}

--- a/components/settings/KeyboardShortcuts.vue
+++ b/components/settings/KeyboardShortcuts.vue
@@ -20,7 +20,23 @@
       </template>
       <div class="card-content">
         <div class="content">
-          <b-table :data="data[collapse.key]" :columns="columns"></b-table>
+          <b-table :data="data[collapse.key]">
+            <b-table-column field="shortcut" label="Shortcut" v-slot="props">
+              <span
+                v-for="(shortcut, index) in props.row.shortcut.split('+')"
+                :key="shortcut">
+                <kbd class="keyboard-shortcut-kbd">
+                  {{ shortcut }}
+                </kbd>
+                <span v-if="index < props.row.shortcut.split('+').length - 1">
+                  +
+                </span>
+              </span>
+            </b-table-column>
+            <b-table-column field="action" label="Action" v-slot="props">
+              {{ props.row.action }}
+            </b-table-column>
+          </b-table>
         </div>
       </div>
     </b-collapse>
@@ -29,7 +45,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
-
+import '@/styles/keyboard-shortcut.scss'
 @Component({})
 export default class keyboardShortcuts extends Vue {
   public isOpen = 0
@@ -45,16 +61,6 @@ export default class keyboardShortcuts extends Vue {
     {
       key: 'filters',
       title: 'Filters',
-    },
-  ]
-  public columns = [
-    {
-      field: 'shortcut',
-      label: 'Shortcut',
-    },
-    {
-      field: 'action',
-      label: 'Action',
     },
   ]
   public data = {

--- a/components/shared/modals/keyboardShortcutsModal.vue
+++ b/components/shared/modals/keyboardShortcutsModal.vue
@@ -6,11 +6,23 @@
     :isButtonHidden="true">
     <template v-slot:default>
       <div class="is-flex is-justify-content-space-between">
-        <b-table :data="data['navigation']" :columns="navColumns"></b-table>
-        <b-table
-          :data="data['item_detail']"
-          :columns="itemDetailColumns"></b-table>
-        <b-table :data="data['filters']" :columns="filterColumns"></b-table>
+        <b-table :data="data[type]" v-for="type in types" :key="type">
+          <b-table-column field="text" :label="labels[type]" v-slot="props">
+            {{ props.row.text }}
+          </b-table-column>
+          <b-table-column field="shortcut" v-slot="props">
+            <span
+              v-for="(shortcut, index) in props.row.shortcut.split('+')"
+              :key="shortcut">
+              <kbd class="keyboard-shortcut-kbd">
+                {{ shortcut }}
+              </kbd>
+              <span v-if="index < props.row.shortcut.split('+').length - 1">
+                +
+              </span>
+            </span>
+          </b-table-column>
+        </b-table>
       </div>
     </template>
     <template #hint>
@@ -23,9 +35,15 @@
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
-
+import '@/styles/keyboard-shortcut.scss'
 const components = {
   ModalWrapper: () => import('./ModalWrapper.vue'),
+}
+
+interface DifferentTypeShortCuts {
+  navigation: string | { text: string; shortcut: string }[]
+  item_detail: string | { text: string; shortcut: string }[]
+  filters: string | { text: string; shortcut: string }[]
 }
 
 @Component({
@@ -34,39 +52,7 @@ const components = {
 })
 export default class KeyboardShortcutsModal extends Vue {
   public title = 'Keyboard Shortcuts'
-  public navColumns = [
-    {
-      field: 'text',
-      label: 'Navigation',
-    },
-    {
-      field: 'shortcut',
-      label: '',
-    },
-  ]
-
-  public itemDetailColumns = [
-    {
-      field: 'text',
-      label: 'Item Detail',
-    },
-    {
-      field: 'shortcut',
-      label: '',
-    },
-  ]
-
-  public filterColumns = [
-    {
-      field: 'text',
-      label: 'Filters',
-    },
-    {
-      field: 'shortcut',
-      label: '',
-    },
-  ]
-  public data = {
+  public data: DifferentTypeShortCuts = {
     navigation: [
       {
         text: 'Next page',
@@ -166,5 +152,11 @@ export default class KeyboardShortcutsModal extends Vue {
       },
     ],
   }
+  public labels: DifferentTypeShortCuts = {
+    navigation: 'Navigation',
+    item_detail: 'Item Detail',
+    filters: 'Filters',
+  }
+  public types = Object.keys(this.data)
 }
 </script>

--- a/components/shared/modals/keyboardShortcutsModal.vue
+++ b/components/shared/modals/keyboardShortcutsModal.vue
@@ -11,16 +11,18 @@
             {{ props.row.text }}
           </b-table-column>
           <b-table-column field="shortcut" v-slot="props">
-            <span
-              v-for="(shortcut, index) in props.row.shortcut.split('+')"
-              :key="shortcut">
-              <kbd class="keyboard-shortcut-kbd">
-                {{ shortcut }}
-              </kbd>
-              <span v-if="index < props.row.shortcut.split('+').length - 1">
-                +
+            <div>
+              <span
+                v-for="(shortcut, index) in props.row.shortcut.split('+')"
+                :key="shortcut">
+                <kbd class="keyboard-shortcut-kbd">
+                  {{ shortcut }}
+                </kbd>
+                <span v-if="index < props.row.shortcut.split('+').length - 1">
+                  +
+                </span>
               </span>
-            </span>
+            </div>
           </b-table-column>
         </b-table>
       </div>

--- a/styles/keyboard-shortcut.scss
+++ b/styles/keyboard-shortcut.scss
@@ -1,0 +1,12 @@
+.keyboard-shortcut-kbd {
+  background-color: #eee;
+  border-radius: 3px;
+  border: 1px solid #b4b4b4;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+  color: #333;
+  display: inline-block;
+  font-weight: 700;
+  line-height:  1;
+  padding: 2px 4px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
change keyboard-shortcut to <kbd>

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2467 
- [x] Use <kbd> tag in KeyboardShortcuts component

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EgCzZLpVe7zg7RHh79qPyC8UrykVkA22YY2oj7sWMZf15Ws)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://user-images.githubusercontent.com/38389586/156206964-94f88930-3c1d-4022-80d5-5e18f01cb1eb.png)
![image](https://user-images.githubusercontent.com/38389586/156207024-e56ded6f-1563-4de5-bc33-cd44a0936952.png)
