### PR TITLE
fix: misleading number on stats page

### DIFF
--- a/components/bsx/Offer/StatsOverview.vue
+++ b/components/bsx/Offer/StatsOverview.vue
@@ -21,10 +21,14 @@
         <div>
           <p class="title">
             {{ `${data.totalCount} /` }}
-            <Money :value="data.totalPrice" inline hideUnit />
+            <Money :value="data.totalPrice" inline />
           </p>
           <p class="heading text-bold mb-5">
-            {{ data.status + ' ' + $t('statsOverview.offers') }}
+            {{
+              `${data.status} ${$t('statsOverview.offers')} / ${$t(
+                'statsOverview.values'
+              )}`
+            }}
           </p>
         </div>
       </div>

--- a/langDir/en.json
+++ b/langDir/en.json
@@ -687,6 +687,7 @@
     "createdCollections": "Created Collections",
     "activeWallets": "Active wallets",
     "offers": "Offers",
+    "values": "VALUES",
     "bsxTitle":  "Basilisk Marketplace Statistics"
   },
   "myOffer": {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #3643
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

BSX:

<img width="971" alt="image" src="https://user-images.githubusercontent.com/31397967/182404728-fbd35561-bcb0-440e-9468-84ad290d86a8.png">


RMRK:
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/31397967/182404685-f2ae674b-910e-4038-ae8f-ce7103f9a7aa.png">

