### PR TITLE
🐛 fix: tile view does not work after entering theatre view

### DIFF
--- a/components/shared/gallery/BaseGalleryItem.vue
+++ b/components/shared/gallery/BaseGalleryItem.vue
@@ -15,7 +15,10 @@
           }">
           <div
             v-orientation="
-              viewMode === 'default' && !isFullScreenView && imageVisible
+              viewMode === 'default' &&
+              !isFullScreenView &&
+              !isTileView &&
+              imageVisible
             "
             class="image-preview has-text-centered"
             :class="{


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [ ] PR closes #<issue_number>
- [x] bug fix: tile view does not work after entering theatre view

It does not work when press tile view button after  entering the theatre view.
As in the video：

https://user-images.githubusercontent.com/31397967/159155276-791c119f-6e0f-43b1-9cd1-1bd14809e6c8.mp4

url: https://kodadot.xyz/rmrk/gallery/11864295-362f7ac490f5168342-VALENTINO_VIBES-RICH_VALENTINO_FELL_IN_LUV_SINGLE-0000000000000036

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [x] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI;a screenshot is best to understand changes for others.

After fixing the bug:  

https://user-images.githubusercontent.com/31397967/159155620-09104abf-98be-469c-bc27-0ec71513c8de.mp4





