### PR TITLE
feat(1818): sales table for better engagement

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -92,6 +92,7 @@
           <b-navbar-item tag="nuxt-link" to="/series-insight">
             Series
           </b-navbar-item>
+          <b-navbar-item tag="nuxt-link" to="/sales"> Sales </b-navbar-item>
         </template>
       </b-navbar-dropdown>
       <LazyChainSelect class="custom-navbar-item" id="NavChainSelect" />

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -16,10 +16,22 @@
         header-class="front-stack-layer"
         cell-class="is-vcentered">
         <div class="image is-48x48">
-          <BasicImage
-            :src="props.row.image"
-            :alt="props.row.name"
-            rounded="true" />
+          <nuxt-link :to="`/rmrk/gallery/${props.row.id}`">
+            <BasicPopup>
+              <template #trigger>
+                <BasicImage
+                  :src="props.row.image"
+                  :alt="props.row.name"
+                  :rounded="true" />
+              </template>
+              <template #content>
+                <BasicImage
+                  :src="props.row.image"
+                  :alt="props.row.name"
+                  class="popup-image" />
+              </template>
+            </BasicPopup>
+          </nuxt-link>
         </div>
       </b-table-column>
 
@@ -96,6 +108,7 @@ const components = {
   Money: () => import('@/components/shared/format/Money.vue'),
   Loader: () => import('@/components/shared/Loader.vue'),
   BasicImage: () => import('@/components/shared/view/BasicImage.vue'),
+  BasicPopup: () => import('@/components/shared/view/BasicPopup.vue'),
 }
 
 @Component({ components })
@@ -166,5 +179,9 @@ export default class SalesTable extends mixins(PrefixMixin) {
 
 .front-stack-layer {
   z-index: 1;
+}
+.popup-image {
+  width: 300px;
+  height: 300px;
 }
 </style>

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -16,13 +16,10 @@
         header-class="front-stack-layer"
         cell-class="is-vcentered">
         <div class="image is-48x48">
-          <b-image
+          <BasicImage
             :src="props.row.image"
-            placeholder="~/assets/K_dot_x2.png"
-            src-fallback="~/assets/K_dot_x2.png"
-            ratio="1by1"
-            rounded />
-          <!-- <b-skeleton :active="isLoading" circle width="48px" height="48px" /> -->
+            :alt="props.row.name"
+            rounded="true" />
         </div>
       </b-table-column>
 
@@ -98,6 +95,7 @@ const components = {
   Identity: () => import('@/components/shared/format/Identity.vue'),
   Money: () => import('@/components/shared/format/Money.vue'),
   Loader: () => import('@/components/shared/Loader.vue'),
+  BasicImage: () => import('@/components/shared/view/BasicImage.vue'),
 }
 
 @Component({ components })

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -121,7 +121,7 @@ export default class SalesTable extends mixins(PrefixMixin) {
     await this.fetchSalesFeed()
   }
 
-  protected paseDate(ts: number): string {
+  protected parseDate(ts: number): string {
     return new Date(ts).toLocaleString('en-GB', {
       timeZone: 'UTC',
       timeZoneName: 'short',
@@ -148,7 +148,7 @@ export default class SalesTable extends mixins(PrefixMixin) {
     salesFeed.forEach((nft, idx) => {
       nft.idx = idx + 1
       nft.image = sanitizeIpfsUrl(nft.image)
-      nft.date = this.paseDate(Number(nft.timestamp))
+      nft.date = this.parseDate(Number(nft.timestamp))
       nft.relDate = formatDistanceToNow(Number(nft.timestamp), {
         addSuffix: true,
       })

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -97,7 +97,7 @@
 
 <script lang="ts">
 import { Component, mixins } from 'nuxt-property-decorator'
-import { RowSeries } from './types'
+import { RowSales } from './types'
 import salesFeedGql from '@/queries/rmrk/subsquid/salesFeed.graphql'
 import { sanitizeIpfsUrl } from '@/components/rmrk/utils'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
@@ -115,7 +115,7 @@ const components = {
 
 @Component({ components })
 export default class SalesTable extends mixins(PrefixMixin) {
-  protected data: RowSeries[] = []
+  protected data: RowSales[] = []
 
   async fetch() {
     await this.fetchSalesFeed()

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -158,10 +158,9 @@ export default class SalesTable extends mixins(PrefixMixin) {
   }
 }
 </script>
-<style lang="scss">
+<style lang="scss" scoped>
 @import '@/styles/variables';
 
-/* ??? global */
 .b-radio.is-selected {
   color: #000;
   background-color: $primary;

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -85,14 +85,11 @@
 </template>
 
 <script lang="ts">
-import { Component, mixins, Watch } from 'nuxt-property-decorator'
-import { RowSeries, SortType, BuyHistory } from './types'
+import { Component, mixins } from 'nuxt-property-decorator'
+import { RowSeries } from './types'
 import salesFeedGql from '@/queries/rmrk/subsquid/salesFeed.graphql'
-import { NFTMetadata, Collection } from '../rmrk/service/scheme'
 import { sanitizeIpfsUrl } from '@/components/rmrk/utils'
-import { exist } from '@/components/rmrk/Gallery/Search/exist'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
-import formatISO9075 from 'date-fns/formatISO9075'
 import { urlBuilderBlockNumber } from '@/utils/explorerGuide'
 
 import PrefixMixin from '~/utils/mixins/prefixMixin'
@@ -109,6 +106,13 @@ export default class SalesTable extends mixins(PrefixMixin) {
 
   async fetch() {
     await this.fetchSalesFeed()
+  }
+
+  protected paseDate(ts: number): string {
+    return new Date(ts).toLocaleString('en-GB', {
+      timeZone: 'UTC',
+      timeZoneName: 'short',
+    })
   }
 
   protected getBlockUrl(block: string): string {
@@ -131,7 +135,7 @@ export default class SalesTable extends mixins(PrefixMixin) {
     salesFeed.forEach((nft, idx) => {
       nft.idx = idx + 1
       nft.image = sanitizeIpfsUrl(nft.image)
-      nft.date = formatISO9075(Number(nft.timestamp))
+      nft.date = this.paseDate(Number(nft.timestamp))
       nft.relDate = formatDistanceToNow(Number(nft.timestamp), {
         addSuffix: true,
       })

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -1,0 +1,168 @@
+<template>
+  <div>
+    <Loader :value="$fetchState.pending" />
+    <b-table :data="data" hoverable class="series-sticky-header">
+      <b-table-column
+        v-slot="props"
+        cell-class="is-vcentered"
+        field="idx"
+        label="N°">
+        {{ props.row.idx }}
+      </b-table-column>
+      <b-table-column
+        v-slot="props"
+        field="image"
+        label=""
+        header-class="front-stack-layer"
+        cell-class="is-vcentered">
+        <div class="image is-48x48">
+          <b-image
+            :src="props.row.image"
+            placeholder="~/assets/K_dot_x2.png"
+            src-fallback="~/assets/K_dot_x2.png"
+            ratio="1by1"
+            rounded />
+          <!-- <b-skeleton :active="isLoading" circle width="48px" height="48px" /> -->
+        </div>
+      </b-table-column>
+
+      <b-table-column
+        v-slot="props"
+        cell-class="is-vcentered"
+        field="name"
+        label="Name">
+        <nuxt-link :to="`/rmrk/gallery/${props.row.id}`">
+          {{ props.row.name }}
+        </nuxt-link>
+      </b-table-column>
+      <b-table-column
+        v-slot="props"
+        cell-class="is-vcentered"
+        field="collectionId"
+        label="Collection">
+        <nuxt-link :to="`/rmrk/collection/${props.row.collectionId}`">
+          {{ props.row.collectionName }}
+        </nuxt-link>
+      </b-table-column>
+      <b-table-column
+        v-slot="props"
+        cell-class="is-vcentered"
+        field="buyer"
+        label="Buyer">
+        <nuxt-link :to="`/rmrk/u/${props.row.buyer}`">
+          <Identity :address="props.row.buyer" inline noOverflow />
+        </nuxt-link>
+      </b-table-column>
+
+      <b-table-column
+        v-slot="props"
+        cell-class="is-vcentered"
+        field="timestamp"
+        label="Relative Date">
+        <b-tooltip :label="props.row.date">
+          <a :href="getBlockUrl(props.row.blockNumber)" target="_blank">
+            {{ props.row.relDate }}
+          </a>
+        </b-tooltip>
+      </b-table-column>
+
+      <b-table-column
+        v-slot="props"
+        cell-class="is-vcentered"
+        field="salePrice"
+        label="Price of sale">
+        <Money :value="props.row.salePrice" inline />
+      </b-table-column>
+
+      <template #empty>
+        <div v-if="!$fetchState.pending" class="has-text-centered">
+          {{ $t('spotlight.empty') }}
+        </div>
+        <b-skeleton :active="$fetchState.pending" />
+      </template>
+    </b-table>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, mixins, Watch } from 'nuxt-property-decorator'
+import { RowSeries, SortType, BuyHistory } from './types'
+import salesFeedGql from '@/queries/rmrk/subsquid/salesFeed.graphql'
+import { NFTMetadata, Collection } from '../rmrk/service/scheme'
+import { sanitizeIpfsUrl } from '@/components/rmrk/utils'
+import { exist } from '@/components/rmrk/Gallery/Search/exist'
+import formatDistanceToNow from 'date-fns/formatDistanceToNow'
+import formatISO9075 from 'date-fns/formatISO9075'
+import { urlBuilderBlockNumber } from '@/utils/explorerGuide'
+
+import PrefixMixin from '~/utils/mixins/prefixMixin'
+
+const components = {
+  Identity: () => import('@/components/shared/format/Identity.vue'),
+  Money: () => import('@/components/shared/format/Money.vue'),
+  Loader: () => import('@/components/shared/Loader.vue'),
+}
+
+@Component({ components })
+export default class SalesTable extends mixins(PrefixMixin) {
+  protected data: RowSeries[] = []
+
+  async fetch() {
+    await this.fetchSalesFeed()
+  }
+
+  protected getBlockUrl(block: string): string {
+    return urlBuilderBlockNumber(
+      block,
+      this.$store.getters['explorer/getCurrentChain'],
+      'subscan'
+    )
+  }
+
+  public async fetchSalesFeed() {
+    const {
+      data: { salesFeed },
+    } = await this.$apollo.query({
+      query: salesFeedGql,
+      client: this.client,
+      variables: {},
+    })
+
+    salesFeed.forEach((nft, idx) => {
+      nft.idx = idx + 1
+      nft.image = sanitizeIpfsUrl(nft.image)
+      nft.date = formatISO9075(Number(nft.timestamp))
+      nft.relDate = formatDistanceToNow(Number(nft.timestamp), {
+        addSuffix: true,
+      })
+    })
+
+    this.data = salesFeed
+  }
+}
+</script>
+<style lang="scss">
+@import '@/styles/variables';
+
+/* ??? global */
+.b-radio.is-selected {
+  color: #000;
+  background-color: $primary;
+}
+
+.history {
+  width: 200px;
+  height: 100px;
+}
+
+.series-sticky-header th {
+  top: 120px;
+  position: sticky;
+  background: $frosted-glass-background;
+  backdrop-filter: $frosted-glass-backdrop-filter;
+}
+
+.front-stack-layer {
+  z-index: 1;
+}
+</style>

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -17,7 +17,7 @@
         cell-class="is-vcentered">
         <div class="image is-48x48">
           <nuxt-link :to="`/rmrk/gallery/${props.row.id}`">
-            <BasicPopup>
+            <BasicPopup placement="top">
               <template #trigger>
                 <BasicImage
                   :src="props.row.image"
@@ -68,11 +68,13 @@
         cell-class="is-vcentered"
         field="timestamp"
         label="Relative Date">
-        <b-tooltip :label="props.row.date">
-          <a :href="getBlockUrl(props.row.blockNumber)" target="_blank">
-            {{ props.row.relDate }}
-          </a>
-        </b-tooltip>
+        <div>
+          <b-tooltip :label="props.row.date">
+            <a :href="getBlockUrl(props.row.blockNumber)" target="_blank">
+              {{ props.row.relDate }}
+            </a>
+          </b-tooltip>
+        </div>
       </b-table-column>
 
       <b-table-column

--- a/components/sales/types.ts
+++ b/components/sales/types.ts
@@ -1,0 +1,19 @@
+export interface SubsquidSalesFeed {
+  id: string
+  buyer: string
+  collectionId: string
+  collectionName: string
+  image: string | null
+  issuer: string
+  name: string
+  salePrice: string
+  timestamp: string
+  blockNumber: string
+}
+
+export interface RowSales extends SubsquidSalesFeed {
+  idx: Int
+  image: string
+  date: Date
+  relDate: string
+}

--- a/components/shared/view/BasicPopup.vue
+++ b/components/shared/view/BasicPopup.vue
@@ -19,8 +19,8 @@ import { Component, Prop, Vue } from 'nuxt-property-decorator'
 
 @Component({})
 export default class BasicPopup extends Vue {
-  @Prop({ default: () => [100, 800] }) delay: [number, number]
-  @Prop({ default: 'bottom', type: String }) placement: string
+  @Prop({ default: () => [100, 800] }) delay?: [number, number]
+  @Prop({ type: String, default: 'bottom' }) placement?: string
 }
 </script>
 

--- a/components/shared/view/BasicPopup.vue
+++ b/components/shared/view/BasicPopup.vue
@@ -3,7 +3,7 @@
     class="tippy-container"
     interactive
     :animate-fill="false"
-    placement="bottom"
+    :placement="placement"
     :delay="delay">
     <template v-slot:trigger>
       <slot name="trigger" />
@@ -19,7 +19,8 @@ import { Component, Prop, Vue } from 'nuxt-property-decorator'
 
 @Component({})
 export default class BasicPopup extends Vue {
-  @Prop({ default: [100, 800] }) delay: [number, number]
+  @Prop({ default: () => [100, 800] }) delay: [number, number]
+  @Prop({ default: 'bottom', type: String }) placement: string
 }
 </script>
 

--- a/components/shared/view/BasicPopup.vue
+++ b/components/shared/view/BasicPopup.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-tippy
+    class="tippy-container"
+    interactive
+    :animate-fill="false"
+    placement="bottom"
+    :delay="delay">
+    <template v-slot:trigger>
+      <slot name="trigger" />
+    </template>
+    <div class="popover-content-container p-4 ms-dos-shadow">
+      <slot name="content" />
+    </div>
+  </v-tippy>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+
+@Component({})
+export default class BasicPopup extends Vue {
+  @Prop({ default: [100, 800] }) delay: [number, number]
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles/variables';
+
+.tippy-container {
+  width: 100%;
+  display: inline-block;
+}
+
+.popover-content-container {
+  border: 2px solid $primary;
+  max-width: 350px;
+}
+
+.break-word {
+  overflow-wrap: break-word;
+}
+
+.ms-dos-shadow {
+  box-shadow: $dropdown-content-shadow;
+}
+</style>

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -523,6 +523,11 @@
     "showQr": "Show QR",
     "collectedFromCreator": "Collected {0} NFT(s) from this creator"
   },
+  "sales": {
+    "page": "Sales",
+    "title": "Latest KUSAMA Sales",
+    "subtitle": "Featuring the recent sold nfts on RMRK."
+  },
   "spotlight": {
     "page": "Spotlight",
     "title": "User Spotlight",

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -526,7 +526,7 @@
   "sales": {
     "page": "Sales",
     "title": "Latest KUSAMA Sales",
-    "subtitle": "Featuring the recent sold nfts on RMRK."
+    "subtitle": "Featuring the most recently sold NFTs on RMRK."
   },
   "spotlight": {
     "page": "Spotlight",

--- a/pages/sales.vue
+++ b/pages/sales.vue
@@ -1,0 +1,49 @@
+<template>
+  <section>
+    <div class="columns">
+      <div class="column is-four-fifths">
+        <h1 class="title is-2">{{ $t('sales.title') }}</h1>
+        <p class="subtitle is-size-5">{{ $t('sales.subtitle') }}</p>
+      </div>
+      <div class="column">
+        <img
+          src="~/assets/rmrk-logo-pink-faded.png"
+          alt="RMRK"
+          class="rmrk-logo is-hidden-mobile" />
+      </div>
+    </div>
+
+    <!-- <SeriesTable /> -->
+  </section>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+
+@Component<Sales>({
+  components: {
+    Identity: () => import('@/components/shared/format/Identity.vue'),
+    // SeriesTable: () => import('@/components/series/SeriesTable.vue'),
+  },
+  head() {
+    const title = 'NFT recent sold'
+    const metaData = {
+      title,
+      type: 'profile',
+      description: 'Discover new artists based on ranking',
+      url: './sales.vue',
+      image: `${this.$config.baseUrl}/k_card_series.png`,
+    }
+    return {
+      title,
+      meta: [...this.$seoMeta(metaData)],
+    }
+  },
+})
+export default class Sales extends Vue {}
+</script>
+
+<style scoped lang="scss">
+.rmrk-logo {
+  aspect-ratio: 127 / 42;
+}
+</style>

--- a/pages/sales.vue
+++ b/pages/sales.vue
@@ -22,14 +22,13 @@ import { Component, Vue } from 'nuxt-property-decorator'
 @Component<Sales>({
   components: {
     Identity: () => import('@/components/shared/format/Identity.vue'),
-    // SeriesTable: () => import('@/components/series/SeriesTable.vue'),
   },
   head() {
-    const title = 'NFT recent sold'
+    const title = 'Latest KUSAMA Sales'
     const metaData = {
       title,
       type: 'profile',
-      description: 'Discover new artists based on ranking',
+      description: 'Featuring the most recently sold NFTs on RMRK.',
       url: './sales.vue',
       image: `${this.$config.baseUrl}/k_card_series.png`,
     }

--- a/pages/sales.vue
+++ b/pages/sales.vue
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <!-- <SeriesTable /> -->
+    <SalesTable />
   </section>
 </template>
 <script lang="ts">

--- a/queries/rmrk/subsquid/salesFeed.graphql
+++ b/queries/rmrk/subsquid/salesFeed.graphql
@@ -1,0 +1,14 @@
+query SalesFeed {
+  salesFeed {
+    id
+    buyer
+    collectionId
+    collectionName
+    image
+    issuer
+    name
+    salePrice
+    timestamp
+    blockNumber
+  }
+}


### PR DESCRIPTION
- feat: page for sale engagement
- feat: saels feed query
- feat: init page for sales
- refactor: update time format
- refactor: using basic image
- feat: popup for larger nft image

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #1818
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer?target=DaWoVNNhBTdqJ5iPN3UcaLeamkPpJeGWdrs8LhvX9TQbadc)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://user-images.githubusercontent.com/11361147/168976669-27c02ae0-cebc-4bc2-a545-fcc6d7363153.png)


https://user-images.githubusercontent.com/11361147/168977069-7b0001b9-cfca-4a2f-97fc-84d920dbfd29.mov
