### PR TITLE
nav bar display on different width

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -234,25 +234,25 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
 //   }
 // }
 
-// @media only screen and (min-width: 1215px) and (max-width: 1190px) {
-//   div#NavHistoryBrowser {
-//     display: none;
-//   }
-// }
-
-@media only screen and (min-width: 1024px) and (max-width: 1337px) {
-  .navbar-menu .search-navbar {
-    width: 300px !important;
+@media only screen and (min-width: 1024px) and (max-width: 1100px) {
+  div#NavHistoryBrowser {
+    display: none;
   }
 }
 
-@media only screen and (min-width: 1024px) and (max-width: 1180px) {
+@media only screen and (min-width: 1024px) and (max-width: 1200px) {
+  a#NavCreate {
+    display: none;
+  }
+}
+
+@media only screen and (min-width: 1024px) and (max-width: 1250px) {
   div#NavChainSelect {
     display: none;
   }
 }
 
-@media only screen and (min-width: 1024px) and (max-width: 1220px) {
+@media only screen and (min-width: 1024px) and (max-width: 1340px) {
   div#NavLocaleChanger {
     display: none;
   }
@@ -316,12 +316,16 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
       margin-left: 0 !important;
     }
   }
+  .navbar-start {
+    flex: 1;
+  }
   .search-navbar {
     flex-grow: 1;
     margin: 0rem 1rem;
     background-color: transparent;
     box-shadow: none;
-    width: 400px;
+    min-width: 350px;
+    flex: 1;
     margin: 0 1rem;
     input {
       border: inherit;

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -269,7 +269,7 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
       .navbar-menu {
         margin-right: 0;
         .button {
-          height: 42px;
+          height: 40px;
         }
       }
     }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #2770 
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/31397967/161764147-1c545c51-544a-4e75-9503-e0c446c8b36c.png">

Keep the width of the search bar at release 350px.
