### PR TITLE
#4284 Show trending collection in SearchSuggestions if *urlPrefix* either *rmrk* or *bsx*

### DIFF
--- a/components/search/SearchBar.vue
+++ b/components/search/SearchBar.vue
@@ -107,7 +107,7 @@ export default class SearchBar extends mixins(
   }
 
   get showDefaultSuggestions() {
-    return this.urlPrefix === 'rmrk'
+    return this.urlPrefix === 'rmrk' || this.urlPrefix === 'bsx'
   }
 
   redirectToGalleryPageIfNeed(params?: Record<string, string>) {


### PR DESCRIPTION
 **Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4284
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EDEQxiVzazTboSCuedYx7KAsXs6edPQUsEEMMAazSA68f5y&usdamount=25&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1126" alt="Screenshot 2022-11-09 at 12 11 42" src="https://user-images.githubusercontent.com/43046411/200815575-e60decfa-f10e-42f3-830e-e454e124a50d.png">
<img width="1017" alt="Screenshot 2022-11-09 at 12 11 23" src="https://user-images.githubusercontent.com/43046411/200815591-1e3434ab-4798-4212-a41b-abf22276fe61.png">
