### PR TITLE
fix: gallery item break point set to 930px

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -203,6 +203,20 @@ useNuxt2Meta({
   }
 }
 
+@media screen and (max-width: 930px) {
+  .columns {
+    display: inherit;
+    & > .column {
+      width: 100%;
+    }
+  }
+}
+
+.gallery-item-media image {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .h-audio {
   height: 70%;
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #4762
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EZiu1PjV2j2JHKxY6mHnFwwCRCoV27uHKQSkKXATSh1srJT)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


change the breakpoint for mobile up to 930px

<img width="525" alt="image" src="https://user-images.githubusercontent.com/16473062/226423242-14957eec-d516-434c-85c1-4ea55ccd3f74.png">
