### PR TITLE
fix: GalleryItem Chart wrong y axis label scale and number

### DIFF
--- a/components/rmrk/Gallery/History.vue
+++ b/components/rmrk/Gallery/History.vue
@@ -142,6 +142,7 @@ import PrefixMixin from '@/utils/mixins/prefixMixin'
 import {
   HistoryEventType,
   InteractionBsxOnly,
+  parseChartAmount,
   parseDate,
   wrapEventNameWithIcon,
 } from '@/utils/historyEvent'
@@ -380,9 +381,9 @@ export default class History extends mixins(
 
       // Push to chart data
       if (newEvent['interaction'] === Interaction.LIST) {
-        chartData.list.push([date, parseFloat(event['Amount'].substring(0, 6))])
+        this.pushChartData(chartData.list, date, event['Amount'])
       } else if (newEvent['interaction'] === Interaction.BUY) {
-        chartData.buy.push([date, parseFloat(event['Amount'].substring(0, 6))])
+        this.pushChartData(chartData.buy, date, event['Amount'])
       }
 
       this.copyTableData.push(event)
@@ -395,6 +396,10 @@ export default class History extends mixins(
     }
 
     this.$emit('setPriceChartData', [chartData.buy, chartData.list])
+  }
+
+  private pushChartData(array, date, amount) {
+    array.push([date, parseChartAmount(amount, this.decimals)])
   }
 
   @Watch('events', { immediate: true })

--- a/utils/historyEvent.ts
+++ b/utils/historyEvent.ts
@@ -42,10 +42,6 @@ export const parseDate = (date: Date): string => {
   })
 }
 
-export const parseAmount = (
-  amount: string,
-  decimals: number,
-  unit: string
-): string => {
-  return parseInt(amount) ? formatBalance(amount, decimals, unit) : '-'
+export const parseChartAmount = (amount: string, decimals: number): number => {
+  return parseFloat(formatBalance(amount, decimals))
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [x] PR closes #4225
- [ ] Requires deployment <rubick/magick_issue>
- [ ] <brief_description_of_what_I've_added>

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've tested it at </rmrk/collection/26902bc2f7c20c546a-1FVG7>
- [ ] I've tested PR on mobile and everything seems works
- [ ] I found edge cases
- [ ] I've written some unit tests 🧪

### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

### Screenshot

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

/rmrk/gallery/9691296-b2ed7a9394517e712d-EBY6M-YG-0000000000000040

<img width="520" alt="image" src="https://user-images.githubusercontent.com/31397967/199528253-150ca46e-fec7-45eb-a1cd-da9f376aeaa6.png">
