### PR TITLE
fix: correct prefix for E2E tests

### DIFF
--- a/pages/e2e-login.vue
+++ b/pages/e2e-login.vue
@@ -6,15 +6,18 @@
 import { Component, Vue } from 'nuxt-property-decorator'
 import { mnemonicGenerate } from '@polkadot/util-crypto'
 import keyring from '@polkadot/ui-keyring'
+import PrefixMixin from '@/utils/mixins/prefixMixin'
+import { ss58Of } from '~~/utils/config/chain.config'
 
 @Component({})
-export default class E2ELogin extends Vue {
+export default class E2ELogin extends PrefixMixin {
   created() {
     const mnemonic = mnemonicGenerate(12)
     const { pair } = keyring.addUri(mnemonic, '', {
       name: 'mnemonic acc',
     })
     // TODO: check 'loadAll' error, approx 1 in 10 tests fail without this
+    keyring.setSS58Format(ss58Of(this.urlPrefix))
     keyring.addPair(pair, '')
     const account = pair.address
     this.$store.dispatch('setAuth', { address: account })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## What's new

E2E login was returning address in 42 prefix
