### PR TITLE
fix: remove transparent color from focused placeholder on darkmode 

### DIFF
--- a/styles/components/_search.scss
+++ b/styles/components/_search.scss
@@ -109,9 +109,6 @@
     border-radius: 0;
     padding: 0 50px 0 42px !important;
     background-color: $search-background-color;
-    &:focus::placeholder {
-      color: transparent!important;
-    }
 
     &::placeholder {
       color: $placeholder-color !important;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4310
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [x] I've tested it at </bsx/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=FNyt7T1xdbhN7dagf7yGYCRJuE3R45VmTCE3tjzy1rKxa7y)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
![image](https://user-images.githubusercontent.com/73316633/201518580-eedc74b9-c8e4-46c7-8391-77c31d385288.png)

