### PR TITLE
Redesign breadcrumbs

### DIFF
--- a/components/explore/MobileFilter.vue
+++ b/components/explore/MobileFilter.vue
@@ -58,7 +58,6 @@ onMounted(() => {
   window.addEventListener('resize', () => {
     width.value = window.innerWidth
   })
-  syncFromUrl()
 })
 
 const emit = defineEmits(['resetPage'])
@@ -122,6 +121,8 @@ const applyFilters = () => {
   emit('resetPage')
   closeFilterModal()
 }
+
+watch(() => route.query, syncFromUrl)
 </script>
 
 <style lang="scss" scoped>

--- a/components/explore/SidebarFilter.vue
+++ b/components/explore/SidebarFilter.vue
@@ -1,8 +1,8 @@
 <template>
   <div :class="{ 'mr-5 bordered sticky': open }" class="is-hidden-mobile">
     <NeoSidebar :reduce="false" :open="open" fullheight>
+      <StatusFilter expanded />
       <PriceFilter />
-      <StatusFilter />
     </NeoSidebar>
   </div>
 </template>

--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -68,7 +68,14 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Prop, Ref, mixins } from 'nuxt-property-decorator'
+import {
+  Component,
+  Emit,
+  Prop,
+  Ref,
+  Watch,
+  mixins,
+} from 'nuxt-property-decorator'
 import { Debounce } from 'vue-debounce-decorator'
 import { exist, existArray } from './exist'
 import { SearchQuery } from './types'
@@ -115,6 +122,18 @@ export default class Search extends mixins(
     number | string | undefined
   ] = [undefined, undefined]
   public priceRangeDirty = false
+
+  get urlSearchQuery() {
+    return this.$route.query.search
+  }
+
+  // clear search bar value when search is cannceled via breadcrumbs
+  @Watch('urlSearchQuery')
+  syncSearchfromUrl(urlSearchQuery) {
+    if (urlSearchQuery == undefined) {
+      this.name = ''
+    }
+  }
 
   public created() {
     this.initKeyboardEventHandler({
@@ -279,7 +298,7 @@ export default class Search extends mixins(
         query: {
           page: '1',
           ...this.$route.query,
-          search: this.searchQuery || undefined,
+          search: this.searchQuery || this.$route.query.search || undefined,
           ...queryCondition,
         },
       })

--- a/components/shared/gallery/BreadcrumbsFilter.vue
+++ b/components/shared/gallery/BreadcrumbsFilter.vue
@@ -20,6 +20,21 @@ const { $i18n, $consola } = useNuxtApp()
 
 const breads = computed(() => route.query)
 
+onMounted(() => {
+  if (route.query.listed == undefined) {
+    router
+      .replace({
+        path: String(route.path),
+        query: {
+          ...route.query,
+          page: '1',
+          listed: 'true',
+        },
+      })
+      .catch($consola.warn)
+  }
+})
+
 const closeTag = (key: string) => {
   router
     .replace({

--- a/components/shared/gallery/BreadcrumbsFilter.vue
+++ b/components/shared/gallery/BreadcrumbsFilter.vue
@@ -12,7 +12,7 @@
         :key="key"
         class="control">
         <NeoTag @close="removeSearch">
-          {{ `search: ${value}` }}
+          {{ `${$i18n.t('general.search')}: ${value}` }}
         </NeoTag>
       </div>
     </template>

--- a/components/shared/gallery/BreadcrumbsFilter.vue
+++ b/components/shared/gallery/BreadcrumbsFilter.vue
@@ -7,6 +7,14 @@
           {{ $i18n.t(`sort.${String(key)}`) }}
         </NeoTag>
       </div>
+      <div
+        v-if="key === 'search' && value != undefined"
+        :key="key"
+        class="control">
+        <NeoTag @close="removeSearch">
+          {{ `search: ${value}` }}
+        </NeoTag>
+      </div>
     </template>
   </b-field>
 </template>
@@ -42,6 +50,18 @@ const closeTag = (key: string) => {
       query: {
         ...route.query,
         ...{ [key]: false },
+        page: '1',
+      },
+    })
+    .catch($consola.warn)
+}
+const removeSearch = () => {
+  router
+    .replace({
+      path: String(route.path),
+      query: {
+        ...route.query,
+        search: undefined,
         page: '1',
       },
     })

--- a/components/shared/gallery/BreadcrumbsFilter.vue
+++ b/components/shared/gallery/BreadcrumbsFilter.vue
@@ -3,19 +3,17 @@
     <template v-for="(value, key) in breads">
       <div v-if="value === 'true'" :key="key" class="control">
         <!-- NeoTag -->
-        <b-tag
-          attached
-          closable
-          aria-close-label="clear filter"
-          @close="closeTag(String(key))">
+        <NeoTag @close="closeTag(String(key))">
           {{ $i18n.t(`sort.${String(key)}`) }}
-        </b-tag>
+        </NeoTag>
       </div>
     </template>
   </b-field>
 </template>
 
 <script lang="ts" setup>
+import NeoTag from './NeoTag.vue'
+
 const route = useRoute()
 const router = useRouter()
 const { $i18n, $consola } = useNuxtApp()

--- a/components/shared/gallery/NeoTag.vue
+++ b/components/shared/gallery/NeoTag.vue
@@ -23,22 +23,21 @@ const onClose = () => {
 .neo-tag {
   @include ktheme() {
     border: 1px solid theme('k-primary');
-    // color: theme('text-color') !important;
+  }
+  &:hover {
+    @include ktheme() {
+      background-color: theme('k-accentlight2');
+    }
   }
 
   .tag {
     margin-bottom: 0;
     padding: 0;
-    background-color: transparent;
+    background-color: inherit;
     font-size: 16px;
 
     @include ktheme() {
       color: theme('text-color');
-    }
-    &:hover {
-      @include ktheme() {
-        background-color: theme('k-accentlight2');
-      }
     }
 
     &:first-child {
@@ -48,7 +47,7 @@ const onClose = () => {
     &.is-delete {
       &:hover,
       &:focus {
-        background-color: transparent;
+        background-color: inherit;
         @include ktheme() {
           color: theme('k-grey');
         }

--- a/components/shared/gallery/NeoTag.vue
+++ b/components/shared/gallery/NeoTag.vue
@@ -1,0 +1,59 @@
+<template>
+  <!-- NeoTag -->
+  <b-tag
+    attached
+    closable
+    class="neo-tag pl-3 pr-1"
+    aria-close-label="clear filter"
+    @close="onClose">
+    <slot></slot>
+  </b-tag>
+</template>
+
+<script lang="ts" setup>
+const emit = defineEmits(['close'])
+const onClose = () => {
+  emit('close')
+}
+</script>
+
+<style lang="scss">
+@import '@/styles/abstracts/variables';
+
+.neo-tag {
+  @include ktheme() {
+    border: 1px solid theme('k-primary');
+    // color: theme('text-color') !important;
+  }
+
+  .tag {
+    margin-bottom: 0;
+    padding: 0;
+    background-color: transparent;
+    font-size: 16px;
+
+    @include ktheme() {
+      color: theme('text-color');
+    }
+    &:hover {
+      @include ktheme() {
+        background-color: theme('k-accentlight2');
+      }
+    }
+
+    &:first-child {
+      margin-right: 0.3rem;
+      cursor: default;
+    }
+    &.is-delete {
+      &:hover,
+      &:focus {
+        background-color: transparent;
+        @include ktheme() {
+          color: theme('k-grey');
+        }
+      }
+    }
+  }
+}
+</style>

--- a/layouts/explore-layout.vue
+++ b/layouts/explore-layout.vue
@@ -18,12 +18,6 @@
             <h1 v-if="isExplore" class="title">{{ $t('explore') }}</h1>
 
             <ExploreTabsFilterSort />
-            <div v-if="$route.query.search">
-              {{ $t('general.searchResultsText') }}
-              <span class="text__stroked is-size-3">{{
-                $route.query.search
-              }}</span>
-            </div>
           </div>
         </section>
         <hr class="m-0" />

--- a/locales/en.json
+++ b/locales/en.json
@@ -923,6 +923,7 @@
     "copyRewardTooltip": "Your reward link copied to clipboard",
     "copyRewardLink": "Copy Reward Me link",
     "latestSales": "Latest sales",
+    "search": "Search",
     "searchResultsText": "Showing results for",
     "searchNoResultsTitle": "Whoops, Couldn't find anything matching your search",
     "searchNoResultsText": "Give it another shot with different parameters or check back later - New awesome NFTs are added all the time",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #4533 
- [x] Closes #5084 
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EfmnRhHaQqfT3phm4cUCHCU3gFVDoSPR1U9WXzMRQBMqZ4L)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://user-images.githubusercontent.com/22791238/221112578-0595c227-c1c3-4777-8634-aa96e834b6d1.png)
![image](https://user-images.githubusercontent.com/22791238/221112613-072d16d2-53ae-4b11-8624-09d6871647e6.png)

### Hover 
![image](https://user-images.githubusercontent.com/22791238/221112762-50f119c8-048d-4324-96e6-c287a26a8d5a.png)
![image](https://user-images.githubusercontent.com/22791238/221112819-e7fff51a-dcb0-4115-a5a2-c97745657558.png)

### Hover over X

![image](https://user-images.githubusercontent.com/22791238/221113007-f4728480-e8ea-4f3e-8e8d-1d148e82f861.png)
![image](https://user-images.githubusercontent.com/22791238/221113037-778839da-c5ba-4d94-8d63-0d750b4fd7fb.png)

## integrate with search

![image](https://user-images.githubusercontent.com/22791238/221155859-4c8aea48-119e-425e-9fc0-5289a68bdefc.png)


