### PR TITLE
✨ remove empty rmrk collections

### DIFF
--- a/components/rmrk/Gallery/CollectionItem.vue
+++ b/components/rmrk/Gallery/CollectionItem.vue
@@ -239,7 +239,7 @@ export default class CollectionItem extends mixins(
 
     if (this.searchQuery.search) {
       params.push({
-        name: { likeInsensitive: `%${this.searchQuery.search}%` },
+        name: `%${this.searchQuery.search}%`,
       })
     }
 

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -416,6 +416,10 @@
     "BLOCK_NUMBER_ASC": "Old first",
     "UPDATED_AT_DESC": "Last interacted",
     "UPDATED_AT_ASC": "Least Interacted",
+    "blockNumber_DESC": "New first",
+    "blockNumber_ASC": "Old first",
+    "updatedAt_DESC": "Last interacted",
+    "updatedAt_ASC": "Least Interacted",
     "PRICE_DESC": "Price: High to Low",
     "PRICE_ASC": "Price: Low to High",
     "listed": "Buy now"

--- a/queries/collectionListWithSearch.graphql
+++ b/queries/collectionListWithSearch.graphql
@@ -4,30 +4,30 @@
 query collectionListWithSearch(
   $first: Int!
   $offset: Int
-  $search: [CollectionEntityFilter!]
-  $listed: [NFTEntityFilter!]
-  $orderBy: CollectionEntitiesOrderBy = BLOCK_NUMBER_DESC
+  $search: [CollectionEntityWhereInput!]
+  $orderBy: CollectionEntityOrderByInput = blockNumber_DESC
 ) {
   collectionEntities(
-    orderBy: [$orderBy, BLOCK_NUMBER_DESC]
-    first: $first
+    orderBy: [$orderBy, blockNumber_DESC]
+    limit: $first
     offset: $offset
-    filter: { id: { notLike: "%KAN%" }, and: $search }
+    where: { nfts_some: { burned_eq: false }, AND: $search }
+  ) {
+    ...collection
+    ...collectionDetails
+    nfts {
+      id
+      metadata
+      name
+      price
+      burned
+      currentOwner
+    }
+  }
+  stats: collectionEntitiesConnection(
+    where: { nfts_some: { burned_eq: false }, AND: $search }
+    orderBy: blockNumber_DESC
   ) {
     totalCount
-    nodes {
-      ...collection
-      ...collectionDetails
-      nfts(filter: { burned: { distinctFrom: true }, and: $listed }) {
-        nodes {
-          id
-          metadata
-          name
-          price
-          burned
-          currentOwner
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
continue #2705 

⚠️ There is a very good chance that I broke the `/collections` page on other chain (statemine, westmint) since it don't use subsquid and the filter are not the same as before.

### PR type

- [x] Bugfix
- [x] Feature

### What's new?

- [x] PR closes #1357 
- [x] remove empty collection on rmrk `/collections` using subsquid

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Screenshot

#### before
![Screenshot 2022-03-31 at 14-48-59 Low minting fees and carbonless NFTs](https://user-images.githubusercontent.com/9987732/161058416-7fd8fa8a-de4d-4333-b8d4-12d679554a03.png)

#### after
![Screenshot 2022-03-31 at 14-48-29 Low minting fees and carbonless NFTs](https://user-images.githubusercontent.com/9987732/161058610-5c794961-56c4-44ab-b2ae-63ef3dccbf7b.png)

