### PR TITLE
⚒️ missing mediaUri meta

### DIFF
--- a/components/rmrk/Gallery/GalleryCard.vue
+++ b/components/rmrk/Gallery/GalleryCard.vue
@@ -99,7 +99,10 @@ export default class GalleryCard extends mixins(AuthMixin) {
 
       this.image = image || getSanitizer(meta.image || '')(meta.image || '')
       this.title = meta.name
-      this.animatedUrl = sanitizeIpfsUrl(meta.animation_url || '', 'pinata')
+      this.animatedUrl = sanitizeIpfsUrl(
+        meta.animation_url || meta.mediaUri || '',
+        'pinata'
+      )
     }
   }
 

--- a/components/rmrk/Gallery/GalleryItem.vue
+++ b/components/rmrk/Gallery/GalleryItem.vue
@@ -310,7 +310,7 @@ export default class GalleryItem extends mixins(PrefixMixin) {
         ...meta,
         image: imageSanitizer(meta.image),
         animation_url: sanitizeIpfsUrl(
-          meta.animation_url || meta.image,
+          meta.animation_url || meta.image || meta.mediaUri,
           'pinata'
         ),
       }

--- a/components/rmrk/service/scheme.ts
+++ b/components/rmrk/service/scheme.ts
@@ -68,6 +68,7 @@ export interface Metadata {
 
 export interface NFTMetadata extends Metadata {
   name: string
+  mediaUri?: string
   background_color?: string
   animation_url?: string
   youtube_url?: string


### PR DESCRIPTION
⚠️ need to be tested, page with multiple media video is slow

### PR type

- [x] Bugfix

### What's new?

- [x] PR closes #2836 
- [x] missing `meta.mediaUri`
- [x] fix `/rmrk/u/DVa676uebTkgH8uZyS2umio7JtmkcSHHoPvPJJQY3bbYoAu`
- [x] fix `/rmrk/detail/12009176-289d0e953cbdc59a73-HHK-0072_HYPEHELL_KEYCHAIN-0000000000000072`
- [x] fix `/rmrk/collection/289d0e953cbdc59a73-HHK`

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=HguGafrfk8nRP9a4tgJf7hLvSSFie8GtkDjyWFHQ2kDUAMc)

### Screenshot
