### PR TITLE
:zap: fix identity reactivity

### DIFF
--- a/components/generative/promptBuilder.ts
+++ b/components/generative/promptBuilder.ts
@@ -99,7 +99,7 @@ export const buildMetadata = async (
   const imageHash = await pinImageSafe(file, 'token')
   const attributes = buildAttributes(options)
   const description = buildDescription(options)
-  const name = `Metaverse Championship ${options.gender}`
+  const name = `SubWork Christmas ${options.gender}`
 
   const meta = createMetadata(
     name,

--- a/components/identity/IdentityIndex.vue
+++ b/components/identity/IdentityIndex.vue
@@ -27,7 +27,7 @@
 import { GenericAccountId } from '@polkadot/types/generic/AccountId'
 import { defineEmits } from '#app'
 
-import useIdentity from './utils/useIdentity'
+import useIdentity, { IdentityFields } from './utils/useIdentity'
 
 type Address = string | GenericAccountId | undefined
 
@@ -47,17 +47,25 @@ const props = defineProps<{
   hideIdentityPopover?: boolean
   customNameOption?: string
 }>()
+const identity = ref<IdentityFields>()
+const shortenedAddress = ref<string>()
+const name = ref<string>()
+const twitter = ref<string>()
+const discord = ref<string>()
+const isFetchingIdentity = ref(false)
 
-const {
-  identity,
-  isFetchingIdentity,
-  shortenedAddress,
-  twitter,
-  discord,
-  name,
-} = useIdentity({
-  address: props.address,
-  customNameOption: props.customNameOption,
+watchEffect(async () => {
+  isFetchingIdentity.value = true
+  const fields = await useIdentity({
+    address: props.address,
+    customNameOption: props.customNameOption,
+  })
+  identity.value = fields.identity.value
+  shortenedAddress.value = fields.shortenedAddress.value
+  name.value = fields.name.value
+  twitter.value = fields.twitter.value
+  discord.value = fields.discord.value
+  isFetchingIdentity.value = fields.isFetchingIdentity.value
 })
 
 provide('address', props.address)

--- a/components/identity/IdentityIndex.vue
+++ b/components/identity/IdentityIndex.vue
@@ -27,7 +27,7 @@
 import { GenericAccountId } from '@polkadot/types/generic/AccountId'
 import { defineEmits } from '#app'
 
-import useIdentity, { IdentityFields } from './utils/useIdentity'
+import useIdentity from './utils/useIdentity'
 
 type Address = string | GenericAccountId | undefined
 
@@ -47,26 +47,31 @@ const props = defineProps<{
   hideIdentityPopover?: boolean
   customNameOption?: string
 }>()
-const identity = ref<IdentityFields>()
-const shortenedAddress = ref<string>()
-const name = ref<string>()
-const twitter = ref<string>()
-const discord = ref<string>()
-const isFetchingIdentity = ref(false)
 
-watchEffect(async () => {
-  isFetchingIdentity.value = true
-  const fields = await useIdentity({
+const identity = ref({})
+const isFetchingIdentity = ref(false)
+const discord = ref<string>()
+const twitter = ref<string>()
+const name = ref<string>()
+const shortenedAddress = ref<string>()
+
+const syncIdentity = () => {
+  const { identity: id, ...rest } = useIdentity({
     address: props.address,
     customNameOption: props.customNameOption,
   })
-  identity.value = fields.identity.value
-  shortenedAddress.value = fields.shortenedAddress.value
-  name.value = fields.name.value
-  twitter.value = fields.twitter.value
-  discord.value = fields.discord.value
-  isFetchingIdentity.value = fields.isFetchingIdentity.value
-})
+  watch(id, () => {
+    identity.value = id?.value
+    isFetchingIdentity.value = rest.isFetchingIdentity?.value
+    discord.value = rest.discord.value
+    twitter.value = rest.twitter.value
+    name.value = rest.name.value
+    shortenedAddress.value = rest.shortenedAddress.value
+  })
+}
+
+onMounted(syncIdentity)
+watch(() => props.address, syncIdentity)
 
 provide('address', props.address)
 provide('shortenedAddress', shortenedAddress.value)

--- a/components/identity/utils/useIdentity.ts
+++ b/components/identity/utils/useIdentity.ts
@@ -8,6 +8,8 @@ import { identityStore } from '@/utils/idbStore'
 import shortAddress from '@/utils/shortAddress'
 
 import type { NFT } from '@/components/rmrk/service/scheme'
+import { Ref } from 'vue'
+import consolaGlobalInstance from 'consola'
 
 type Address = string | GenericAccountId | undefined
 export type IdentityFields = Record<string, string>
@@ -56,7 +58,7 @@ const fetchIdentity = async (address: string): Promise<IdentityFields> => {
   return final
 }
 
-const displayName = ({
+export const displayName = ({
   customNameOption,
   identity,
   shortenedAddress,
@@ -73,11 +75,17 @@ const displayName = ({
   return display || shortenedAddress.value
 }
 
-export default async function useIdentity({ address, customNameOption }) {
+export default function useIdentity({ address, customNameOption }) {
   const { apiUrl } = useApi()
   const identity = ref<IdentityFields>({})
   const isFetchingIdentity = ref(false)
   const shortenedAddress = computed(() => shortAddress(address))
+  const twitter = computed(() => identity?.value?.twitter)
+  const discord = computed(() => identity?.value?.discord)
+  const display = computed(() => identity?.value?.display)
+  const name = computed(() =>
+    displayName({ customNameOption, identity, shortenedAddress })
+  )
 
   const whichIdentity = async () => {
     const identityCached = await get(resolveAddress(address), identityStore)
@@ -95,14 +103,7 @@ export default async function useIdentity({ address, customNameOption }) {
       })
     }
   }
-  await whichIdentity()
-
-  const twitter = computed(() => identity?.value?.twitter)
-  const discord = computed(() => identity?.value?.discord)
-  const display = computed(() => identity?.value?.display)
-  const name = computed(() =>
-    displayName({ customNameOption, identity, shortenedAddress })
-  )
+  whichIdentity()
 
   return {
     identity,

--- a/components/identity/utils/useIdentity.ts
+++ b/components/identity/utils/useIdentity.ts
@@ -10,7 +10,7 @@ import shortAddress from '@/utils/shortAddress'
 import type { NFT } from '@/components/rmrk/service/scheme'
 
 type Address = string | GenericAccountId | undefined
-type IdentityFields = Record<string, string>
+export type IdentityFields = Record<string, string>
 
 const resolveAddress = (account: Address): string => {
   return account instanceof GenericAccountId
@@ -73,17 +73,11 @@ const displayName = ({
   return display || shortenedAddress.value
 }
 
-export default function useIdentity({ address, customNameOption }) {
+export default async function useIdentity({ address, customNameOption }) {
   const { apiUrl } = useApi()
   const identity = ref<IdentityFields>({})
   const isFetchingIdentity = ref(false)
-  const twitter = computed(() => identity?.value?.twitter)
-  const discord = computed(() => identity?.value?.discord)
-  const display = computed(() => identity?.value?.display)
   const shortenedAddress = computed(() => shortAddress(address))
-  const name = computed(() =>
-    displayName({ customNameOption, identity, shortenedAddress })
-  )
 
   const whichIdentity = async () => {
     const identityCached = await get(resolveAddress(address), identityStore)
@@ -101,8 +95,14 @@ export default function useIdentity({ address, customNameOption }) {
       })
     }
   }
+  await whichIdentity()
 
-  onMounted(whichIdentity)
+  const twitter = computed(() => identity?.value?.twitter)
+  const discord = computed(() => identity?.value?.discord)
+  const display = computed(() => identity?.value?.display)
+  const name = computed(() =>
+    displayName({ customNameOption, identity, shortenedAddress })
+  )
 
   return {
     identity,

--- a/components/identity/utils/useIdentity.ts
+++ b/components/identity/utils/useIdentity.ts
@@ -8,11 +8,9 @@ import { identityStore } from '@/utils/idbStore'
 import shortAddress from '@/utils/shortAddress'
 
 import type { NFT } from '@/components/rmrk/service/scheme'
-import { Ref } from 'vue'
-import consolaGlobalInstance from 'consola'
 
 type Address = string | GenericAccountId | undefined
-export type IdentityFields = Record<string, string>
+type IdentityFields = Record<string, string>
 
 const resolveAddress = (account: Address): string => {
   return account instanceof GenericAccountId
@@ -58,7 +56,7 @@ const fetchIdentity = async (address: string): Promise<IdentityFields> => {
   return final
 }
 
-export const displayName = ({
+const displayName = ({
   customNameOption,
   identity,
   shortenedAddress,


### PR DESCRIPTION
make identity reactive
address and on-chain identity updates without needing to refresh page

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [ ] Closes #<issue_number>
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EfmnRhHaQqfT3phm4cUCHCU3gFVDoSPR1U9WXzMRQBMqZ4L)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
![Screenshot from 2022-12-15 17-06-38](https://user-images.githubusercontent.com/22791238/207831499-3d5bbf1a-ce04-4e24-9490-b5fe604c6cfe.png)
![Screenshot from 2022-12-15 17-06-52](https://user-images.githubusercontent.com/22791238/207831511-355e00d7-a9c6-4d2a-b39f-3a5e7cd3263e.png)




