### PR TITLE
chore: hide attributeinput on collection creation for now

### DIFF
--- a/components/bsx/Create/CreateCollection.vue
+++ b/components/bsx/Create/CreateCollection.vue
@@ -6,12 +6,13 @@
         <b-field class="mb-5" />
       </template>
       <template v-slot:footer>
-        <CustomAttributeInput
+        <!-- Hidden as of 11.July.2022 due to lack of convenience #3407 -->
+        <!-- <CustomAttributeInput
           :max="10"
           v-model="attributes"
           class="mb-3"
           visible="collapse.collection.attributes.show"
-          hidden="collapse.collection.attributes.hide" />
+          hidden="collapse.collection.attributes.hide" /> -->
         <b-field>
           <p class="has-text-weight-medium is-size-6 has-text-warning">
             {{ $t('mint.deposit') }}:
@@ -67,8 +68,8 @@ const components = {
   BasicSwitch: () => import('@/components/shared/form/BasicSwitch.vue'),
   SubmitButton: () => import('@/components/base/SubmitButton.vue'),
   Money: () => import('@/components/shared/format/Money.vue'),
-  CustomAttributeInput: () =>
-    import('@/components/rmrk/Create/CustomAttributeInput.vue'),
+  // CustomAttributeInput: () =>
+  //   import('@/components/rmrk/Create/CustomAttributeInput.vue'),
 }
 
 @Component({ components })

--- a/components/unique/Create/CreateCollection.vue
+++ b/components/unique/Create/CreateCollection.vue
@@ -3,12 +3,13 @@
     <Loader v-model="isLoading" :status="status" />
     <BaseCollectionForm v-bind.sync="base">
       <template v-slot:footer>
-        <CustomAttributeInput
+        <!-- Hidden as of 11.July.2022 due to lack of convenience #3407 -->
+        <!-- <CustomAttributeInput
           :max="10"
           v-model="attributes"
           class="mb-3"
           visible="collapse.collection.attributes.show"
-          hidden="collapse.collection.attributes.hide" />
+          hidden="collapse.collection.attributes.hide" /> -->
         <b-field>
           <p class="has-text-weight-medium is-size-6 has-text-warning">
             {{ $t('mint.deposit') }}:
@@ -60,8 +61,8 @@ const components = {
   BasicSwitch: () => import('@/components/shared/form/BasicSwitch.vue'),
   SubmitButton: () => import('@/components/base/SubmitButton.vue'),
   Money: () => import('@/components/shared/format/Money.vue'),
-  CustomAttributeInput: () =>
-    import('@/components/rmrk/Create/CustomAttributeInput.vue'),
+  // CustomAttributeInput: () =>
+  //   import('@/components/rmrk/Create/CustomAttributeInput.vue'),
 }
 
 @Component({ components })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] chore

### What's new?

- [x] PR closes #3407
- [ ] Requires deployment <rubick/magick_issue>
- [x] due to lack of convenience we hide it for now

<img width="774" alt="Screenshot 2022-07-11 at 19 37 36" src="https://user-images.githubusercontent.com/17953978/178324480-ea9d265a-1511-444f-98fe-8a70cf84c967.png">

### Before submitting Pull Request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </bsx/create>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
