### PR TITLE
fix: tooltip is placed below the table and displayed truncated

### DIFF
--- a/components/rmrk/Gallery/Holder/Holder.vue
+++ b/components/rmrk/Gallery/Holder/Holder.vue
@@ -121,10 +121,7 @@
             field="Timestamp"
             :label="dateHeaderLabel"
             sortable>
-            <b-tooltip
-              :label="props.row.Date"
-              position="is-right"
-              append-to-body>
+            <b-tooltip :label="props.row.Date" position="is-right">
               <BlockExplorerLink
                 :text="props.row.Time"
                 :block-id="props.row.Block" />
@@ -162,10 +159,7 @@
                 {{ item.Percentage | toPercent('-') }}
               </td>
               <td v-show="columnsVisible['Date'].display">
-                <b-tooltip
-                  :label="item.Date"
-                  position="is-right"
-                  append-to-body>
+                <b-tooltip :label="item.Date" position="is-right">
                   <BlockExplorerLink :text="item.Time" :block-id="item.Block" />
                 </b-tooltip>
               </td>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4641
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x]  I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="917" alt="image" src="https://user-images.githubusercontent.com/31397967/211310884-292c4d7e-c305-402d-a171-466236d6b27a.png">
