### PR TITLE
#4153 redesign spotlight leftovers

### DIFF
--- a/components/carousel/CarouselIndex.vue
+++ b/components/carousel/CarouselIndex.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <div v-if="nfts.length">
-      <h2 class="title is-2 has-text-dark">{{ title }}</h2>
+      <h2
+        class="title is-2"
+        :class="textColor === 'light' ? 'has-text-light' : 'has-text-dark'">
+        {{ title }}
+      </h2>
 
       <CarouselList v-if="showCarousel" :nfts="nfts" />
     </div>
@@ -21,6 +25,7 @@ const props = defineProps<{
   subtitle?: string
   nfts: CarouselNFT[] | RowSeries[]
   loading?: boolean
+  textColor?: 'dark' | 'light'
   actionType?: 'pagination' | 'link'
   linkUrl?: string
   linkText?: string

--- a/components/carousel/CarouselTypeSpotlight.vue
+++ b/components/carousel/CarouselTypeSpotlight.vue
@@ -2,6 +2,7 @@
   <CarouselIndex
     :title="`${$t('spotlight.page')}`"
     :nfts="spotlight"
+    text-color="light"
     action-type="pagination"
     item-url="collection" />
 </template>

--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -52,6 +52,15 @@ const [wrapper, slider] = useKeenSlider(
     slideChanged: (s) => {
       current.value = s.track.details.rel
     },
+    detailsChanged: (s) => {
+      s.slides.forEach((slide, index) => {
+        if (s.track.details.slides[index].portion > 0) {
+          slide.style.opacity = '1'
+        } else {
+          slide.style.opacity = '.5'
+        }
+      })
+    },
     breakpoints: {
       '(min-width: 640px)': {
         slides: { perView: 1.5, spacing: 32 },
@@ -60,10 +69,10 @@ const [wrapper, slider] = useKeenSlider(
         slides: { perView: 2.5, spacing: 32 },
       },
       '(min-width: 1024px)': {
-        slides: { perView: 3.5, spacing: 32 },
+        slides: { perView: 3, spacing: 32 },
       },
       '(min-width: 1280px)': {
-        slides: { perView: 4.5, spacing: 32 },
+        slides: { perView: 4, spacing: 32 },
       },
     },
     slides: { perView: 1.5, spacing: 32 },

--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -12,8 +12,6 @@
           </div>
         </div>
       </div>
-      <div class="arrow arrow-left" @click="slider?.prev()"></div>
-      <div class="arrow arrow-right" @click="slider?.next()"></div>
       <div
         v-if="showPrev"
         class="arrow arrow-left"

--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -12,14 +12,8 @@
           </div>
         </div>
       </div>
-      <div
-        v-if="showPrev"
-        class="arrow arrow-left"
-        @click="slider?.prev()"></div>
-      <div
-        v-if="showNext"
-        class="arrow arrow-right"
-        @click="slider?.next()"></div>
+      <div class="arrow arrow-left" @click="slider?.prev()"></div>
+      <div class="arrow arrow-right" @click="slider?.next()"></div>
     </div>
     <div v-if="slider && !isCollection" class="dots">
       <button
@@ -51,8 +45,6 @@ provide('isCollection', isCollection.value)
 
 const current = ref(0)
 const minWidths = [1280, 1024, 768, 640]
-const showPrev = ref(false)
-const showNext = ref(true)
 
 const [wrapper, slider] = useKeenSlider(
   {
@@ -60,16 +52,6 @@ const [wrapper, slider] = useKeenSlider(
     rubberband: false,
     slideChanged: (s) => {
       current.value = s.track.details.rel
-      if (s.track.details.rel === s.track.details.minIdx) {
-        showPrev.value = false
-        showNext.value = true
-      } else if (s.track.details.rel === s.track.details.maxIdx) {
-        showPrev.value = true
-        showNext.value = false
-      } else {
-        showPrev.value = true
-        showNext.value = true
-      }
     },
     detailsChanged: (s) => {
       s.slides.forEach((slide, index) => {

--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -14,6 +14,14 @@
       </div>
       <div class="arrow arrow-left" @click="slider?.prev()"></div>
       <div class="arrow arrow-right" @click="slider?.next()"></div>
+      <div
+        v-if="showPrev"
+        class="arrow arrow-left"
+        @click="slider?.prev()"></div>
+      <div
+        v-if="showNext"
+        class="arrow arrow-right"
+        @click="slider?.next()"></div>
     </div>
     <div v-if="slider && !isCollection" class="dots">
       <button
@@ -45,12 +53,25 @@ provide('isCollection', isCollection.value)
 
 const current = ref(0)
 const minWidths = [1280, 1024, 768, 640]
+const showPrev = ref(false)
+const showNext = ref(true)
+
 const [wrapper, slider] = useKeenSlider(
   {
     initial: current.value,
     rubberband: false,
     slideChanged: (s) => {
       current.value = s.track.details.rel
+      if (s.track.details.rel === s.track.details.minIdx) {
+        showPrev.value = false
+        showNext.value = true
+      } else if (s.track.details.rel === s.track.details.maxIdx) {
+        showPrev.value = true
+        showNext.value = false
+      } else {
+        showPrev.value = true
+        showNext.value = true
+      }
     },
     detailsChanged: (s) => {
       s.slides.forEach((slide, index) => {

--- a/styles/components/_carousel.scss
+++ b/styles/components/_carousel.scss
@@ -102,8 +102,11 @@
   }
 
   .arrow {
-    width: 60px;
-    height: 60px;
+    $side-y: 32px;
+    $side-x: 55px;
+
+    width: $side-x;
+    height: $side-x;
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
@@ -113,9 +116,9 @@
     &-left {
       left: -30px;
 
-      border-bottom: solid 40px transparent;
-      border-top: solid 40px transparent;
-      border-right: solid 60px black;
+      border-bottom: solid $side-y transparent;
+      border-top: solid $side-y transparent;
+      border-right: solid $side-x black;
 
       &::after {
         content: '';
@@ -123,11 +126,11 @@
         height: 0;
 
         position: absolute;
-        border-bottom: solid 36px transparent;
-        border-top: solid 36px transparent;
-        border-right: solid 55px white;
-        top: -36px;
-        right: -58px;
+        border-bottom: solid $side-y - 2 transparent;
+        border-top: solid $side-y - 2 transparent;
+        border-right: solid $side-x - 2 white;
+        top: -($side-y - 2);
+        right: -($side-x - 1);
         transition-duration: 0.2s;
       }
 
@@ -137,11 +140,11 @@
         height: 0;
 
         position: absolute;
-        border-bottom: solid 40px transparent;
-        border-top: solid 40px transparent;
-        border-right: solid 60px black;
-        top: -34px;
-        right: -56px;
+        border-bottom: solid $side-y transparent;
+        border-top: solid $side-y transparent;
+        border-right: solid $side-x black;
+        top: -($side-y - 6);
+        right: -($side-x + 4);
       }
     }
 
@@ -149,9 +152,9 @@
       left: auto;
       right: -30px;
 
-      border-bottom: solid 40px transparent;
-      border-top: solid 40px transparent;
-      border-left: solid 60px black;
+      border-bottom: solid $side-y transparent;
+      border-top: solid $side-y transparent;
+      border-left: solid $side-x black;
 
       &::after {
         content: '';
@@ -159,11 +162,11 @@
         height: 0;
 
         position: absolute;
-        border-bottom: solid 36px transparent;
-        border-top: solid 36px transparent;
-        border-left: solid 55px white;
-        top: -36px;
-        left: -58px;
+        border-bottom: solid $side-y - 2 transparent;
+        border-top: solid $side-y - 2 transparent;
+        border-left: solid $side-x - 2 white;
+        top: -($side-y - 2);
+        left: -($side-x - 1);
         transition-duration: 0.2s;
       }
 
@@ -173,21 +176,21 @@
         height: 0;
 
         position: absolute;
-        border-bottom: solid 40px transparent;
-        border-top: solid 40px transparent;
-        border-left: solid 60px black;
-        top: -34px;
-        left: -56px;
+        border-bottom: solid $side-y transparent;
+        border-top: solid $side-y transparent;
+        border-left: solid $side-x black;
+        top: -($side-y - 6);
+        left: -($side-x - 4);
       }
     }
 
     &:hover {
       &.arrow-left::after {
-        border-right: solid 55px $k-accentlight;
+        border-right: solid $side-x - 2 $k-accentlight;
       }
 
       &.arrow-right::after {
-        border-left: solid 55px $k-accentlight;
+        border-left: solid $side-x - 2 $k-accentlight;
       }
     }
 

--- a/styles/components/_carousel.scss
+++ b/styles/components/_carousel.scss
@@ -1,6 +1,11 @@
+.section {
+  overflow-y: hidden;
+}
+
 .carousel-agnostic {
   .keen-slider {
     padding-bottom: 16px;
+    overflow: visible !important;
   }
 
   .carousel-item {
@@ -8,11 +13,12 @@
     color: black;
     border: 1px solid black;
     box-shadow: 4px 4px 0 0 rgba(255, 255, 255, 0);
-    transition-duration: 0.4s;
-    transition-property: box-shadow;
+    transition: box-shadow 0.4s, opacity 0.4s;
+
 
     &:hover {
       box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 1);
+      opacity: 1 !important;
     }
   }
 

--- a/styles/components/_carousel.scss
+++ b/styles/components/_carousel.scss
@@ -1,5 +1,5 @@
 .section {
-  overflow-y: hidden;
+  overflow-x: hidden;
 }
 
 .carousel-agnostic {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #4153
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [x] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

Changes:
1. "Spotlight" title now is white
2. All cards are visible on all sliders. Off main screen cards are faded
3. Arrows are hidden if there is no more cards that way

<img width="2878" alt="Screenshot 2022-11-01 at 18 33 59" src="https://user-images.githubusercontent.com/2462955/199258830-da412667-e30f-4979-9293-5da5bd5a4156.png">

<img width="2882" alt="Screenshot 2022-11-01 at 18 34 20" src="https://user-images.githubusercontent.com/2462955/199258879-9291ec15-b41c-4304-a970-42fb1e29a0d3.png">

<img width="1141" alt="Screenshot 2022-11-01 at 18 36 21" src="https://user-images.githubusercontent.com/2462955/199259275-5866e561-3b2d-4691-a60e-9aee1ac8ffa7.png">
