### PR TITLE
Creative minting with GPT-3

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -76,6 +76,14 @@
               {{ $t('simple') }}
             </b-navbar-item>
           </b-tooltip>
+          <b-tooltip
+            label="Simplified process to create your NFT in a single step"
+            position="is-right"
+            style="display: block">
+            <b-navbar-item tag="nuxt-link" :to="`/${urlPrefix}/creative`">
+              {{ $t('creative') }}
+            </b-navbar-item>
+          </b-tooltip>
         </template>
       </b-navbar-dropdown>
       <b-navbar-item tag="nuxt-link" :to="`/${urlPrefix}/explore`">

--- a/components/rmrk/Create/CreativeMint.vue
+++ b/components/rmrk/Create/CreativeMint.vue
@@ -1,0 +1,271 @@
+<template>
+  <section>
+    <br />
+    <Loader v-model="isLoading" :status="status" />
+    <div class="box">
+      <p class="title is-size-3">
+        <!-- {{ $t('mint.context') }} -->
+        Creative Minting
+      </p>
+      <p class="subtitle is-size-7">{{ $t('general.using') }} {{ version }}</p>
+      <b-field>
+        <div>
+          {{ $t('computed id') }}: <b>{{ rmrkId }}</b>
+        </div>
+      </b-field>
+      <AuthField />
+
+      <MetadataUpload
+        v-model="file"
+        label="Drop your NFT here or click to upload or simply paste image from clipboard. We support various media types (BMP, GIF, JPEG, PNG, SVG, TIFF, WEBP, MP4, OGV, QUICKTIME, WEBM, GLB, FLAC, MP3, JSON)"
+        expanded
+        preview />
+
+      <LabeledText label="mint.nft.name.label" class="mb-2">
+        {{ rmrkMint.name }}
+      </LabeledText>
+
+      <LabeledText label="mint.nft.description.label">
+        {{ rmrkMint.description }}
+      </LabeledText>
+
+      <BasicNumberInput
+        v-model="rmrkMint.max"
+        key="edition"
+        class="mt-5"
+        :label="$t('mint.nft.edition.label')"
+        :message="$t('mint.nft.edition.message')"
+        :placeholder="$t('mint.nft.edition.placeholder')"
+        expanded />
+
+      <BalanceInput :step="0.1" @input="updateMeta" label="Price" expanded />
+      <div class="content mt-3">
+        <p>
+          Hint: Setting the price now requires making an additional transaction.
+        </p>
+      </div>
+
+      <SubmitButton
+        label="mint.submit"
+        :disabled="disabled"
+        :loading="isLoading"
+        @click="sub" />
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { uploadDirect } from '@/utils/directUpload'
+import { emptyObject } from '@/utils/empty'
+import ChainMixin from '@/utils/mixins/chainMixin'
+import RmrkVersionMixin from '@/utils/mixins/rmrkVersionMixin'
+import { notificationTypes, showNotification } from '@/utils/notification'
+import { pinFileToIPFS, pinJson, PinningKey } from '@/utils/pinning'
+import {
+  basicUpdateNameFunction,
+  createCollection,
+  createMetadata,
+  createMintInteaction,
+  createMultipleNFT,
+  Interaction,
+  makeSymbol,
+  mapAsSystemRemark, toCollectionId, unSanitizeIpfsUrl
+} from '@kodadot1/minimark'
+import Connector from '@kodadot1/sub-api'
+import { Component, mixins, Watch } from 'nuxt-property-decorator'
+import AuthMixin from '~/utils/mixins/authMixin'
+import MetaTransactionMixin from '~/utils/mixins/metaMixin'
+import shouldUpdate from '~/utils/shouldUpdate'
+import {
+  getNftId,
+  NFT,
+  NFTMetadata,
+  SimpleNFT
+} from '../service/scheme'
+import { MediaType } from '../types'
+import { resolveMedia, sanitizeImage, sanitizeIpfsUrl } from '../utils'
+import { askGpt } from '@/utils/gpt'
+
+const components = {
+  AuthField: () => import('@/components/shared/form/AuthField.vue'),
+  MetadataUpload: () => import('./DropUpload.vue'),
+  LabeledText: () => import('@/components/shared/gallery/LabeledText.vue'),
+  SubmitButton: () => import('@/components/base/SubmitButton.vue'),
+  BasicNumberInput: () =>
+    import('@/components/shared/form/BasicNumberInput.vue'),
+}
+
+@Component<CreativeMint>({
+  components,
+})
+export default class CreativeMint extends mixins(
+  RmrkVersionMixin,
+  MetaTransactionMixin,
+  ChainMixin,
+  AuthMixin,
+) {
+  private rmrkMint: SimpleNFT = {
+    ...emptyObject<SimpleNFT>(),
+    max: 1,
+    symbol: makeSymbol(),
+  }
+  private meta: NFTMetadata = emptyObject<NFTMetadata>()
+  private file: File | null = null
+  private price = 0
+  private fileHash = ''
+
+  layout() {
+    return 'centered-half-layout'
+  }
+
+  protected updateMeta(value: number): void {
+    this.price = value
+  }
+
+  get fileType(): MediaType {
+    return resolveMedia(this.file?.type)
+  }
+
+  get rmrkId(): string {
+    return toCollectionId(this.accountId, this.rmrkMint.symbol)
+  }
+
+  get canCalculateTransactionFees(): boolean {
+    const { name, symbol, max } = this.rmrkMint
+    return !!(this.price && name && symbol && max)
+  }
+
+  get disabled(): boolean {
+    const { name, symbol, max } = this.rmrkMint
+    return !(name && symbol && max && this.accountId && this.file)
+  }
+
+  protected async sub(): Promise<void> {
+    this.isLoading = true
+    this.status = 'loader.ipfs'
+    const { api } = Connector.getInstance()
+
+    try {
+      const meta = await this.constructMeta()
+      this.rmrkMint.metadata = meta || ''
+
+      const collection = createCollection(
+        this.accountId,
+        this.rmrkMint.symbol,
+        this.rmrkMint.name,
+        this.rmrkMint.metadata,
+        0
+      )
+
+      const nftList = createMultipleNFT(
+        this.rmrkMint.max,
+        this.accountId,
+        collection.id,
+        this.rmrkMint.name,
+        this.rmrkMint.metadata,
+        0,
+        basicUpdateNameFunction
+      )
+
+      const toRemark = mapAsSystemRemark(api)
+
+      const collectionRemark = createMintInteaction(
+        Interaction.MINT,
+        this.version,
+        collection
+      )
+
+      const mint = nftList.map((nft) =>
+        createMintInteaction(Interaction.MINTNFT, this.version, nft)
+      )
+
+      const cb = api.tx.utility.batchAll
+      const args = [toRemark(collectionRemark), ...mint.map(toRemark)]
+
+      await this.howAboutToExecute(
+        this.accountId,
+        cb,
+        [args],
+        (blockNumber) => {
+          showNotification(
+            `[NFT] Saved ${this.rmrkMint.name} in block ${blockNumber}`,
+            notificationTypes.success
+          )
+        }
+      )
+    } catch (e) {
+      if (e instanceof Error) {
+        showNotification(e.toString(), notificationTypes.danger)
+        this.isLoading = false
+      }
+    }
+  }
+
+  public async constructMeta(): Promise<string | undefined> {
+    const { file, rmrkMint, meta: m } = this
+    if (!file) {
+      throw new ReferenceError('No file found!')
+    }
+
+    const { token }: PinningKey = await this.$store.dispatch(
+      'pinning/fetchPinningKey',
+      this.accountId
+    )
+
+    const fileHash = await pinFileToIPFS(file, token)
+
+    let imageHash: string | undefined = fileHash
+    let animationUrl: string | undefined = undefined
+
+    const attributes = []
+
+    const meta = createMetadata(
+      rmrkMint.name,
+      m.description || '',
+      imageHash,
+      animationUrl,
+      attributes,
+      'https://kodadot.xyz',
+      file.type
+    )
+
+    const metaHash = await pinJson(meta, imageHash)
+
+    if (file) {
+      uploadDirect(file, metaHash).catch(this.$consola.warn)
+    }
+    return unSanitizeIpfsUrl(metaHash)
+  }
+
+  protected navigateToDetail(nft: NFT, blockNumber: string) {
+    showNotification('You will go to the detail in 2 seconds')
+    const go = () =>
+      this.$router.push({
+        path: `/rmrk/detail/${getNftId(nft, blockNumber)}`,
+        query: { message: 'congrats' },
+      })
+    setTimeout(go, 2000)
+  }
+
+  @Watch('file')
+  protected onFileChange(file: File | null, oldFile: File | null) {
+    if (shouldUpdate(file, oldFile) && file) {
+      this.uploadFile(file)
+      this.fileHash = ''
+    }
+  }
+
+  protected async uploadFile(file: File) {
+        const { token }: PinningKey = await this.$store.dispatch(
+      'pinning/fetchPinningKey',
+      this.accountId
+    )
+
+     this.fileHash = await pinFileToIPFS(file, token)
+     const url = sanitizeIpfsUrl(unSanitizeIpfsUrl(this.fileHash))
+     const { title, description } = await askGpt(url)
+     this.$set(this.rmrkMint, 'name', title)
+     this.$set(this.rmrkMint, 'description', description)
+  }
+}
+</script>

--- a/components/shared/form/AuthField.vue
+++ b/components/shared/form/AuthField.vue
@@ -1,0 +1,17 @@
+<template>
+  <b-field>
+    <Auth />
+  </b-field>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+
+const components = {
+  Auth: () => import('@/components/shared/Auth.vue')
+}
+
+@Component({ components })
+export default class AuthField extends Vue {
+}
+</script>

--- a/components/shared/form/BasicNumberInput.vue
+++ b/components/shared/form/BasicNumberInput.vue
@@ -22,7 +22,7 @@
 import { Component, Prop, VModel, Vue } from 'nuxt-property-decorator'
 
 @Component
-export default class BasicInput extends Vue {
+export default class BasicNumberInput extends Vue {
   // Dev: make vValue required
   @VModel({ type: Number }) vValue!: number
   @Prop({ type: String, required: true }) label!: string

--- a/components/shared/gallery/LabeledText.vue
+++ b/components/shared/gallery/LabeledText.vue
@@ -4,9 +4,8 @@
       {{ $t(label) }}
     </p>
     <p class="subtitle is-size-6">
-      <slot>
-        <b-skeleton :active="isLoading"></b-skeleton>
-      </slot>
+      <slot v-if="!isLoading">~</slot>
+      <b-skeleton :active="isLoading"></b-skeleton>
     </p>
   </div>
 </template>

--- a/components/shared/gallery/LabeledText.vue
+++ b/components/shared/gallery/LabeledText.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <p class="label">
+      {{ $t(label) }}
+    </p>
+    <p class="subtitle is-size-6">
+      <slot>
+        <b-skeleton :active="isLoading"></b-skeleton>
+      </slot>
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+
+@Component({})
+export default class LabeledText extends Vue {
+  @Prop({ type: String, required: true, default: 'general.label' })
+  public label!: string
+  @Prop({ type: Boolean, default: false })
+  public isLoading!: string
+
+}
+</script>

--- a/pages/rmrk/creative.vue
+++ b/pages/rmrk/creative.vue
@@ -1,0 +1,33 @@
+<template>
+  <CreativeMint />
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import CreativeMint from '@/components/rmrk/Create/CreativeMint.vue'
+
+@Component({
+  components: {
+    CreativeMint,
+  },
+  head() {
+    const title = 'KodaDot | Low fees and low carbon minting'
+    const metaData = {
+      title,
+      type: 'article',
+      description: 'Create carbonless NFTs with low on-chain fees',
+      url: '/mint',
+      image: `${this.$config.baseUrl}/k_card_mint.png`,
+    }
+    return {
+      title,
+      meta: [...this.$seoMeta(metaData)],
+    }
+  },
+})
+export default class CreativeMintPage extends Vue {
+  layout() {
+    return 'centered-half-layout'
+  }
+}
+</script>

--- a/pages/rmrk/mint.vue
+++ b/pages/rmrk/mint.vue
@@ -25,5 +25,9 @@ import SimpleMint from '@/components/rmrk/Create/SimpleMint.vue'
     }
   },
 })
-export default class SimpleMintPage extends Vue {}
+export default class SimpleMintPage extends Vue {
+  layout() {
+    return 'centered-half-layout'
+  }
+}
 </script>

--- a/utils/gpt.ts
+++ b/utils/gpt.ts
@@ -1,0 +1,22 @@
+import Axios from 'axios'
+
+export const BASE_URL = '' // TODO: @petersopko
+
+const api = Axios.create({
+  baseURL: BASE_URL,
+})
+
+export type GptResponse = {
+	title: string,
+	description: string,
+}
+
+export const askGpt = async (url: string) => {
+  // const { status, data } = await api.get<GptResponse>(`askGpt/${url}`)
+  // console.log(status)
+  const data: GptResponse = {
+    title: 'Very good title',
+    description: `Very good ${url}`,
+  }
+  return data
+}

--- a/utils/gpt.ts
+++ b/utils/gpt.ts
@@ -1,6 +1,6 @@
 import Axios from 'axios'
 
-export const BASE_URL = '' // TODO: @petersopko
+export const BASE_URL = 'https://petersopko.api.stdlib.com/imagedescription@dev/' // TODO: @petersopko
 
 const api = Axios.create({
   baseURL: BASE_URL,
@@ -12,11 +12,7 @@ export type GptResponse = {
 }
 
 export const askGpt = async (url: string) => {
-  // const { status, data } = await api.get<GptResponse>(`askGpt/${url}`)
-  // console.log(status)
-  const data: GptResponse = {
-    title: 'Very good title',
-    description: `Very good ${url}`,
-  }
+  const { status, data } = await api.post<GptResponse>('titleDescriptionGenerator', { url })
+  console.log('[GPT::askGpt]', status)
   return data
 }


### PR DESCRIPTION
- :truck: correct name for basic number input
- :art: updated layout of simple mint
- :zap: smart wrapper over Auth component
- :zap: Labeled text is here <3
- :tada: creative mint is here
- :zap: creative mint is available under /creative
- :construction: GPT3 API WIP
- :tada: gpt-3 is here credits to @petersopko
- :zap: tweaked loading for Labeled text
- :zap: tweaked loading state for gpt
- :zap: creative minting is available in the navbar

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring

### What's new?

- [ ] PR closes #<issue_number>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
