### PR TITLE
display long size image/nft

### DIFF
--- a/components/shared/gallery/BaseGalleryItem.vue
+++ b/components/shared/gallery/BaseGalleryItem.vue
@@ -157,14 +157,14 @@ export default class BaseGalleryItem extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import '@/styles/variables';
 
-.fixed-height {
-  height: 748px;
-}
-
 .gallery-item {
+  .fixed-height {
+    height: 748px;
+  }
+
   .image-wrapper {
     position: relative;
     margin: 30px auto;
@@ -175,6 +175,10 @@ export default class BaseGalleryItem extends Vue {
     }
 
     .image-preview {
+      img {
+        object-fit: contain;
+        height: 100%;
+      }
       .media-container {
         position: relative;
         padding-top: 100%;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2923 
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
regular
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/31397967/165983243-7559c332-b9ce-44f0-b4e4-218e6372d938.png">

full screen: 
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/31397967/165983566-41a83018-1d58-49ab-8143-af9cb1b6a51d.png">




