### PR TITLE
refactor: BlockExplorerLink component

### DIFF
--- a/components/rmrk/Gallery/History.vue
+++ b/components/rmrk/Gallery/History.vue
@@ -110,14 +110,9 @@
               :label="props.row.Date"
               position="is-right"
               append-to-body>
-              <span v-if="hasDisabledBlockUrl"> {{ props.row.Time }}</span>
-              <a
-                v-else
-                target="_blank"
-                rel="noopener noreferrer"
-                :href="getBlockUrl(props.row.Block)">
-                {{ props.row.Time }}</a
-              >
+              <BlockExplorerLink
+                :blockId="props.row.Block"
+                :text="props.row.Time" />
             </b-tooltip>
           </b-table-column>
         </b-table>
@@ -127,7 +122,6 @@
 </template>
 
 <script lang="ts">
-import { urlBuilderBlockNumber } from '@/utils/explorerGuide'
 import ChainMixin from '@/utils/mixins/chainMixin'
 import { Component, Prop, Watch, mixins } from 'nuxt-property-decorator'
 import { Interaction as EventInteraction } from '../service/scheme'
@@ -149,6 +143,7 @@ import PrefixMixin from '~/utils/mixins/prefixMixin'
 const components = {
   Identity: () => import('@/components/shared/format/Identity.vue'),
   Pagination: () => import('@/components/rmrk/Gallery/Pagination.vue'),
+  BlockExplorerLink: () => import('@/components/shared/BlockExplorerLink.vue'),
 }
 
 type TableRowItem = {
@@ -244,11 +239,6 @@ export default class History extends mixins(
 
   get isPercentageColumnVisible() {
     return [HistoryEventType.ALL, Interaction.BUY].includes(this.event)
-  }
-
-  get hasDisabledBlockUrl(): boolean {
-    const disableBlockUrlPrefix = ['bsx']
-    return disableBlockUrlPrefix.includes(this.urlPrefix)
   }
 
   get selectedEvent(): HistoryEventType {
@@ -399,14 +389,6 @@ export default class History extends mixins(
 
   private parsePrice(amount): string {
     return parseAmount(amount, this.decimals, this.unit)
-  }
-
-  protected getBlockUrl(block: string): string {
-    return urlBuilderBlockNumber(
-      block,
-      this.$store.getters['explorer/getCurrentChain'],
-      'subscan'
-    )
   }
 
   @Watch('events', { immediate: true })

--- a/components/rmrk/Gallery/Holder/Holder.vue
+++ b/components/rmrk/Gallery/Holder/Holder.vue
@@ -126,12 +126,9 @@
               :label="props.row.Date"
               position="is-right"
               append-to-body>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                :href="getBlockUrl(props.row.Block)">
-                {{ props.row.Time }}</a
-              >
+              <BlockExplorerLink
+                :text="props.row.Time"
+                :blockId="props.row.Block" />
             </b-tooltip>
           </b-table-column>
           <template slot="detail" slot-scope="props">
@@ -170,12 +167,7 @@
                   :label="item.Date"
                   position="is-right"
                   append-to-body>
-                  <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    :href="getBlockUrl(item.Block)">
-                    {{ item.Time }}</a
-                  >
+                  <BlockExplorerLink :text="item.Time" :blockId="item.Block" />
                 </b-tooltip>
               </td>
             </tr>
@@ -187,7 +179,6 @@
 </template>
 
 <script lang="ts">
-import { urlBuilderBlockNumber } from '@/utils/explorerGuide'
 import ChainMixin from '@/utils/mixins/chainMixin'
 import { Component, Prop, Watch, mixins } from 'nuxt-property-decorator'
 import { Interaction as EventInteraction } from '../../service/scheme'
@@ -200,6 +191,7 @@ import PrefixMixin from '~/utils/mixins/prefixMixin'
 
 const components = {
   Identity: () => import('@/components/shared/format/Identity.vue'),
+  BlockExplorerLink: () => import('@/components/shared/BlockExplorerLink.vue'),
 }
 
 export type NftHolderEvent = {
@@ -525,14 +517,6 @@ export default class CommonHolderTable extends mixins(
       group['Percentage'] = group['Percentage'] / group['Amount']
     })
     return customGroupsList
-  }
-
-  protected getBlockUrl(block: string): string {
-    return urlBuilderBlockNumber(
-      block,
-      this.$store.getters['explorer/getCurrentChain'],
-      'subscan'
-    )
   }
 
   @Watch('events', { immediate: true })

--- a/components/rmrk/Profile/Sales.vue
+++ b/components/rmrk/Profile/Sales.vue
@@ -72,12 +72,9 @@
               :label="props.row.Date"
               position="is-right"
               append-to-body>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                :href="getBlockUrl(props.row.Block)">
-                {{ props.row.Time }}</a
-              >
+              <BlockExplorerLink
+                :text="props.row.Time"
+                :blockId="props.row.Block" />
             </b-tooltip>
           </b-table-column>
         </b-table>
@@ -88,7 +85,6 @@
 
 <script lang="ts">
 import { DocumentNode } from 'graphql'
-import { urlBuilderBlockNumber } from '@/utils/explorerGuide'
 import formatBalance from '@/utils/formatBalance'
 import ChainMixin from '@/utils/mixins/chainMixin'
 import { Component, Prop, Watch, mixins } from 'nuxt-property-decorator'
@@ -103,6 +99,7 @@ import PrefixMixin from '~/utils/mixins/prefixMixin'
 const components = {
   Identity: () => import('@/components/shared/format/Identity.vue'),
   Pagination: () => import('@/components/rmrk/Gallery/Pagination.vue'),
+  BlockExplorerLink: () => import('@/components/shared/BlockExplorerLink.vue'),
 }
 
 type TableRowItem = {
@@ -291,14 +288,6 @@ export default class Sales extends mixins(
       timeZone: 'UTC',
       timeZoneName: 'short',
     })
-  }
-
-  protected getBlockUrl(block: string): string {
-    return urlBuilderBlockNumber(
-      block,
-      this.$store.getters['explorer/getCurrentChain'],
-      'subscan'
-    )
   }
 
   @Watch('events', { immediate: true })

--- a/components/sales/SalesTable.vue
+++ b/components/sales/SalesTable.vue
@@ -70,9 +70,9 @@
         label="Relative Date">
         <div>
           <b-tooltip :label="props.row.date">
-            <a :href="getBlockUrl(props.row.blockNumber)" target="_blank">
-              {{ props.row.relDate }}
-            </a>
+            <BlockExplorerLink
+              :text="props.row.relDate"
+              :blockId="props.row.blockNumber" />
           </b-tooltip>
         </div>
       </b-table-column>
@@ -101,7 +101,6 @@ import { RowSales } from './types'
 import salesFeedGql from '@/queries/rmrk/subsquid/salesFeed.graphql'
 import { sanitizeIpfsUrl } from '@/components/rmrk/utils'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
-import { urlBuilderBlockNumber } from '@/utils/explorerGuide'
 
 import PrefixMixin from '~/utils/mixins/prefixMixin'
 
@@ -111,6 +110,7 @@ const components = {
   Loader: () => import('@/components/shared/Loader.vue'),
   BasicImage: () => import('@/components/shared/view/BasicImage.vue'),
   BasicPopup: () => import('@/components/shared/view/BasicPopup.vue'),
+  BlockExplorerLink: () => import('@/components/shared/BlockExplorerLink.vue'),
 }
 
 @Component({ components })
@@ -126,14 +126,6 @@ export default class SalesTable extends mixins(PrefixMixin) {
       timeZone: 'UTC',
       timeZoneName: 'short',
     })
-  }
-
-  protected getBlockUrl(block: string): string {
-    return urlBuilderBlockNumber(
-      block,
-      this.$store.getters['explorer/getCurrentChain'],
-      'subscan'
-    )
   }
 
   public async fetchSalesFeed() {

--- a/components/shared/BlockExplorerLink.vue
+++ b/components/shared/BlockExplorerLink.vue
@@ -1,0 +1,40 @@
+<template>
+  <span v-if="hasDisabledBlockUrl"> {{ text }}</span>
+  <a
+    v-else
+    target="_blank"
+    rel="noopener noreferrer"
+    :href="getBlockUrl(blockId)">
+    {{ text }}
+  </a>
+</template>
+
+<script lang="ts">
+import { Component, mixins, Prop } from 'nuxt-property-decorator'
+import { urlBuilderBlockNumber } from '@/utils/explorerGuide'
+import PrefixMixin from '~/utils/mixins/prefixMixin'
+
+const components = {}
+
+@Component({ components })
+export default class BlockExplorerLink extends mixins(PrefixMixin) {
+  @Prop({ type: String, default: 'subscan' }) public provider!: string
+  @Prop({ type: String, required: true }) public blockId!: string
+  @Prop({ type: String, required: true }) public text!: string
+
+  public getBlockUrl(block: string): string {
+    return urlBuilderBlockNumber(
+      block,
+      this.$store.getters['explorer/getCurrentChain'],
+      this.provider
+    )
+  }
+
+  get hasDisabledBlockUrl(): boolean {
+    const disableBlockUrlPrefix = ['bsx']
+    return disableBlockUrlPrefix.includes(this.urlPrefix)
+  }
+}
+</script>
+
+<style scoped></style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
+    "jsx": "react",
     "esModuleInterop": true,
     "allowJs": true,
     "sourceMap": true,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3298 
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

RMRK:
history\holder\filppers...
<img width="1578" alt="image" src="https://user-images.githubusercontent.com/31397967/176328113-1ead79f6-6658-49cb-b1f3-461e1230dd93.png">

BSX:
history\holder\filppers...
<img width="1636" alt="image" src="https://user-images.githubusercontent.com/31397967/176328215-aa1011e0-a64e-4456-9664-651f89c8d4a3.png">

