### PR TITLE
fix: Dark mode explore leftover occasionally

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -145,7 +145,7 @@
           </b-navbar-item>
         </template>
       </b-navbar-dropdown>
-        <LazyChainSelect
+      <LazyChainSelect
         id="NavChainSelect"
         class="navbar-item has-dropdown"
         data-cy="chain-select" />
@@ -256,8 +256,15 @@ export default class NavbarMenu extends mixins(
     return this.$route.name === 'index'
   }
 
+  get isDarkMode() {
+    return (
+      this.$colorMode.preference === 'dark' ||
+      document.documentElement.className.includes('dark-mode')
+    )
+  }
+
   get logoSrc() {
-    return this.$colorMode.preference === 'dark' ? KodaBetaDark : KodaBeta
+    return this.isDarkMode ? KodaBetaDark : KodaBeta
   }
 
   get showSearchOnNavbar(): boolean {

--- a/components/landing/SearchLanding.vue
+++ b/components/landing/SearchLanding.vue
@@ -40,7 +40,11 @@ import { getChainTestList } from '~/utils/constants'
 
 const { urlPrefix } = usePrefix()
 const { $store, $colorMode, $router } = useNuxtApp()
-const isDarkMode = computed(() => $colorMode.preference === 'dark')
+const isDarkMode = computed(
+  () =>
+    $colorMode.preference === 'dark' ||
+    document.documentElement.className.includes('dark-mode')
+)
 
 const landingImage = computed(() => {
   if (isDarkMode.value) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## PR Context?

- [x] Closes #4260
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

WFM on preview environment:

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/31397967/200128637-53a8ad6f-2528-4682-89ea-94065b0b6115.png">
