### PR TITLE
#3225 Fixing wrong numbers

### DIFF
--- a/queries/subsquid/general/userStatsByAccount.graphql
+++ b/queries/subsquid/general/userStatsByAccount.graphql
@@ -9,13 +9,17 @@ query userStatsByAccount($account: String!) {
   }
   created: nftEntitiesConnection(
     orderBy: blockNumber_DESC
-    where: { issuer_eq: $account }
+    where: { issuer_eq: $account, burned_eq: false }
   ) {
     totalCount
   }
   collected: nftEntitiesConnection(
     orderBy: blockNumber_DESC
-    where: { issuer_not_eq: $account, currentOwner_eq: $account }
+    where: {
+      issuer_not_eq: $account
+      currentOwner_eq: $account
+      burned_eq: false
+    }
   ) {
     totalCount
     edges {
@@ -37,7 +41,11 @@ query userStatsByAccount($account: String!) {
 
   sold: nftEntitiesConnection(
     orderBy: blockNumber_DESC
-    where: { issuer_eq: $account, currentOwner_not_eq: $account }
+    where: {
+      issuer_eq: $account
+      currentOwner_not_eq: $account
+      burned_eq: false
+    }
   ) {
     totalCount
   }

--- a/queries/userStatsByAccount.graphql
+++ b/queries/userStatsByAccount.graphql
@@ -10,7 +10,9 @@ query userStatsByAccount($account: String!) {
     }
   }
 
-  created: nFTEntities(filter: { issuer: { equalTo: $account } }) {
+  created: nFTEntities(
+    filter: { issuer: { equalTo: $account }, burned: { distinctFrom: true } }
+  ) {
     totalCount
   }
 
@@ -18,6 +20,7 @@ query userStatsByAccount($account: String!) {
     filter: {
       issuer: { notEqualTo: $account }
       currentOwner: { equalTo: $account }
+      burned: { distinctFrom: true }
     }
     orderBy: BLOCK_NUMBER_DESC
     first: 1
@@ -34,6 +37,7 @@ query userStatsByAccount($account: String!) {
     filter: {
       issuer: { equalTo: $account }
       currentOwner: { notEqualTo: $account }
+      burned: { distinctFrom: true }
     }
   ) {
     totalCount


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3225
- [ ] Requires deployment <rubick/magick_issue>
- [x] So the numbers shown in tab and in the popover, they both use different queries (not sure why, maybe we can create a ticket for merging queries if possible?) , so the query for the popover was missing the burned check that was causing the count discrepancy 

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
![Screen Shot 2022-06-21 at 6 44 15 PM](https://user-images.githubusercontent.com/39299315/174925433-0db9f6b3-499e-4603-ac24-edf5e6d758b4.png)

