### PR TITLE
sorted by highest percentage in flippers

### DIFF
--- a/components/rmrk/Gallery/Flipper.vue
+++ b/components/rmrk/Gallery/Flipper.vue
@@ -6,6 +6,7 @@
     dateHeaderLabel="Last Activity"
     nameHeaderLabel="User"
     saleHeaderLabel="Sold"
+    defaultSortOption="Percentage"
     :collapseTitleOption="$t('Flipper')"
     hideCollapse />
 </template>

--- a/components/rmrk/Gallery/Holder/Holder.vue
+++ b/components/rmrk/Gallery/Holder/Holder.vue
@@ -52,7 +52,7 @@
           aria-page-label="Page"
           aria-current-label="Current page"
           :current-page.sync="currentPage"
-          :default-sort="['Amount', 'desc']">
+          :default-sort="[defaultSortOption, 'desc']">
           <b-table-column
             :visible="columnsVisible['Name'].display"
             :field="groupKey"
@@ -253,6 +253,7 @@ export default class CommonHolderTable extends mixins(
   @Prop({ type: String, default: 'Date' }) dateHeaderLabel!: string
   @Prop({ type: String, default: 'Sale' }) saleHeaderLabel!: string
   @Prop({ type: String, default: '' }) collapseTitleOption!: string
+  @Prop({ type: String, default: 'Amount' }) defaultSortOption!: string
 
   private readonly openOnDefault!: boolean
   private currentPage = parseInt(this.$route.query?.page as string) || 1


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2861
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.  
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/31397967/163566863-dbf01355-cbe7-4e25-8190-110e23adeaaa.png">
