### PR TITLE
fix: disable buy button

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionSlides.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionSlides.vue
@@ -76,9 +76,10 @@ defineProps<{
   width: 10rem;
   font-size: 1rem;
   position: relative;
-  .wrapper {
+  .neo-tooltip {
     width: 100%;
     height: 100%;
+    position: absolute;
   }
   .full-width-action-button {
     width: 100%;

--- a/components/gallery/GalleryItemAction/GalleryItemActionSlides.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionSlides.vue
@@ -80,6 +80,7 @@ defineProps<{
     width: 100%;
     height: 100%;
     position: absolute;
+    z-index: 2;
   }
   .full-width-action-button {
     width: 100%;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

There was a case that wasn't solved in the original pr #4758. Now fixed. 

Disabled buy button:

<img width="830" alt="image" src="https://user-images.githubusercontent.com/31397967/213511596-cc3b94e9-9661-4c5b-9934-dabed675b675.png">

<img width="445" alt="image" src="https://user-images.githubusercontent.com/31397967/213511679-e66e1ab1-8990-410b-bbdf-e94d49186d53.png">
