### PR TITLE
fix: enable sourcemap if token exists

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -320,8 +320,8 @@ export default defineNuxtConfig({
     ],
     extend(config) {
       if (
-        process.env.NODE_ENV !== 'development' ||
-        process.env.DISABLE_SENTRY === 'true'
+        process.env.NODE_ENV !== 'development' &&
+        process.env.SENTRY_AUTH_TOKEN
       ) {
         config.devtool = 'source-map'
 


### PR DESCRIPTION
previously https://github.com/kodadot/nft-gallery/pull/4671/files#diff-65d5d69bb59dcc81ad971719549cdee5018f0a240add8b7ef5c65bee3e73dae0R323-R324 I put the wrong logic. with this, forked repository doesn't need to add additional env in their github