### PR TITLE
#3124 Add nudge on preloader to sign the transaction

### DIFF
--- a/components/shared/Loader.vue
+++ b/components/shared/Loader.vue
@@ -16,6 +16,9 @@
         <figcaption v-if="status" class="loading-text">
           {{ $t(status) }}
         </figcaption>
+        <div v-if="status" class="mt-3 mb-3 has-text-primary">
+          {{ $t('helper.signStuckText') }}
+        </div>
       </figure>
     </div>
   </b-loading>

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -638,7 +638,8 @@
       "placeholder": "singular.rmrk.app/collectibles/",
       "copy": "Kodadot link successfuly copied"
     },
-    "builtOn": "Built on"
+    "builtOn": "Built on",
+    "signStuckText": "Stuck? Make sure to check for any popups and SIGN the transaction."
   },
   "cookies": {
     "notice": "We use third-party 🍪 in order to personalize your site experience",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #3124
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="641" alt="Screen Shot 2022-06-09 at 3 20 46 PM" src="https://user-images.githubusercontent.com/39299315/172955984-7a2a0594-af0c-4f55-a6fa-e5b9d18c9b24.png">
