### PR TITLE
fix: remove black drop shadow on default state (dark mode)

### DIFF
--- a/styles/components/_top-collections.scss
+++ b/styles/components/_top-collections.scss
@@ -31,7 +31,6 @@
     background-color: $dark-accent;
     color: $white;
     border: 1px solid $white;
-    box-shadow: 4px 4px 0 0 black;
 
     &:hover {
       box-shadow: 4px 4px 0 0 $white;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4311
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ x I've tested it at </bsx/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=FNyt7T1xdbhN7dagf7yGYCRJuE3R45VmTCE3tjzy1rKxa7y)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://user-images.githubusercontent.com/73316633/201518510-0e0a53f6-bb1e-4b13-a2dc-dde8793266e6.png)

