### PR TITLE
fix: Neobrutalism landing page release UI

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -18,7 +18,7 @@
       <div
         class="is-hidden-desktop is-flex is-flex-grow-1 is-align-items-center is-justify-content-flex-end"
         @click="closeBurgerMenu">
-        <HistoryBrowser class="navbar-item" />
+        <!-- <HistoryBrowser class="navbar-item" /> -->
         <b-button
           v-if="showSearchOnNavbar"
           icon-left="search"
@@ -40,9 +40,9 @@
       </div>
     </template>
     <template v-if="showTopNavbar || isBurgerMenuOpened" #end>
-      <LazyHistoryBrowser
+      <!-- <LazyHistoryBrowser
         id="NavHistoryBrowser"
-        class="custom-navbar-item navbar-link-background is-hidden-touch" />
+        class="custom-navbar-item navbar-link-background is-hidden-touch" /> -->
 
       <NavbarExplore />
 

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -16,8 +16,8 @@
               theme: 'custom',
               colors: {
                 primary: '#FF7AC3',
-                input: '#000000',
-                email: '#FFFFFF',
+                input: '#FFFFFF',
+                email: '#000000',
                 text: '#000000',
               },
             }

--- a/components/landing/SearchLanding.vue
+++ b/components/landing/SearchLanding.vue
@@ -39,7 +39,7 @@ import { Option } from '@kodadot1/vuex-options/dist/types'
 import { getChainTestList } from '~/utils/constants'
 
 const { urlPrefix } = usePrefix()
-const { $store, $colorMode } = useNuxtApp()
+const { $store, $colorMode, $router } = useNuxtApp()
 const isDarkMode = computed(() => $colorMode.preference === 'dark')
 
 const landingImage = computed(() => {
@@ -62,6 +62,6 @@ const switchChain = (value) => {
     return
   }
   $store.dispatch('setUrlPrefix', value)
-  window.location.reload()
+  $router.push({ path: `/${value}/explore` })
 }
 </script>

--- a/components/landing/TopCollectionsItem.vue
+++ b/components/landing/TopCollectionsItem.vue
@@ -8,7 +8,7 @@
         </div>
         <div>
           <BasicImage
-            custom-class="is-48x48"
+            custom-class="is-48x48 image-outline"
             rounded
             :src="collection.image || '/placeholder.webp'" />
         </div>

--- a/styles/components/_search.scss
+++ b/styles/components/_search.scss
@@ -202,10 +202,6 @@
     padding: 0px 32px;
   }
 
-  .image-outline {
-    border: 1px solid $black;
-    border-radius: 50%;
-  }
 }
 
 .search-navbar-container-mobile {

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -123,6 +123,11 @@ body {
   }
 }
 
+.image-outline {
+  border: 1px solid $black;
+  border-radius: 50%;
+}
+
 .box {
   .box-container {
     @media screen and (max-width: 768px) {

--- a/styles/layouts/_footer.scss
+++ b/styles/layouts/_footer.scss
@@ -174,6 +174,10 @@
       font-family: 'Work Sans';
       font-weight: 400 !important;
       padding: 0 28px !important;
+      border-left: 1px solid $black !important;
+      &:hover {
+        background: $white !important;
+      }
 
     }
   }

--- a/styles/layouts/_footer.scss
+++ b/styles/layouts/_footer.scss
@@ -152,6 +152,31 @@
       }
     }
   }
+
+  .csw-substack-gradient-custom {
+    border: 1px solid $black !important;
+    border-radius: 0 !important;
+    box-shadow: 4px 4px 0px $black;
+    height: 35px !important;
+
+    input {
+      font-weight: 400;
+      border-radius: 0 !important;
+      font-size: 16px !important;
+      font-family: 'Work Sans';
+      padding-left: 24px !important;
+      &::placeholder {
+        color: $placeholder-color !important;
+      }
+    }
+    button {
+      font-size: 16px !important;
+      font-family: 'Work Sans';
+      font-weight: 400 !important;
+      padding: 0 28px !important;
+
+    }
+  }
 }
 
 .icons {

--- a/styles/themes/_dark.scss
+++ b/styles/themes/_dark.scss
@@ -118,7 +118,7 @@ html.dark-mode {
     color: $white
   }
 
-  
+
   }
 
   .dropdown-content {
@@ -204,6 +204,25 @@ html.dark-mode {
       .is-white {
         color: $background-dark !important;
       }
+    }
+  }
+
+  .image-outline {
+    border-color: $white;
+  }
+
+  .csw-substack-gradient-custom {
+    border-color: $white !important;
+    box-shadow: 4px 4px 0px $white;
+    input {
+      color: $white !important;
+      background-color: $black !important;
+      &::placeholder {
+        color: $placeholder-color !important;
+      }
+    }
+    button {
+      color: $white !important;
     }
   }
 }

--- a/styles/themes/_dark.scss
+++ b/styles/themes/_dark.scss
@@ -24,6 +24,7 @@ html.dark-mode {
   }
 
   .navbar {
+    border-color: $white;
     .dropdown-content .dropdown-item .menu-item {
       color: $white !important;
     }
@@ -89,6 +90,7 @@ html.dark-mode {
   }
 
   .instance {
+    border-color: $white;
     &-accent,
     &-blue {
       background-color: $dark-accent;
@@ -129,7 +131,7 @@ html.dark-mode {
 
   .footer-container {
     background-color: $dark-accent;
-    border-top: 1px solid $white;
+    // border-top: 1px solid $white;
 
     &-socials {
       &-list {

--- a/styles/themes/_dark.scss
+++ b/styles/themes/_dark.scss
@@ -218,13 +218,19 @@ html.dark-mode {
     box-shadow: 4px 4px 0px $white;
     input {
       color: $white !important;
-      background-color: $black !important;
+      background-color: $k-dark !important;
       &::placeholder {
         color: $placeholder-color !important;
       }
     }
     button {
-      color: $white !important;
+      color: $dark-accent !important;
+      border-left: 1px solid $white !important;
+      background: $k-accent !important;
+      &:hover {
+        background: $k-dark !important;
+        color: $white !important;
+      }
     }
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [x] Feature
- [ ] Refactoring

### What's new?

- [x] PR #4185


- [x] At the search bar, the link should navigate to explorer view like when click on Basilisk will land at https://beta.kodadot.xyz/bsx/explore/ 
- [x] Top collections: Stroke around the collection icon
- [x]  Subscribe button design
- [x] lines that seperates containers are white, not black. 
- [x] Hide history component on navbar 

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

- [x] At the search bar, the link should navigate to explorer view like when click on Basilisk will land at https://beta.kodadot.xyz/bsx/explore/ 
- [x] Top collections: Stroke around the collection icon
<img width="805" alt="image" src="https://user-images.githubusercontent.com/31397967/198337178-2201cd8f-b967-47e3-8eca-26242683a376.png">

- [x]  Subscribe button design

<img width="423" alt="image" src="https://user-images.githubusercontent.com/31397967/198337254-2f2d1d89-3c11-4801-9df9-3709abf45dba.png">
<img width="393" alt="image" src="https://user-images.githubusercontent.com/31397967/198337331-ed93555e-30c7-4f60-81ff-198872093db8.png">


- [x] lines that seperates containers are white, not black. 

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/31397967/198337430-bc5d2dda-7c5d-44f2-8e5f-14d496e65479.png">

- [x] Hide history component on navbar 


