### PR TITLE
fix: use totalcount of nfts for vercel image rendering

### DIFF
--- a/components/rmrk/Gallery/CollectionItem.vue
+++ b/components/rmrk/Gallery/CollectionItem.vue
@@ -399,7 +399,7 @@ export default class CollectionItem extends mixins(
         name: this.name,
         image: this.image,
         description: this.description,
-        numberOfItems: this.collection?.nfts?.length || 0,
+        numberOfItems: this.total || 0,
       })
     }
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

![Donkey Gang](https://user-images.githubusercontent.com/17953978/158786006-3f1555b1-e610-4e40-989d-5806b09a4b6d.jpg)

### What's new?

- [x] PR closes #2563
- [x] use `collectionEntity.nfts.totalCount` for corrent item count

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/0a8ce195286c168f19-DONKEY?tab=history>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
