### PR TITLE
fix: Unnamed NFTs on Moonriver

### DIFF
--- a/components/rmrk/Gallery/Gallery.vue
+++ b/components/rmrk/Gallery/Gallery.vue
@@ -58,10 +58,10 @@
                 <span
                   v-if="!isLoading"
                   class="title mb-0 is-4 has-text-centered"
-                  :title="nft.name">
+                  :title="getDisplayNameOfNft(nft)">
                   <nuxt-link :to="`/${urlPrefix}/gallery/${nft.id}`">
                     <div class="has-text-overflow-ellipsis">
-                      {{ nft.name }}
+                      {{ getDisplayNameOfNft(nft) }}
                     </div>
                   </nuxt-link>
                   <p
@@ -112,9 +112,9 @@ import AuthMixin from '@/utils/mixins/authMixin'
 import InfiniteScrollMixin from '@/utils/mixins/infiniteScrollMixin'
 import PrefixMixin from '@/utils/mixins/prefixMixin'
 
-import { NFTMetadata } from '../service/scheme'
+import { NFT, NFTMetadata } from '../service/scheme'
 import { SearchQuery } from './search/types'
-import { getSanitizer } from '../utils'
+import { getNameOfNft, getSanitizer } from '../utils'
 
 // import passionQuery from '@/queries/rmrk/subsquid/passionFeed.graphql'
 
@@ -343,6 +343,10 @@ export default class Gallery extends mixins(
     // }
 
     return params
+  }
+
+  public getDisplayNameOfNft(nft: NFT) {
+    return getNameOfNft(nft)
   }
 
   @Watch('$route.query.search')

--- a/components/rmrk/utils.ts
+++ b/components/rmrk/utils.ts
@@ -349,3 +349,7 @@ export const getRandomIntInRange = (min: number, max: number): number => {
   max = Math.floor(max)
   return Math.floor(Math.random() * (max - min + 1)) + min
 }
+
+export const getNameOfNft = (nft: NFT): string => {
+  return nft.name || `${nft.collection.name} - #${nft.sn}`
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #4023
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/31397967/192443425-4207d785-5883-4a3c-9cb7-7ecef8cc963a.png">


The property of Unnamed NFT is like this: 
<img width="684" alt="image" src="https://user-images.githubusercontent.com/31397967/192443589-dd56689f-dd02-4c14-9de5-d8f127000e7c.png">


