### PR TITLE
[WIP, just for preview]feat: add external link redirect

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -144,6 +144,7 @@ export default defineNuxtConfig({
     { src: '~/plugins/assets', mode: 'client' },
     '~/plugins/filters',
     '~/plugins/globalVariables',
+    '~/plugins/handleRedirect',
     '~/plugins/pwa',
     '~/plugins/vueAudioVisual',
     '~/plugins/vueClipboard',

--- a/pages/redirect.vue
+++ b/pages/redirect.vue
@@ -1,0 +1,44 @@
+<!--
+ * @Description:
+ * @Author: Floyd Li (floyd.li@outlook.com)
+ * @Date: 2023-03-24 16:10:46
+ * @LastEditors: Floyd Li (floyd.li@outlook.com)
+ * @LastEditTime: 2023-03-25 17:49:29
+-->
+<template>
+  <div>
+    <div v-if="warn">
+      {{ warn }}
+    </div>
+    <span>
+      {{ redirectUrl }}
+    </span>
+    <div>
+      you are redirecting to the external link which is not hosted by KodaDot,
+      make sure it's safe!
+    </div>
+    <div>
+      <NeoButton @click.native="redirect">Continue</NeoButton>
+      <NeoButton @click.native="close">Close</NeoButton>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { NeoButton } from '@kodadot1/brick'
+
+const route = useRoute()
+const redirectUrl = ref(route.query.redirect)
+const warn = ref(route.query.warn)
+
+function redirect() {
+  // window.open is hooked,  use the origin _open instead
+  window._open(redirectUrl.value, '_self')
+}
+
+function close() {
+  window.close()
+}
+</script>
+
+<style scoped lang="scss"></style>

--- a/plugins/handleRedirect.ts
+++ b/plugins/handleRedirect.ts
@@ -1,0 +1,53 @@
+import {
+  EXTERNAL_LINK_BLACKLIST,
+  EXTERNAL_LINK_WHITELIST,
+} from '../utils/constants'
+
+function isExternal(url: string) {
+  return !url.startsWith(window.location.origin)
+}
+
+function getRedirectUrl(url: string) {
+  const urlObj = new URL(url)
+  const redirectHost = urlObj.host.toLocaleLowerCase()
+  if (EXTERNAL_LINK_WHITELIST.includes(redirectHost)) {
+    return url
+  }
+  const redirectUrl = encodeURIComponent(url)
+  if (EXTERNAL_LINK_BLACKLIST.includes(redirectHost)) {
+    return `/redirect?redirect=${redirectUrl}&warn=blacklist`
+  }
+  return `/redirect?redirect=${redirectUrl}`
+}
+
+function handleLink() {
+  document.body.addEventListener('click', (event) => {
+    if ((event.target as HTMLElement).tagName === 'A') {
+      const target = event.target as HTMLLinkElement
+      if (isExternal(target.href)) {
+        event.preventDefault()
+        window.open(target.href)
+      }
+    }
+  })
+}
+
+function handleOpen() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const _window = window as any
+  _window._open = _window._open || _window.open
+  window.open = (url, target, ...args) => {
+    let redirectUrl = url
+    if (isExternal(url as string)) {
+      redirectUrl = getRedirectUrl(url as string)
+      target = '_blank'
+    }
+    _window._open(redirectUrl, target, ...args)
+    return window
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  handleLink()
+  handleOpen()
+})

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -110,3 +110,7 @@ export const getChainTestList = () => {
 }
 
 export const MIN_OFFER_PRICE = 0.01
+
+export const EXTERNAL_LINK_WHITELIST = ['docs.kodadot.xyz']
+
+export const EXTERNAL_LINK_BLACKLIST = ['github.com']


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

this commit is to add the external link redirect page, i've added some hooks to prevent user open external link directly and will landing a redirect page to show some tips. also we can add whitelist and blacklist for the link so we can block some links for safety.

i think it's the first step for #5218 , just open this pr as draft and if anybody got better idea please leave comments here.

also, this one just a quick demo so forget the ui part :)

@yangwao @vikiival if the redirect logic is okay generally i'll continue the rest :) 

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #5218 
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EZiu1PjV2j2JHKxY6mHnFwwCRCoV27uHKQSkKXATSh1srJT)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/16473062/227710130-23b9c6f2-ea37-4ca9-91e1-84b0ee4127c4.png">
