### PR TITLE
fix: Gallery item tab typeface

### DIFF
--- a/styles/components/_o-tabs.scss
+++ b/styles/components/_o-tabs.scss
@@ -6,6 +6,7 @@
 
     &-item {
       font-family: 'Work Sans';
+      font-size: 1rem;
       &-default {
         border: 1px solid black;
         border-right: 0;

--- a/styles/components/_o-tabs.scss
+++ b/styles/components/_o-tabs.scss
@@ -5,6 +5,7 @@
     overflow-x: initial;
 
     &-item {
+      font-family: 'Work Sans';
       &-default {
         border: 1px solid black;
         border-right: 0;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4470
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/31397967/206868277-266dce7e-09b2-4bf0-a48f-c745983b95c9.png">
