### PR TITLE
fix: dont show empty string on spotlight

### DIFF
--- a/queries/subsquid/general/collectionCuratedList.graphql
+++ b/queries/subsquid/general/collectionCuratedList.graphql
@@ -5,7 +5,11 @@ query collectionCuratedList {
   collectionEntities(
     orderBy: blockNumber_DESC
     limit: 5
-    where: { nfts_some: { burned_eq: false }, name_isNull: false }
+    where: {
+      nfts_some: { burned_eq: false }
+      name_isNull: false
+      name_not_eq: ""
+    }
   ) {
     ...collection
     ...collectionDetails


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] similar to this issue https://github.com/kodadot/nft-gallery/pull/4203. not only null, spotlight can return empty string

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
