### PR TITLE
fix: missing BURN event in GalleryItem Activity tab

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
@@ -36,13 +36,14 @@ defineProps<{
   nftId: string
 }>()
 
-const defaultInteractions = ['MINTNFT', 'BUY', 'LIST', 'SEND']
+const defaultInteractions = ['MINTNFT', 'BUY', 'LIST', 'SEND', 'CONSUME']
 const interactions = ref(['BUY']) // default to sales
 const filters = {
   mints: 'MINTNFT',
   sales: 'BUY',
   listings: 'LIST',
   transfers: 'SEND',
+  burns: 'CONSUME',
 }
 
 const checkAll = () => {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1131,7 +1131,8 @@
       "MINTNFT": "Mints",
       "BUY": "Sales",
       "LIST": "Listings",
-      "SEND": "Transfers"
+      "SEND": "Transfers",
+      "CONSUME": "Burns"
     }
   },
   "cancel": "Cancel",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4805
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

/snek/gallery/331660682-4

<img width="743" alt="image" src="https://user-images.githubusercontent.com/31397967/214022626-6f065663-4ba8-427d-ae41-b0e08d167ce0.png">

