### PR TITLE
#2578 Keep only top-border on pagination and sharing buttons

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -244,7 +244,7 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
   .navbar-item {
     text-transform: uppercase;
     font-weight: 500;
-    border-top: 2px solid $primary;
+    border-top: 1px solid $primary;
     margin-left: 0.5em;
     transition: 0.3s;
     background: rgba(9, 9, 9, 0.55);

--- a/components/rmrk/Gallery/Item/Sharing.vue
+++ b/components/rmrk/Gallery/Item/Sharing.vue
@@ -8,7 +8,7 @@
       <b-button
         @click="toast('URL copied to clipboard')"
         v-clipboard:copy="realworldFullPathShare"
-        type="is-primary">
+        type="is-primary is-bordered-light share-button">
         <b-icon size="is-small" pack="fas" icon="link" />
       </b-button>
 
@@ -85,7 +85,7 @@
             <b-icon size="is-medium" pack="fas" icon="code" />
           </b-button>
         </template>
-        <b-button type="is-primary">
+        <b-button type="is-primary is-bordered-light share-button">
           <b-icon size="is-small" pack="fas" icon="share" />
         </b-button>
       </b-tooltip>

--- a/components/rmrk/Gallery/Layout.vue
+++ b/components/rmrk/Gallery/Layout.vue
@@ -49,8 +49,14 @@ export default class Layout extends Vue {
   }
 }
 </script>
-<style>
+<style lang="scss">
+@import '@/styles/variables';
+
 .b-radio.radio.button.is-selected {
   background-color: #db2980;
+}
+.b-radio.radio.button {
+  border: none !important;
+  border-top: 1px solid $primary !important;
 }
 </style>

--- a/components/rmrk/Gallery/Layout.vue
+++ b/components/rmrk/Gallery/Layout.vue
@@ -4,6 +4,7 @@
       <b-tooltip label="Large display">
         <b-radio-button
           type="is-primary"
+          class="collection-radio-btn"
           v-model="layout"
           native-value="is-half-desktop is-half-tablet"
           :disabled="disabled"
@@ -16,6 +17,7 @@
       <b-tooltip label="Small display">
         <b-radio-button
           type="is-primary"
+          class="collection-radio-btn"
           v-model="layout"
           native-value="is-one-quarter-desktop is-one-third-tablet"
           :disabled="disabled"
@@ -55,7 +57,7 @@ export default class Layout extends Vue {
 .b-radio.radio.button.is-selected {
   background-color: #db2980;
 }
-.b-radio.radio.button {
+.collection-radio-btn .b-radio.radio.button {
   border: none !important;
   border-top: 1px solid $primary !important;
 }

--- a/components/rmrk/Gallery/Pagination.vue
+++ b/components/rmrk/Gallery/Pagination.vue
@@ -18,7 +18,7 @@
     </b-pagination>
     <b-tooltip :label="$t('tooltip.random') + ' (g+r)'">
       <b-button
-        class="ml-2 magicBtn"
+        class="ml-2 magicBtn is-bordered-light share-button"
         title="Go to random page"
         v-if="hasMagicBtn"
         type="is-primary"

--- a/components/rmrk/Gallery/Search/SearchBar.vue
+++ b/components/rmrk/Gallery/Search/SearchBar.vue
@@ -13,7 +13,7 @@
           v-if="!hideFilter"
           icon-left="filter"
           aria-controls="sortAndFilter"
-          type="is-primary"
+          type="is-primary is-bordered-light"
           class="is-hidden-mobile mr-2"
           @click="isVisible = !isVisible" />
         <b-autocomplete

--- a/components/rmrk/Profile/NavbarProfileDropdown.vue
+++ b/components/rmrk/Profile/NavbarProfileDropdown.vue
@@ -4,7 +4,7 @@
       <span v-if="account" class="is-mobile is-vcentered navbar__avatar">
         <!-- <Avatar class="navbar__avatar-icon" :value="account" :size="34" /> -->
         <b-button
-          type="is-primary navbar-link-background"
+          type="is-primary navbar-link-background is-bordered-light"
           class="navbar__button">
           <Identity
             :address="account"

--- a/components/rmrk/Profile/ProfileDetail.vue
+++ b/components/rmrk/Profile/ProfileDetail.vue
@@ -33,7 +33,7 @@
       <div class="column has-text-right">
         <div class="is-flex is-justify-content-right">
           <div class="control" v-for="network in networks" :key="network.alt">
-            <b-button class="network-button" type="is-primary">
+            <b-button class="share-button" type="is-primary is-bordered-light">
               <a
                 :href="`${network.url}${id}`"
                 target="_blank"
@@ -405,9 +405,5 @@ export default class Profile extends mixins(PrefixMixin) {
 .title {
   flex-grow: 0;
   flex-basis: auto;
-}
-
-.network-button {
-  width: 40px;
 }
 </style>

--- a/components/shared/ChainSelect.vue
+++ b/components/shared/ChainSelect.vue
@@ -2,7 +2,7 @@
   <b-dropdown v-model="selected" aria-role="list">
     <template #trigger="{ active }">
       <b-button
-        type="is-primary is-bordered navbar-link-background"
+        type="is-primary is-bordered navbar-link-background is-bordered-light"
         :label="selected"
         :icon-right="active ? 'caret-up' : 'caret-down'" />
     </template>

--- a/components/shared/ConnectWalletButton.vue
+++ b/components/shared/ConnectWalletButton.vue
@@ -1,5 +1,7 @@
 <template>
-  <b-button type="is-primary is-bordered" @click="openWalletConnectModal()">
+  <b-button
+    type="is-primary is-bordered-light"
+    @click="openWalletConnectModal()">
     {{ $t(label) }}
   </b-button>
 </template>

--- a/components/shared/ConnectWalletButton.vue
+++ b/components/shared/ConnectWalletButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-button type="is-primary" @click="openWalletConnectModal()">
+  <b-button type="is-primary is-bordered" @click="openWalletConnectModal()">
     {{ $t(label) }}
   </b-button>
 </template>

--- a/components/shared/SwitchLocale.vue
+++ b/components/shared/SwitchLocale.vue
@@ -2,7 +2,7 @@
   <b-dropdown aria-role="list">
     <template #trigger="{ active }">
       <b-button
-        type="is-primary is-bordered navbar-link-background"
+        type="is-primary is-bordered-light navbar-link-background"
         :label="userFlag"
         :icon-right="active ? 'caret-up' : 'caret-down'" />
     </template>

--- a/components/shared/history/HistoryBrowser.vue
+++ b/components/shared/history/HistoryBrowser.vue
@@ -2,7 +2,7 @@
   <b-dropdown v-if="hasHistory" aria-role="list" position="is-bottom-left">
     <template #trigger>
       <b-button
-        type="is-primary is-bordered"
+        type="is-primary is-bordered-light"
         class="navbar-link-background"
         icon-left="history" />
     </template>

--- a/components/shared/modals/ShowQRModal.vue
+++ b/components/shared/modals/ShowQRModal.vue
@@ -1,5 +1,8 @@
 <template>
-  <ModalWrapper icon="qrcode" :title="title">
+  <ModalWrapper
+    icon="qrcode"
+    :title="title"
+    :type="'is-primary is-bordered-light share-button'">
     <template v-slot:default>
       <QRCode :text="qrCodePath" color="#db2980" bgColor="#000" />
     </template>

--- a/components/transfer/DonationButton.vue
+++ b/components/transfer/DonationButton.vue
@@ -1,5 +1,8 @@
 <template>
-  <b-button type="is-primary" icon-left="gift" @click="goToTransfer">
+  <b-button
+    type="is-primary is-bordered-light share-button"
+    icon-left="gift"
+    @click="goToTransfer">
   </b-button>
 </template>
 

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -196,6 +196,15 @@ button.button.is-bordered {
   border-top: 2px solid $primary !important;
 }
 
+button.button.is-bordered-light {
+  border: 0;
+  border-top: 1px solid $primary !important;
+}
+
+.share-button {
+  width: 40px;
+}
+
 button.button.navbar-link-background {
   background-color: $blacklight;
 }
@@ -260,4 +269,10 @@ button.button.navbar-link-background {
     padding-right: 0!important;
     margin: 0 -12px!important
   }
+}
+
+// global css for pagination
+.pagination-link {
+  border: none!important;
+  border-top: 1px solid $primary!important;
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #2578
- [ ]

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="524" alt="Screenshot 2022-03-17 at 7 10 50 PM" src="https://user-images.githubusercontent.com/39299315/158821222-2e1a1f71-97e2-4cfe-a12c-54f7c45c1010.png">
<img width="370" alt="Screenshot 2022-03-17 at 7 10 54 PM" src="https://user-images.githubusercontent.com/39299315/158821239-6e7fa0c5-8222-4eb7-ac8d-96004ad14b0d.png">
<img width="496" alt="Screenshot 2022-03-17 at 7 11 11 PM" src="https://user-images.githubusercontent.com/39299315/158821257-bbf7c2e7-a0d3-4084-9d93-0143bfd41dac.png">
