### PR TITLE
feat: hidden `westend` `westmint` in production env

### DIFF
--- a/components/shared/ChainSelect.vue
+++ b/components/shared/ChainSelect.vue
@@ -20,11 +20,20 @@
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
+import { Option } from '@kodadot1/vuex-options/dist/types'
+import { chainTestList } from '~/utils/constants'
 
 @Component({})
 export default class ChainSelect extends Vue {
   get options() {
-    return this.$store.getters['availableUrlPrefixes']
+    const availableUrlPrefixes: Option[] =
+      this.$store.getters['availableUrlPrefixes']
+    if (!this.$config.dev) {
+      return availableUrlPrefixes.filter(
+        (urlPrefix) => !chainTestList.includes(urlPrefix.value as string)
+      )
+    }
+    return availableUrlPrefixes
   }
 
   get selected() {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -316,6 +316,7 @@ export default defineNuxtConfig({
     prefix: process.env.URL_PREFIX || 'rmrk',
     baseUrl: process.env.BASE_URL || 'http://localhost:9090',
     googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID || '',
+    dev: process.env.NODE_ENV === 'development',
   },
   // In case of using ssr
   // privateRuntimeConfig: {}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -64,3 +64,5 @@ export const NFT_SQUID_SORT_CONDITION_LIST: string[] = [
   'price_ASC',
   'sn_ASC',
 ]
+
+export const chainTestList = ['westend', 'westmint']


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3561
- [ ] Requires deployment <rubick/magick_issue>
- [x] <brief_description_of_what_I've_added>
according to env variables, to determine whether show these two test chains.

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EgCzZLpVe7zg7RHh79qPyC8UrykVkA22YY2oj7sWMZf15Ws)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

- development env
<img width="659" alt="image" src="https://user-images.githubusercontent.com/38389586/180830017-cb643884-faed-4d67-9093-67fa078fc595.png">

- production env
<img width="830" alt="image" src="https://user-images.githubusercontent.com/38389586/180830539-83f296d1-2ac4-4f29-adf4-24966d653f4c.png">
