### PR TITLE
fix: missing token symbol in offers table

### DIFF
--- a/components/bsx/Offer/OfferTable.vue
+++ b/components/bsx/Offer/OfferTable.vue
@@ -17,7 +17,7 @@
       :label="$t('offer.price')"
       v-slot="props"
       sortable>
-      <Money :value="props.row.price" inline hideUnit />
+      <Money :value="props.row.price" inline />
     </b-table-column>
     <b-table-column
       v-if="!isBsxStats"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3354
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1457" alt="image" src="https://user-images.githubusercontent.com/31397967/177666239-f2387570-502c-4f63-a20a-663f6985a9d1.png">

<img width="924" alt="image" src="https://user-images.githubusercontent.com/31397967/177666257-ed91f278-d8c9-4a66-aec8-2a3e8943794c.png">

<img width="1371" alt="image" src="https://user-images.githubusercontent.com/31397967/177666345-0bdd8356-a7cb-4c97-8577-c501798961af.png">

