### PR TITLE
fix: replace gmt with umt in history date column

### DIFF
--- a/components/rmrk/Gallery/History.vue
+++ b/components/rmrk/Gallery/History.vue
@@ -327,9 +327,10 @@ export default class History extends mixins(ChainMixin, KeyboardEventsMixin) {
   }
 
   protected parseDate(date: Date): string {
-    const utcDate: string = date.toUTCString()
-    // toUTCString() prints GMT for historical compatibility
-    return utcDate.substring(4).replace('GMT', 'UTC')
+    return date.toLocaleString('en-GB', {
+      timeZone: 'UTC',
+      timeZoneName: 'short',
+    })
   }
 
   protected getBlockUrl(block: string): string {

--- a/components/rmrk/Gallery/History.vue
+++ b/components/rmrk/Gallery/History.vue
@@ -328,7 +328,8 @@ export default class History extends mixins(ChainMixin, KeyboardEventsMixin) {
 
   protected parseDate(date: Date): string {
     const utcDate: string = date.toUTCString()
-    return utcDate.substring(4)
+    // toUTCString() prints GMT for historical compatibility
+    return utcDate.substring(4).replace('GMT', 'UTC')
   }
 
   protected getBlockUrl(block: string): string {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

<img width="485" alt="Screenshot 2022-05-08 at 18 24 19" src="https://user-images.githubusercontent.com/17953978/167306033-104804fc-4b18-4151-b848-e50d803dc9e1.png">

### What's new?

- [x] PR closes #1161
- [x] for historical compatability reasons `toUTCString()` prints `GMT` at the end of the string -> therefore use replace function as you cannot pass any parameters to `toUTCString` call to control its behaviour
https://www.nhc.noaa.gov/aboututc.shtml#:~:text=Prior%20to%201972%2C%20this%20time,%22%20or%20%22Zulu%20Time%22.

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/gallery/10679597-0a8ce195286c168f19-DONKEY-DONKEY_GANG_391-0000000000000391>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
