### PR TITLE
Css less border on gallery/collections Card

### DIFF
--- a/components/base/CarouselCardList.vue
+++ b/components/base/CarouselCardList.vue
@@ -134,9 +134,6 @@ export default class CarouselList extends mixins(AuthMixin) {
 }
 
 .card {
-  border-radius: 8px;
-  border: 2px solid $primary;
-
   .media-content {
     width: 100%;
   }

--- a/components/base/CarouselCardList.vue
+++ b/components/base/CarouselCardList.vue
@@ -134,6 +134,9 @@ export default class CarouselList extends mixins(AuthMixin) {
 }
 
 .card {
+  border-radius: 8px;
+  border: 2px solid $primary;
+
   .media-content {
     width: 100%;
   }

--- a/components/rmrk/Collection/List/CollectionList.vue
+++ b/components/rmrk/Collection/List/CollectionList.vue
@@ -270,10 +270,8 @@ export default class CollectionList extends mixins(PrefixMixin) {
     padding-top: 10px;
 
     .card {
-      border-radius: 8px;
       position: relative;
       overflow: hidden;
-      border: 2px solid $primary-light;
 
       &-image {
         &__emotes {

--- a/components/rmrk/Gallery/Collections.vue
+++ b/components/rmrk/Gallery/Collections.vue
@@ -263,10 +263,8 @@ export default class Collections extends mixins(PrefixMixin) {
     padding-top: 10px;
 
     .card {
-      border-radius: 8px;
       position: relative;
       overflow: hidden;
-      border: 2px solid $primary-light;
 
       &-image {
         &__emotes {

--- a/components/rmrk/Gallery/Gallery.vue
+++ b/components/rmrk/Gallery/Gallery.vue
@@ -389,10 +389,8 @@ export default class Gallery extends mixins(PrefixMixin) {
   .columns {
     padding-top: 10px;
     .card {
-      border-radius: 8px;
       position: relative;
       overflow: hidden;
-      border: 2px solid $primary-light;
 
       &-image {
         &__emotes {

--- a/components/rmrk/Gallery/GalleryCard.vue
+++ b/components/rmrk/Gallery/GalleryCard.vue
@@ -118,10 +118,8 @@ export default class GalleryCard extends mixins(AuthMixin) {
 @import '@/styles/variables';
 
 .nft-card {
-  border-radius: 8px;
   position: relative;
   overflow: hidden;
-  border: 2px solid $primary-light;
 
   &.is-current-owner {
     box-shadow: 0px 2px 5px 0.5px #41b883;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [ ] PR closes : 2503 # https://github.com/kodadot/nft-gallery/issues/2503
- [ ] Less border on gallery and collections 

### Before submitting Pull Request, please make sure:

- [V ] My contribution builds **clean without any errors or warnings**
- [ V] I've merged recent default branch -- **main** and I've no conflicts
- [ V] I've tried to respect high code quality standards
- [ V] I've didn't break any original functionality
- [ V] I've posted a screenshot of demonstrated change in this PR

### Optional

- [V ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ V] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

FktEWsDxuWqPuuGRYog1LqTT6BetCAdPkgR3GMj8b6C15dA

### Community participation

- [V ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

-  #[V ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![CSS_BORDER](https://user-images.githubusercontent.com/59928086/156905907-26e76ba3-723c-4e76-8886-b6be41f835b4.png)

