### PR TITLE
fix: Sort visited NFTs by time user has visited them

### DIFF
--- a/components/rmrk/Gallery/GalleryItemCarousel.vue
+++ b/components/rmrk/Gallery/GalleryItemCarousel.vue
@@ -15,7 +15,7 @@ import { MIN_CAROUSEL_NFT } from '~/utils/constants'
 
 import collectionEntityById from '@/queries/rmrk/subsquid/collectionEntityById.graphql'
 import nftEntitiesByIDs from '@/queries/rmrk/subsquid/nftEntitiesByIDs.graphql'
-
+import { sortItemListByIds } from '@/utils/sorting'
 import { CarouselNFT } from '@/components/base/types'
 
 @Component({
@@ -61,7 +61,8 @@ export default class GalleryItemCarousel extends Vue {
         },
       })
 
-      this.nfts = await formatNFT(data?.nftEntities)
+      const sortedNftList = sortItemListByIds(data?.nftEntities, ids, 10)
+      this.nfts = await formatNFT(sortedNftList)
     }
   }
 

--- a/queries/rmrk/subsquid/nftEntitiesByIDs.graphql
+++ b/queries/rmrk/subsquid/nftEntitiesByIDs.graphql
@@ -3,7 +3,7 @@
 #import "../../fragments/baseMeta.graphql"
 
 query nftEntitiesByIDs($ids: [ID!]!) {
-  nftEntities(where: { id_in: $ids, price_gt: "0" }, limit: 10) {
+  nftEntities(where: { id_in: $ids, price_gt: "0" }) {
     ...nftSubsquid
     ...nftDetails
     meta {

--- a/tests/sorting.spec.ts
+++ b/tests/sorting.spec.ts
@@ -1,0 +1,40 @@
+import { sortItemListByIds } from '@/utils/sorting'
+
+describe('sortItemListByIds TEST', (): void => {
+  const itemList = [
+    { id: '1' },
+    { id: '4' },
+    { id: '2' },
+    { id: '3' },
+    { id: '13' },
+    { id: '23' },
+    { id: '33' },
+    { id: '43' },
+  ]
+
+  it('test case 1', async () => {
+    const result = sortItemListByIds(itemList, ['1', '3'], 2)
+    expect(result).toEqual([{ id: '1' }, { id: '3' }])
+  })
+
+  it('test case 2', async () => {
+    const result = sortItemListByIds(itemList, ['1', '3', '2'], 2)
+    expect(result).toEqual([{ id: '1' }, { id: '3' }])
+  })
+
+  it('test case 3', async () => {
+    const result = sortItemListByIds(itemList, ['3', '1', '2', '4', '13'], 3)
+    expect(result).toEqual([{ id: '3' }, { id: '1' }, { id: '2' }])
+  })
+
+  it('test case 3', async () => {
+    const result = sortItemListByIds(itemList, ['3', '1', '2', '4', '13'], 5)
+    expect(result).toEqual([
+      { id: '3' },
+      { id: '1' },
+      { id: '2' },
+      { id: '4' },
+      { id: '13' },
+    ])
+  })
+})

--- a/utils/sorting.ts
+++ b/utils/sorting.ts
@@ -20,3 +20,21 @@ export const sortedEventByDate = (
   }
   return events
 }
+
+export const sortItemListByIds = (
+  itemList: { id: string }[],
+  ids: string[],
+  limit = 10
+) => {
+  let count = 0
+  const dataMap = new Map(itemList.map((item) => [item.id, item]))
+  const sortedList: { id: string }[] = []
+  for (let i = 0; i < ids.length && count < limit; i++) {
+    const item = dataMap.get(ids[i])
+    if (item) {
+      sortedList.push(item)
+      count += 1
+    }
+  }
+  return sortedList
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #2873
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [x] I found edge cases
- [x] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
