### PR TITLE
fix: filter disappear when click the same tab

### DIFF
--- a/components/explore/tab/TabOnExplore.vue
+++ b/components/explore/tab/TabOnExplore.vue
@@ -3,11 +3,11 @@
     <TabItem
       :active="selectedTab === TabType.COLLECTION"
       :text="`${$t('collections')}`"
-      :to="pathWithSearchQuery('collectibles')" />
+      :to="pathWithSearchQuery(TabType.COLLECTION)" />
     <TabItem
       :active="selectedTab === TabType.ITEMS"
       :text="`${$t('items')}`"
-      :to="pathWithSearchQuery('items')" />
+      :to="pathWithSearchQuery(TabType.ITEMS)" />
   </div>
 </template>
 
@@ -26,6 +26,9 @@ enum TabType {
 const selectedTab = computed(() => route?.name?.split('-')[2])
 
 const pathWithSearchQuery = (path: string) => {
+  if (path === selectedTab.value) {
+    return route.fullPath
+  }
   const searchQuery = route.query.search
   return searchQuery ? `${path}?search=${searchQuery}` : path
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
> when you click item again when you are on the items already, the buy now filter disappear
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5243
- [ ] Requires deployment <>
