### PR TITLE
make searchbar expand on hover

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -259,44 +259,6 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
   }
 }
 
-// Reserved for future adjustments
-
-// @media only screen and (min-width: 1215px) and (max-width: 1140px) {
-//   a#NavProfile {
-//     display: none;
-//   }
-// }
-
-// @media only screen and (min-width: 1215px) and (max-width: 1160px) {
-//   a#NavStats {
-//     display: none;
-//   }
-// }
-
-@media only screen and (min-width: 1024px) and (max-width: 1100px) {
-  div#NavHistoryBrowser {
-    display: none;
-  }
-}
-
-@media only screen and (min-width: 1024px) and (max-width: 1200px) {
-  a#NavCreate {
-    display: none;
-  }
-}
-
-@media only screen and (min-width: 1024px) and (max-width: 1250px) {
-  div#NavChainSelect {
-    display: none;
-  }
-}
-
-@media only screen and (min-width: 1024px) and (max-width: 1340px) {
-  div#NavLocaleChanger {
-    display: none;
-  }
-}
-
 @include touch {
   .navbar {
     .navbar-item,
@@ -345,6 +307,7 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
   }
 
   .navbar-item {
+    height: 40px;
     text-transform: uppercase;
     font-weight: 500;
     border-top: 1px solid $primary;
@@ -390,11 +353,46 @@ export default class NavbarMenu extends mixins(PrefixMixin) {
   .search-navbar {
     background-color: transparent;
     box-shadow: none;
-    min-width: 350px;
     margin: 0 1rem;
+    overflow: visible;
+
+    @media only screen and (min-width: $tablet) and (max-width: $widescreen) {
+      width: 140px;
+
+      .gallery-search {
+        width: 0;
+        min-width: 100%;
+        transition: width 0.3s;
+        z-index: 5;
+
+        &::after {
+          content: '';
+          width: 50px;
+          position: absolute;
+          right: -50px;
+          top: 0;
+          bottom: 0;
+          background: transparent;
+        }
+
+        .dropdown-menu {
+          min-width: 350px;
+        }
+      }
+
+      &:hover {
+        .gallery-search {
+          width: 350px;
+          &::after {
+            background: linear-gradient(90deg, rgb(41, 41, 47), transparent);
+          }
+        }
+      }
+    }
+
     input {
       border: inherit;
-      background-color: rgba(41, 41, 47, 0.5);
+      background-color: rgb(41, 41, 47);
       &::placeholder {
         color: #898991 !important;
       }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3109 
- [ ] Requires deployment <rubick/magick_issue>
- [x] 
My solution does not hide any navbar items depending on the device width (like suggested in #2760) but instead makes sure the search bar does only take minimal space and expand on hover on certain screen sizes (see screencast at bottom):

1. on > $widescreen remain the same
2. on < $tablet remain the same (collapsed navbar)
3. on $tablet to $widescreen, extend the navbar on hover as shown in the video.

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [x] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=5CwW67PPdZQQCcdWJVaRJCepSQSrtKUumDAGa7UZbBKwd9R2)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

https://user-images.githubusercontent.com/1685139/173449213-2af92f78-3845-4652-8044-e7ab626727c1.mp4

What do you think?

