### PR TITLE
5316 payments

### DIFF
--- a/components/shared/DisabledInput.vue
+++ b/components/shared/DisabledInput.vue
@@ -9,8 +9,8 @@ withDefaults(
   defineProps<{
     label: string
     value: string
-    expanded: boolean
-    readonly: boolean
+    expanded?: boolean
+    readonly?: boolean
   }>(),
   {
     label: '',

--- a/pages/transfer.vue
+++ b/pages/transfer.vue
@@ -170,7 +170,6 @@ import { useFiatStore } from '@/stores/fiat'
 
 import { getExplorer, hasExplorer } from '@/components/rmrk/Profile/utils'
 import { emptyObject } from '@kodadot1/minimark'
-import shouldUpdate from '@/utils/shouldUpdate'
 
 type Target = 'target' | `target${number}`
 type TargetMap = Record<Target, string>
@@ -253,8 +252,7 @@ export default class Transfer extends mixins(
   }
 
   protected created() {
-    this.fiatStore.fetchFiatPrice()
-    this.checkQueryParams()
+    this.fiatStore.fetchFiatPrice().then(this.checkQueryParams)
     onApiConnect(this.apiUrl, async (api) => {
       this.$store.commit('setApiConnected', api.isConnected)
     })
@@ -461,13 +459,6 @@ export default class Transfer extends mixins(
       )
     this.targets = targets
     this.$router.replace({ query: { ...targets, usdamount } }).catch(() => null) // null to further not throw navigation errors
-  }
-
-  @Watch('fiatStore.getCurrentKSMValue')
-  onKusamaValueChange(value: any, oldValue: any): void {
-    if (shouldUpdate(value, oldValue)) {
-      this.onUSDFieldChange()
-    }
   }
 
   @Watch('usdValue')

--- a/pages/transfer.vue
+++ b/pages/transfer.vue
@@ -307,6 +307,11 @@ export default class Transfer extends mixins(
 
     if (query.usdamount) {
       this.usdValue = Number(query.usdamount)
+
+      this.price = calculateKsmFromUsd(
+        Number(this.fiatStore.getCurrentKSMValue),
+        this.usdValue
+      )
     }
   }
 

--- a/pages/transfer.vue
+++ b/pages/transfer.vue
@@ -169,6 +169,10 @@ import UseApiMixin from '@/utils/mixins/useApiMixin'
 import { useFiatStore } from '@/stores/fiat'
 
 import { getExplorer, hasExplorer } from '@/components/rmrk/Profile/utils'
+import { emptyObject } from '@kodadot1/minimark'
+
+type Target = 'target' | `target${number}`
+type TargetMap = Record<Target, string>
 
 @Component({
   components: {
@@ -194,7 +198,7 @@ export default class Transfer extends mixins(
   protected transactionValue = ''
   protected price = 0
   protected usdValue = 0
-  protected targets = {}
+  protected targets = emptyObject<TargetMap>()
 
   layout() {
     return 'centered-half-layout'
@@ -457,7 +461,7 @@ export default class Transfer extends mixins(
           ...object,
           [`target${i == 0 ? '' : i}`]: address,
         }),
-        {}
+        {} as TargetMap
       )
     this.targets = targets
     this.$router.replace({ query: { ...targets, usdamount } }).catch(() => null) // null to further not throw navigation errors

--- a/pages/transfer.vue
+++ b/pages/transfer.vue
@@ -170,6 +170,7 @@ import { useFiatStore } from '@/stores/fiat'
 
 import { getExplorer, hasExplorer } from '@/components/rmrk/Profile/utils'
 import { emptyObject } from '@kodadot1/minimark'
+import shouldUpdate from '@/utils/shouldUpdate'
 
 type Target = 'target' | `target${number}`
 type TargetMap = Record<Target, string>
@@ -308,11 +309,6 @@ export default class Transfer extends mixins(
 
     if (query.usdamount) {
       this.usdValue = Number(query.usdamount)
-      const onChange = this.onUSDFieldChange
-
-      setTimeout(() => {
-        onChange()
-      }, 2000)
     }
   }
 
@@ -465,6 +461,13 @@ export default class Transfer extends mixins(
       )
     this.targets = targets
     this.$router.replace({ query: { ...targets, usdamount } }).catch(() => null) // null to further not throw navigation errors
+  }
+
+  @Watch('fiatStore.getCurrentKSMValue')
+  onKusamaValueChange(value: any, oldValue: any): void {
+    if (shouldUpdate(value, oldValue)) {
+      this.onUSDFieldChange()
+    }
   }
 
   @Watch('usdValue')

--- a/pages/transfer.vue
+++ b/pages/transfer.vue
@@ -308,11 +308,11 @@ export default class Transfer extends mixins(
 
     if (query.usdamount) {
       this.usdValue = Number(query.usdamount)
-      // getting ksm value from the usd value
-      this.price = calculateKsmFromUsd(
-        Number(this.fiatStore.getCurrentKSMValue),
-        this.usdValue
-      )
+      const onChange = this.onUSDFieldChange
+
+      setTimeout(() => {
+        onChange()
+      }, 2000)
     }
   }
 


### PR DESCRIPTION
## It's really :poop: fix but should work

# What was happening?

**From url we checked usd amount, multiplied with ksm value (which is 0 when component is created)
the result of multiply was `Infinity` and that failed to sign the transaction.**


- :bug: making props in disabled input optional
- :label: properly typed
- :poop: resolve usd value to KSM

**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #5316
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


**BETA:**

<img width="1292" alt="Screenshot 2023-03-21 at 15 14 22" src="https://user-images.githubusercontent.com/22471030/226633726-3cf945d8-69a7-4c5a-a0ed-43575bdf22f9.png">


**PR:** 

<img width="1292" alt="Screenshot 2023-03-21 at 15 14 05" src="https://user-images.githubusercontent.com/22471030/226633822-2c9e609a-b779-45f8-9d64-d2726df8496f.png">



