### PR TITLE
refactor (3733): error messaging on Creative Minting

### DIFF
--- a/components/rmrk/Create/CreativeMint.vue
+++ b/components/rmrk/Create/CreativeMint.vue
@@ -18,7 +18,7 @@
       ref="uploadFileRef"
       v-model="file"
       required
-      label="Drop your NFT here or click to upload or simply paste image from clipboard. We support various media types (BMP, GIF, JPEG, PNG, SVG, TIFF, WEBP, MP4, OGV, QUICKTIME, WEBM, GLB, FLAC, MP3, JSON)"
+      label="Drop your NFT here, click to upload or paste the image from the clipboard. AI module limits our support for Creative Minting to only JPEG, PNG, GIF or BMP image files. The file size must be less than 4MB, and the image's dimensions must be greater than 50x50 pixels."
       expanded
       preview />
 
@@ -85,7 +85,7 @@ import {
   unSanitizeIpfsUrl,
 } from '@kodadot1/minimark'
 import { Component, Ref, Watch, mixins } from 'nuxt-property-decorator'
-import { NFT, NFTMetadata, SimpleNFT, getNftId } from '../service/scheme'
+import { NFT, SimpleNFT, getNftId } from '../service/scheme'
 import { MediaType } from '../types'
 import { resolveMedia, sanitizeIpfsUrl } from '../utils'
 
@@ -115,7 +115,6 @@ export default class CreativeMint extends mixins(
     name: '~',
     description: '~',
   }
-  private meta: NFTMetadata = emptyObject<NFTMetadata>()
   private file: File | null = null
   private price = 0
   private fileHash = ''
@@ -238,9 +237,7 @@ export default class CreativeMint extends mixins(
       this.accountId
     )
 
-    const fileHash = await pinFileToIPFS(file, token)
-
-    let imageHash: string | undefined = fileHash
+    let imageHash: string | undefined = await pinFileToIPFS(file, token)
     let animationUrl: string | undefined = undefined
 
     const attributes = []
@@ -298,6 +295,12 @@ export default class CreativeMint extends mixins(
     } catch (e) {
       this.$consola.error(e)
       this.isGptLoading = false
+      this.$set(this.rmrkMint, 'name', 'Something went wrong.')
+      this.$set(
+        this.rmrkMint,
+        'description',
+        'Generating the title and description failed. Please check whether the uploaded file fits the limits of Creative Minting: JPEG, PNG, GIF or BMP with a size less than 4MB and dimensions greater than 50x50 pixels.'
+      )
     }
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

### What's new?

- [x] PR closes #3733
- [ ] Requires deployment <rubick/magick_issue>
- [ ] Better messaging around Creative Minting, all of the edge cases should be handled. 
In order to test this properly, try to upload whatever files you want at /creative and you should receive proper error messages and avoid seeing undefined errors.  

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [x] I found edge cases
- [ ] I've written some unit tests 🧪


### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.



