### PR TITLE
fix: switch button broken at some video nft on mobile

### DIFF
--- a/components/rmrk/Gallery/Item/Navigation.vue
+++ b/components/rmrk/Gallery/Item/Navigation.vue
@@ -116,6 +116,7 @@ export default class Navigation extends mixins(KeyboardEventsMixin) {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  z-index: 99999;
   @media screen and (max-width: 768px) {
     right: -12px;
     left: -12px;

--- a/components/unique/Gallery/Item/Detail.vue
+++ b/components/unique/Gallery/Item/Detail.vue
@@ -5,6 +5,7 @@
     </p>
     <p class="subtitle is-size-6">
       <nuxt-link
+        v-if="nft.collection"
         :to="`/${urlPrefix}/collection/${nft.collectionId}`"
         v-show="!isLoading">
         {{ nft.collection.name }}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [ ] PR closes #<issue_number>
- [x] switch button broken at some video nft on mobile

button isn't clickable on nft of vedio
what's more, switch button is hidden when a video is playing.

https://user-images.githubusercontent.com/31397967/161480622-581ccdd6-7968-4db5-8486-554daea70b4a.mp4



### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
![8231649050933_ pic](https://user-images.githubusercontent.com/31397967/161480924-be2ef65c-c9ee-483f-96c1-9ce2bbd41da7.jpg)

