### PR TITLE
fix: quickfix for correctly displaying price of bsx gallery items

### DIFF
--- a/components/bsx/Gallery/Item/GalleryItem.vue
+++ b/components/bsx/Gallery/Item/GalleryItem.vue
@@ -70,7 +70,7 @@
                       </div>
                       <div class="price-block__container">
                         <div class="price-block__original">
-                          <Money :value="nft.price" inline />
+                          <Money :value="calculatedPrice" inline />
                         </div>
                       </div>
                       <div v-if="nftRoyalties">
@@ -254,6 +254,11 @@ export default class GalleryItem extends mixins(
     )
   }
 
+  get calculatedPrice(): number {
+    // price value for bsx nft isn't fetched in right format
+    return Number(this.nft?.price || 0) * 100000000000
+  }
+
   public offersUpdate({ offers }) {
     this.isMakeOffersAllowed = !offers.find(({ caller }) => {
       return caller === this.accountId
@@ -393,8 +398,8 @@ export default class GalleryItem extends mixins(
   }
 
   get nftRoyalties(): string {
-    return this.nft.price && this.nft.royalty
-      ? royaltyOf(this.nft.price, this.nft.royalty)
+    return this.calculatedPrice && this.nft.royalty
+      ? royaltyOf(this.calculatedPrice, this.nft.royalty)
       : ''
   }
 

--- a/utils/formatBalance.ts
+++ b/utils/formatBalance.ts
@@ -27,7 +27,7 @@ export function calculateBalance(value: number, decimals = 12): number {
 }
 
 export function checkInvalidBalanceFilter(value) {
-  if (value === Infinity) {
+  if (value === Infinity || value === -Infinity) {
     return '0'
   }
   return value


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3533
- [ ] Requires deployment <rubick/magick_issue>
- [x] solution for price displaying issues, but i dont like it. snek should return correctly formatted value isntead but i guess this will do for now

<img width="1144" alt="Screenshot 2022-07-24 at 16 18 59" src="https://user-images.githubusercontent.com/17953978/180651276-8124d163-3c96-4afb-b32f-a933a7b4a4ec.png">

### Before submitting Pull Request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </bsx/gallery/2526524581-4>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://kodadot.xyz/transfer/?target=EqdyzrzVmeHwMdMwvPeCMnNdbuQDbD3YrjY93xq9Ln3jUGW)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
