### PR TITLE
Retry on the minting in case of errors

### DIFF
--- a/components/bsx/Create/CreateToken.vue
+++ b/components/bsx/Create/CreateToken.vue
@@ -54,7 +54,7 @@
           label="mint.submit"
           :disabled="disabled"
           :loading="isLoading"
-          @click="() => submit()" />
+          @click="submit()" />
       </template>
     </BaseTokenForm>
   </div>
@@ -311,12 +311,15 @@ export default class CreateToken extends mixins(
       })
     } catch (e) {
       if (e instanceof Error) {
-        showNotification(e.toString(), notificationTypes.danger)
         this.stopLoader()
 
         if (retryCount < 3) {
-          showNotification('You will retry to mint NFT')
+          // retry
+          showNotification('Retrying to complete minting process.')
           this.submit(retryCount + 1)
+        } else {
+          // finally fail
+          showNotification(e.toString(), notificationTypes.danger)
         }
       }
     }

--- a/components/bsx/Create/CreateToken.vue
+++ b/components/bsx/Create/CreateToken.vue
@@ -54,7 +54,7 @@
           label="mint.submit"
           :disabled="disabled"
           :loading="isLoading"
-          @click="submit" />
+          @click="() => submit()" />
       </template>
     </BaseTokenForm>
   </div>
@@ -261,7 +261,7 @@ export default class CreateToken extends mixins(
     return !this.listed || (price > 0 && price <= this.maxPrice)
   }
 
-  protected async submit(): Promise<void> {
+  protected async submit(retryCount = 0): Promise<void> {
     if (!this.base.selectedCollection) {
       throw ReferenceError('[MINT] Unable to mint without collection')
     }
@@ -313,6 +313,11 @@ export default class CreateToken extends mixins(
       if (e instanceof Error) {
         showNotification(e.toString(), notificationTypes.danger)
         this.stopLoader()
+
+        if (retryCount < 3) {
+          showNotification('You will retry to mint NFT')
+          this.submit(retryCount + 1)
+        }
       }
     }
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3547
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

I emit a mock error while minting, and it could retry to mint again successfully.
![Kapture 2022-07-24 at 16 18 03](https://user-images.githubusercontent.com/31397967/180639408-e270ca37-e903-4be3-8621-f2772c4f11cb.gif)

