### PR TITLE
display collection name in detail page

### DIFF
--- a/components/unique/Gallery/Item/Detail.vue
+++ b/components/unique/Gallery/Item/Detail.vue
@@ -7,7 +7,7 @@
       <nuxt-link
         :to="`/${urlPrefix}/collection/${nft.collectionId}`"
         v-show="!isLoading">
-        {{ nft.collectionId }}
+        {{ nft.collection.name }}
       </nuxt-link>
       <b-skeleton :active="isLoading"></b-skeleton>
     </p>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [ ] PR closes #<issue_number>
- [x] nft details page shows the collection id instead of its name, very strange
https://kodadot.xyz/rmrk/detail/11904483-800f8a914281765a7d-DREAMS-DREAM_6_OR_UNITY-0000000000000006

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/31397967/161429824-75eefcbc-3cb3-41ea-94c8-aac62d146333.png">


### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/31397967/161429873-ae717298-20a1-4280-8986-1c1312027be9.png">


