### PR TITLE
fix: Incorrect url of nft on More From This Collection

### DIFF
--- a/utils/carousel.ts
+++ b/utils/carousel.ts
@@ -13,7 +13,10 @@ import { sanitizeIpfsUrl } from '@/components/rmrk/utils'
  * Get cloudflare images
  * Update timestamp
  */
-export const formatNFT = async (nfts, chain): Promise<CarouselNFT[]> => {
+export const formatNFT = async (
+  nfts,
+  chain?: string
+): Promise<CarouselNFT[]> => {
   if (!nfts) {
     return []
   }

--- a/utils/carousel.ts
+++ b/utils/carousel.ts
@@ -13,10 +13,7 @@ import { sanitizeIpfsUrl } from '@/components/rmrk/utils'
  * Get cloudflare images
  * Update timestamp
  */
-export const formatNFT = async (
-  nfts,
-  chain = 'rmrk'
-): Promise<CarouselNFT[]> => {
+export const formatNFT = async (nfts, chain): Promise<CarouselNFT[]> => {
   if (!nfts) {
     return []
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #4158 
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
/bsx/gallery/3813476019-44


<img width="664" alt="image" src="https://user-images.githubusercontent.com/31397967/197225480-62b6e91f-1fee-4e06-8b5e-0e46642989eb.png">

<img width="1407" alt="image" src="https://user-images.githubusercontent.com/31397967/197225581-011b3cc4-16fd-4537-9d54-24a6e391079e.png">


