### PR TITLE
fix: KSM address prefix does not match but sent successfully

### DIFF
--- a/components/rmrk/Gallery/AvailableActions.vue
+++ b/components/rmrk/Gallery/AvailableActions.vue
@@ -52,6 +52,7 @@
       v-if="showSubmit"
       type="is-primary"
       icon-left="paper-plane"
+      :disabled="disabled"
       @click="submit">
       Submit {{ selectedAction }}
     </b-button>
@@ -74,6 +75,7 @@ import KeyboardEventsMixin from '~/utils/mixins/keyboardEventsMixin'
 import { get } from 'idb-keyval'
 import { identityStore } from '@/utils/idbStore'
 import { emptyObject } from '~/utils/empty'
+import { isAddress } from '@polkadot/util-crypto'
 
 type Address = string | GenericAccountId | undefined
 type IdentityFields = Record<string, string>
@@ -125,6 +127,10 @@ export default class AvailableActions extends mixins(
     this.initKeyboardEventHandler({
       a: this.bindActionEvents,
     })
+  }
+
+  get disabled(): boolean {
+    return this.selectedAction === 'SEND' && !isAddress(this.meta.toString())
   }
 
   private bindActionEvents(event) {


### PR DESCRIPTION
Disable button when address is invalid

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2460
- [x] disable submit button when address is invalid

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EgCzZLpVe7zg7RHh79qPyC8UrykVkA22YY2oj7sWMZf15Ws)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

https://user-images.githubusercontent.com/38389586/156304236-c2cd1e44-c0e4-4882-8e10-26565e4a4436.mp4


