### PR TITLE
fix: modal ui justify on mobile

### DIFF
--- a/components/rmrk/Gallery/EmotionList.vue
+++ b/components/rmrk/Gallery/EmotionList.vue
@@ -72,6 +72,7 @@ export default class EmotionList extends Vue {
     this.$buefy.modal.open({
       parent: this,
       component: EmotionModal,
+      canCancel: ['escape', 'outside'],
       hasModalCard: true,
       props: {
         emotes: this.emotes,

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -104,6 +104,16 @@ body {
     background-color: rgba(0, 0, 0, 0.5);
   }
 
+  .animation-content {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .modal.is-active {
+    z-index: 99999;
+  }
+
   .modal-background {
     background-color: rgba(0, 0, 0, 0.86);
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2939
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [x] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

before:  
ui problems:  
1. Arrows in gallery are overlapping
2. emotion modal is not align center. 
3. extral close button at the top right corner.
<img width="444" alt="image" src="https://user-images.githubusercontent.com/31397967/166246149-836e13c7-3cd9-41b9-b06c-143ebc4ccb36.png">

after:  
<img width="443" alt="image" src="https://user-images.githubusercontent.com/31397967/166247688-804bc583-bba8-438b-b9a5-9df272e52f63.png">



