### PR TITLE
fix: tabs covered background

### DIFF
--- a/styles/abstracts/_theme.scss
+++ b/styles/abstracts/_theme.scss
@@ -14,6 +14,8 @@ $themes: (
     'k-blue': #6188e7,
     'k-shade': #cccccc,
     'primary-shadow': 4px 4px $black,
+    'background-color': #ffffff,
+
   ),
   'dark-mode': (
     'white': #ffffff,
@@ -30,6 +32,7 @@ $themes: (
     'k-blue': #6188e7,
     'k-shade': #cccccc,
     'primary-shadow': 4px 4px $white,
+    'background-color': #181717,
   ),
 );
 

--- a/styles/abstracts/_theme.scss
+++ b/styles/abstracts/_theme.scss
@@ -15,7 +15,6 @@ $themes: (
     'k-shade': #cccccc,
     'primary-shadow': 4px 4px $black,
     'background-color': #ffffff,
-
   ),
   'dark-mode': (
     'white': #ffffff,
@@ -32,7 +31,7 @@ $themes: (
     'k-blue': #6188e7,
     'k-shade': #cccccc,
     'primary-shadow': 4px 4px $white,
-    'background-color': #181717,
+    'background-color': #191718,
   ),
 );
 

--- a/styles/components/_o-tabs.scss
+++ b/styles/components/_o-tabs.scss
@@ -1,6 +1,8 @@
 .o-tabs {
   box-shadow: 4px 4px 0px #000;
-
+  @include ktheme() {
+    background: theme('background-color');
+  }
   &__nav {
     overflow-x: initial;
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #4848
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

tested at /rmrk/gallery/16113219-DE15C1BA39DDD3C94B-FLW-LILIES-0000000000000001
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/31397967/215132368-4a81d8e3-8a10-44bc-90fd-505c651e7748.png">

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/31397967/215138265-0b1cf406-496d-43b7-9311-4e8aac358a0d.png">


