### PR TITLE
:bug: ability to sign transactions with any extension

### DIFF
--- a/components/common/WalletModal.vue
+++ b/components/common/WalletModal.vue
@@ -108,6 +108,7 @@ export default class WalletModal extends Vue {
     this.$emit('close')
     this.$store.dispatch('setAuth', { address: account })
     localStorage.setItem('kodaauth', account)
+    localStorage.setItem('wallet', this.selectedWalletProvider.extensionName)
   }
 
   get account() {

--- a/utils/extension.ts
+++ b/utils/extension.ts
@@ -1,12 +1,19 @@
-import { web3Enable, web3FromAddress } from '@polkadot/extension-dapp'
-import { WalletAccount } from '@/utils/config/wallets'
+import { web3Enable } from '@polkadot/extension-dapp'
+import { getWalletBySource, WalletAccount } from '@/utils/config/wallets'
 
 export const enableExtension = async () => await web3Enable('KodaDot')
 
 export const getAddress = async (address: string) => {
   try {
-    const injector = await web3FromAddress(address)
-    return injector
+    const walletName = localStorage.getItem('wallet')
+    console.log(walletName)
+    const wallet = getWalletBySource(walletName)
+    await wallet?.enable()
+    if (wallet?.extension) {
+      return wallet.extension
+    }
+
+    throw new Error('Wallet not found')
   } catch (e) {
     console.warn(`[EXTENSION] No Addr ${address}`)
     return null


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

What: the previous implementation relies on the fact that we support only one extension.
Since our wallet model changed: App checked if the address is in the polkadot-js (false) fallback was keypair (false) so it threw error.


ht/ @roiLeo for the nice wallet impl :)


### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2607
- [x] Closes #2594
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

### Optional

- [x] I've tested it [Kusama Bot 075 :: robot emote] rmrk/gallery/11895344-900D19DC7D3C444E4C-KSMBOT-KUSAMA_BOT_075-0000000000000078
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

