### PR TITLE
Fix: Search reload explore

### DIFF
--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -127,6 +127,11 @@ export default class Search extends mixins(
     this.initKeyboardEventHandler({
       f: this.bindFilterEvents,
     })
+    if (!this.name && this.$route.query.search) {
+      this.name = Array.isArray(this.$route.query.search)
+        ? ''
+        : this.$route.query.search
+    }
   }
 
   public mounted(): void {

--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -81,6 +81,7 @@ import PrefixMixin from '~/utils/mixins/prefixMixin'
 import KeyboardEventsMixin from '~/utils/mixins/keyboardEventsMixin'
 import { NFT_SQUID_SORT_CONDITION_LIST } from '@/utils/constants'
 import ChainMixin from '~/utils/mixins/chainMixin'
+import { isEmpty } from 'cypress/types/lodash'
 
 @Component({
   components: {
@@ -238,7 +239,7 @@ export default class Search extends mixins(
   @Emit('update:search')
   @Debounce(50)
   updateSearch(value: string): string {
-    if (value !== this.searchQuery) {
+    if (!value != !this.$route.query.search && value !== this.searchQuery) {
       this.replaceUrl({ search: value ?? undefined }, this.$route.path)
     }
     return value
@@ -284,7 +285,7 @@ export default class Search extends mixins(
           ...queryCondition,
         },
       })
-      .catch(this.$consola.warn /*Navigation Duplicate err fix later */)
+      .catch(this.$consola.warn)
     // if searchbar request or filter is set, pagination should always revert to page 1
     this.$emit('resetPage')
   }

--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -81,7 +81,6 @@ import PrefixMixin from '~/utils/mixins/prefixMixin'
 import KeyboardEventsMixin from '~/utils/mixins/keyboardEventsMixin'
 import { NFT_SQUID_SORT_CONDITION_LIST } from '@/utils/constants'
 import ChainMixin from '~/utils/mixins/chainMixin'
-import { isEmpty } from 'cypress/types/lodash'
 
 @Component({
   components: {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [X] Closes #4357
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried to respect high code quality standards
- [X] I've didn't break any original functionality
- [X] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [X] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=DdFn4hDQDTkzoH9dFPnsuE2VvmnHAhAn2RezVedZHVYaCEb)

#### Community participation

- [X] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [X] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Aditional notes
The validation on the `updateSearch` function also fixes the duplicated navigation console error, so i went ahead and removed it (Hope its ok)
In addition to the fixed bug, i added the search string after a reload (on the explore route) to the searchBar, like this:
![Uploading reloadBug.PNG…]()
Let me know if you want this reverted as it was my intuition that made me change it and didnt want to open a new fresh bug just for it.


