### PR TITLE
fix: wrap transition-group element to prevent race condition

### DIFF
--- a/components/bsx/Create/CreateToken.vue
+++ b/components/bsx/Create/CreateToken.vue
@@ -13,17 +13,16 @@
           label="Price"
           expanded
           key="price"
-          value="0.1"
           @input="updatePrice"
           class="mb-3" />
-        <CustomAttributeInput
-          key="attributes"
-          v-show="base.selectedCollection"
-          :max="10"
-          v-model="attributes"
-          class="mb-3"
-          visible="collapse.collection.attributes.show"
-          hidden="collapse.collection.attributes.hide" />
+        <div v-show="base.selectedCollection" key="attributes">
+          <CustomAttributeInput
+            :max="10"
+            v-model="attributes"
+            class="mb-3"
+            visible="collapse.collection.attributes.show"
+            hidden="collapse.collection.attributes.hide" />
+        </div>
         <RoyaltyForm key="royalty" v-bind.sync="royalty" />
       </template>
       <template v-slot:footer>

--- a/components/unique/Create/CreateToken.vue
+++ b/components/unique/Create/CreateToken.vue
@@ -7,14 +7,14 @@
       :hasEdition="false">
       <template v-slot:main>
         <BasicSwitch key="nsfw" v-model="nsfw" label="mint.nfsw" />
-        <CustomAttributeInput
-          key="attributes"
-          v-show="base.selectedCollection"
-          :max="10"
-          v-model="attributes"
-          class="mb-3"
-          visible="collapse.collection.attributes.show"
-          hidden="collapse.collection.attributes.hide" />
+        <div v-show="base.selectedCollection" key="attributes">
+          <CustomAttributeInput
+            :max="10"
+            v-model="attributes"
+            class="mb-3"
+            visible="collapse.collection.attributes.show"
+            hidden="collapse.collection.attributes.hide" />
+        </div>
       </template>
       <template v-slot:footer>
         <b-field key="advanced">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

<img width="812" alt="Screenshot 2022-07-15 at 17 08 09" src="https://user-images.githubusercontent.com/17953978/179252452-18c364b9-e57d-4063-9841-b397058df572.png">

### What's new?

- [x] PR closes #3444
- [ ] Requires deployment <rubick/magick_issue>
- [x] according to this known issue https://github.com/vuejs/vue/issues/8516 , transition group elements that require async component imports, v-for loops and conditional rendering may result in race conditions. it is therefore suggested to wrap such elements into an additional html element

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </bsx/create>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [y] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
