### PR TITLE
fix: bring back galleryItem price chart data

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemChart.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemChart.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <PriceChart class="mt-4" :price-chart-data="priceChartData" />
+    <LazyGalleryHistory
+      class="is-hidden"
+      :events="nftEvents"
+      @setPriceChartData="setPriceChartData" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Interaction } from '@/components/rmrk/service/scheme'
+import PriceChart from '@/components/chart/PriceChart.vue'
+
+defineProps<{
+  nftEvents?: Interaction[]
+}>()
+const priceChartData = ref<[Date, number][][]>([])
+
+const setPriceChartData = (data: [Date, number][][]) => {
+  priceChartData.value = data
+}
+</script>

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemTabsPanel.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemTabsPanel.vue
@@ -20,6 +20,10 @@
     <!-- chart -->
     <o-tab-item value="2" :label="$t('tabs.chart')" class="p-5">
       <PriceChart class="mt-4" :price-chart-data="priceChartData" />
+      <LazyGalleryHistory
+        class="is-hidden"
+        :events="nft?.events"
+        @setPriceChartData="setPriceChartData" />
     </o-tab-item>
   </o-tabs>
 </template>
@@ -38,6 +42,10 @@ const priceChartData = ref<[Date, number][][]>([])
 
 const activeTab = ref('0')
 const collectionId = ref('')
+
+const setPriceChartData = (data: [Date, number][][]) => {
+  priceChartData.value = data
+}
 
 watchEffect(() => {
   if (urlPrefix.value === 'rmrk') {

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemTabsPanel.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemTabsPanel.vue
@@ -19,11 +19,7 @@
 
     <!-- chart -->
     <o-tab-item value="2" :label="$t('tabs.chart')" class="p-5">
-      <PriceChart class="mt-4" :price-chart-data="priceChartData" />
-      <LazyGalleryHistory
-        class="is-hidden"
-        :events="nft?.events"
-        @setPriceChartData="setPriceChartData" />
+      <GalleryItemChart :nft-events="nft?.events" />
     </o-tab-item>
   </o-tabs>
 </template>
@@ -33,19 +29,14 @@ import { OTabItem, OTabs } from '@oruga-ui/oruga'
 
 import { useGalleryItem } from '../useGalleryItem'
 import GalleryItemActivity from './GalleryItemActivity.vue'
+import GalleryItemChart from './GalleryItemChart.vue'
 import GalleryItemOffers from './GalleryItemOffers.vue'
-import PriceChart from '@/components/chart/PriceChart.vue'
 
 const { urlPrefix } = usePrefix()
 const { nft } = useGalleryItem()
-const priceChartData = ref<[Date, number][][]>([])
 
 const activeTab = ref('0')
 const collectionId = ref('')
-
-const setPriceChartData = (data: [Date, number][][]) => {
-  priceChartData.value = data
-}
 
 watchEffect(() => {
   if (urlPrefix.value === 'rmrk') {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4482
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="743" alt="image" src="https://user-images.githubusercontent.com/31397967/207236517-c078c442-9653-43ee-8704-a68741f04256.png">

