### PR TITLE
Deorbit SubQuery from search

### DIFF
--- a/components/rmrk/Collection/List/CollectionList.vue
+++ b/components/rmrk/Collection/List/CollectionList.vue
@@ -3,19 +3,19 @@
     <Loader :value="isLoading" />
     <Search
       v-bind.sync="searchQuery"
-      @resetPage="resetPage"
-      hideSearch
-      :sortOption="collectionSortOption">
+      hide-search
+      :sort-option="collectionSortOption"
+      @resetPage="resetPage">
       <b-field class="is-flex">
         <Layout class="mr-5" @change="onResize" />
         <Pagination
-          hasMagicBtn
+          v-model="currentValue"
+          has-magic-btn
           simple
           replace
-          preserveScroll
+          preserve-scroll
           :total="total"
-          v-model="currentValue"
-          :perPage="first" />
+          :per-page="first" />
       </b-field>
     </Search>
 
@@ -29,9 +29,9 @@
         class="columns is-multiline"
         @scroll="onScroll">
         <div
-          :class="`column is-4 column-padding ${scrollItemClassName} ${classLayout}`"
           v-for="collection in results"
-          :key="collection.id">
+          :key="collection.id"
+          :class="`column is-4 column-padding ${scrollItemClassName} ${classLayout}`">
           <nuxt-link
             :to="`/${urlPrefix}/collection/${collection.id}`"
             tag="div"
@@ -41,7 +41,7 @@
               <BasicImage
                 :src="collection.image"
                 :alt="collection.name"
-                customClass="collection__image-wrapper" />
+                custom-class="collection__image-wrapper" />
             </div>
 
             <div class="card-content">
@@ -64,11 +64,11 @@
 </template>
 
 <script lang="ts">
-import { Component, mixins, Vue, Watch } from 'nuxt-property-decorator'
+import { Component, Vue, Watch, mixins } from 'nuxt-property-decorator'
 import { Debounce } from 'vue-debounce-decorator'
 import {
-  CollectionWithMeta,
   Collection,
+  CollectionWithMeta,
   Metadata,
   NFTMetadata,
 } from '@/components/rmrk/service/scheme'
@@ -233,7 +233,7 @@ export default class CollectionList extends mixins(
     try {
       const collections = this.$apollo.query({
         query: collectionListWithSearch,
-        client: this.urlPrefix === 'rmrk' ? 'subsquid' : this.urlPrefix,
+        client: this.client,
         variables: {
           first: this.first,
           offset,

--- a/components/rmrk/Gallery/Collections.vue
+++ b/components/rmrk/Gallery/Collections.vue
@@ -4,11 +4,11 @@
     <!-- TODO: Make it work with graphql -->
     <b-field class="column">
       <Pagination
-        hasMagicBtn
+        v-model="currentValue"
+        has-magic-btn
         simple
         :total="total"
-        v-model="currentValue"
-        :perPage="first"
+        :per-page="first"
         replace
         class="is-right" />
     </b-field>
@@ -16,9 +16,9 @@
     <div>
       <div class="columns is-multiline">
         <div
-          class="column is-4 column-padding"
           v-for="collection in results"
-          :key="collection.id">
+          :key="collection.id"
+          class="column is-4 column-padding">
           <div class="card collection-card">
             <nuxt-link
               :to="`/statemine/collection/${collection.id}`"
@@ -28,7 +28,7 @@
                 <BasicImage
                   :src="collection.image"
                   :alt="collection.name"
-                  customClass="collection__image-wrapper" />
+                  custom-class="collection__image-wrapper" />
               </div>
 
               <div class="card-content">
@@ -45,24 +45,25 @@
       </div>
     </div>
     <Pagination
+      v-model="currentValue"
       class="pt-5 pb-5"
       :total="total"
-      :perPage="first"
-      v-model="currentValue"
+      :per-page="first"
       replace />
   </div>
 </template>
 
 <script lang="ts">
-import { Component, mixins, Vue } from 'nuxt-property-decorator'
+import { Component, Vue, mixins } from 'nuxt-property-decorator'
 
+import resolveQueryPath from '@/utils/queryPathResolver'
+import { unwrapSafe } from '@/utils/uniquery'
 import { getMany, update } from 'idb-keyval'
 import 'lazysizes'
-import { MetaFragment } from '~/components/unique/graphqlResponseTypes'
-import PrefixMixin from '~/utils/mixins/prefixMixin'
+import { MetaFragment } from '@/components/unique/graphqlResponseTypes'
+import PrefixMixin from '@/utils/mixins/prefixMixin'
 import { Collection, CollectionWithMeta } from '../service/scheme'
 import { fetchCollectionMetadata, sanitizeIpfsUrl } from '../utils'
-import resolveQueryPath from '@/utils/queryPathResolver'
 
 const components = {
   Pagination: () => import('./Pagination.vue'),
@@ -72,6 +73,7 @@ const components = {
   BasicImage: () => import('@/components/shared/view/BasicImage.vue'),
 }
 
+// TODO: Is this used anywhere?
 @Component<Collections>({
   components,
 })
@@ -95,14 +97,14 @@ export default class Collections extends mixins(PrefixMixin) {
 
   public async created() {
     const query = await resolveQueryPath(
-      this.urlPrefix,
+      this.client,
       'collectionListWithSearch'
     )
     this.$apollo.addSmartQuery('collection', {
       query: query.default,
       manual: true,
       loadingKey: 'loadingState',
-      client: this.urlPrefix,
+      client: this.client,
       result: this.handleResult,
       variables: () => {
         return {
@@ -112,7 +114,7 @@ export default class Collections extends mixins(PrefixMixin) {
       },
       update: ({ collectionEntity }) => ({
         ...collectionEntity,
-        nfts: collectionEntity.nfts.nodes,
+        nfts: unwrapSafe(collectionEntity.nfts),
       }),
     })
   }

--- a/components/rmrk/Profile/NavbarProfileDropdown.vue
+++ b/components/rmrk/Profile/NavbarProfileDropdown.vue
@@ -29,9 +29,6 @@
 
       <hr class="dropdown-divider" aria-role="menuitem" />
       <template v-if="isRmrk">
-        <b-dropdown-item v-if="isRmrk" has-link aria-role="menuitem">
-          <nuxt-link to="/rmrk/admin">{{ $t('Admin') }}</nuxt-link>
-        </b-dropdown-item>
         <b-dropdown-item has-link aria-role="menuitem">
           <a @click="showRampSDK">
             {{ $t('credit') }}

--- a/components/rmrk/Profile/ProfileDetail.vue
+++ b/components/rmrk/Profile/ProfileDetail.vue
@@ -834,12 +834,12 @@ export default class ProfileDetail extends mixins(
   public async fetchMyNftByIssuer() {
     if (this.id && shouldUpdate(this.accountId, this.id)) {
       const query = await resolveQueryPath(
-        this.urlPrefix,
+        this.client,
         'nftListByIssuerAndOwner'
       )
       const { data } = await this.$apollo.query({
         query: query.default,
-        client: this.urlPrefix,
+        client: this.client,
         variables: {
           account: this.id,
           currentOwner: this.accountId,

--- a/components/shared/gallery/CollectionNavigation.vue
+++ b/components/shared/gallery/CollectionNavigation.vue
@@ -1,24 +1,25 @@
 <template>
   <Navigation
     v-if="isVisible"
-    :showNavigation="showNavigation"
+    :show-navigation="showNavigation"
     :items="nftIdList"
-    :currentId="nftId" />
+    :current-id="nftId" />
 </template>
 
 <script lang="ts">
-import { Component, mixins, Prop, Watch } from 'nuxt-property-decorator'
-import { mapToId } from '~/utils/mappers'
-import PrefixMixin from '~/utils/mixins/prefixMixin'
-import { notificationTypes, showNotification } from '~/utils/notification'
-import resolveQueryPath from '~/utils/queryPathResolver'
-import shouldUpdate from '~/utils/shouldUpdate'
-import { unwrapSafe } from '~/utils/uniquery'
+import { mapToId } from '@/utils/mappers'
+import PrefixMixin from '@/utils/mixins/prefixMixin'
+import { notificationTypes, showNotification } from '@/utils/notification'
+import resolveQueryPath from '@/utils/queryPathResolver'
+import shouldUpdate from '@/utils/shouldUpdate'
+import { unwrapSafe } from '@/utils/uniquery'
+import { Component, Prop, Watch, mixins } from 'nuxt-property-decorator'
 
 const components = {
   Navigation: () => import('@/components/rmrk/Gallery/Item/Navigation.vue'),
 }
 
+// TODO: Is this used anywhere?
 @Component({ components })
 export default class CollectionNavigation extends mixins(PrefixMixin) {
   @Prop(String) public collectionId!: string
@@ -39,13 +40,10 @@ export default class CollectionNavigation extends mixins(PrefixMixin) {
 
   protected async fetchNftIdList() {
     try {
-      const query = await resolveQueryPath(
-        this.urlPrefix,
-        'nftIdListByCollection'
-      )
+      const query = await resolveQueryPath(this.client, 'nftIdListByCollection')
       const nfts = await this.$apollo.query({
         query: query.default,
-        client: this.urlPrefix,
+        client: this.client,
         variables: {
           id: this.collectionId,
         },


### PR DESCRIPTION
- :zap: use subsquid on rmrk search
- :soap: using this.client for subsquid prefix
- :soap: Collections.vue
- :zap: ProfileDetail uses squid
- :zap: Collection Navigation by squid
- :zap: removed admin from dropdown

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [ ] PR closes #<issue_number>
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
