### PR TITLE
Fix: falls back to english on navigate #3131

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -219,6 +219,7 @@ export default defineNuxtConfig({
   },
 
   i18n: {
+    skipSettingLocaleOnNavigate: true,
     vueI18nLoader: true,
     defaultLocale: 'en',
     detectBrowserLanguage: {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3131
- [ ] Requires deployment <rubick/magick_issue>
- [x] I've added `skipSettingLocaleOnNavigate: true` in `nuxt.config.js` to skip resetting locale on route change.

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=5H6EZuYaiU9sJ426Zbt6LPSZ2GQ8GTwYZzacxeSMje2kwjVn)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
![image](https://user-images.githubusercontent.com/11574195/173671656-6ede8f8b-8394-4efc-9f52-201187cc6249.png)

