### PR TITLE
fix: Identity at item is shown twice

### DIFF
--- a/components/shared/format/Identity.vue
+++ b/components/shared/format/Identity.vue
@@ -43,14 +43,14 @@
           >
         </template>
       </span>
-      <template v-if="!hideIdentityPopover && !showOnchainIdentity">
+      <template v-else-if="!hideIdentityPopover">
         <IdentityPopover :identity="{ ...identity, address }">
           <template #trigger>
             {{ name | toString }}
           </template>
         </IdentityPopover>
       </template>
-      <span v-if="!showOnchainIdentity">
+      <span v-else>
         {{ name | toString }}
       </span>
     </template>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3367
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

related to https://github.com/kodadot/nft-gallery/pull/3357

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="865" alt="image" src="https://user-images.githubusercontent.com/31397967/177789293-4e3bd5b3-b636-408b-b635-3622f1a5fdff.png">


<img width="362" alt="image" src="https://user-images.githubusercontent.com/31397967/177789441-b7ddcb43-94f4-4c8b-ba3c-844ac2fa9df7.png">


