### PR TITLE
New endpoint for RMRK2

### DIFF
--- a/libs/static/README.md
+++ b/libs/static/README.md
@@ -90,7 +90,7 @@ Published under [MIT License](./LICENSE).
 [npm-version-href]: https://npmjs.com/package/@kodadot1/static
 [npm-downloads-src]: https://img.shields.io/npm/dm/@kodadot1/static?style=flat-square
 [npm-downloads-href]: https://npmjs.com/package/@kodadot1/static
-[github-actions-src]: https://img.shields.io/github/actions/workflow/status/unjs/@kodadot1/static/ci.yml?branch=main&style=flat-square
-[github-actions-href]: https://github.com/unjs/@kodadot1/static/actions?query=workflow%3Aci
-[codecov-src]: https://img.shields.io/codecov/c/gh/unjs/@kodadot1/static/main?style=flat-square
-[codecov-href]: https://codecov.io/gh/unjs/@kodadot1/static
+[github-actions-src]: https://img.shields.io/github/actions/workflow/status/@kodadot1/static/ci.yml?branch=main&style=flat-square
+[github-actions-href]: https://github.com/@kodadot1/static/actions?query=workflow%3Aci
+[codecov-src]: https://img.shields.io/codecov/c/gh/@kodadot1/static/main?style=flat-square
+[codecov-href]: https://codecov.io/gh/@kodadot1/static

--- a/libs/static/package.json
+++ b/libs/static/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kodadot1/static",
-  "version": "0.0.1-rc.0",
-  "description": "",
+  "version": "0.0.1-rc.1",
+  "description": "Static constants in the KodaDot development",
   "repository": "kodadot/nft-gallery",
   "license": "MIT",
   "sideEffects": false,

--- a/libs/static/src/indexers.ts
+++ b/libs/static/src/indexers.ts
@@ -9,7 +9,7 @@ export const INDEXERS: Config<SquidEndpoint> = {
   glmr: 'https://squid.subsquid.io/click/v/002/graphql',
   ksm: 'https://squid.subsquid.io/rubick/graphql',
   movr: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
-  rmrk2: 'https://squid.subsquid.io/rubick/v/009-rc0/graphql',
+  rmrk2: 'https://squid.subsquid.io/marck/graphql',
   snek: 'https://squid.subsquid.io/snekk/v/004/graphql',
 }
 

--- a/libs/static/src/types.ts
+++ b/libs/static/src/types.ts
@@ -4,7 +4,7 @@ export type Prefix = 'bsx' | 'glmr' | 'ksm' | 'movr' | 'rmrk2' | 'snek'
 
 export type BackwardPrefix = 'rmrk' & Prefix
 
-export type Squid = 'rubick' | 'snekk' | 'click' | 'antick'
+export type Squid = 'rubick' | 'snekk' | 'click' | 'antick' | 'marck'
 
 export type Config<T = boolean> = Record<Prefix, T>
 


### PR DESCRIPTION
Seems like rubick@009-rc.0 can't recover from the issues, it is going super slow

<img width="1244" alt="Screenshot 2023-03-29 at 19 29 41" src="https://user-images.githubusercontent.com/22471030/228620260-2438324d-ad05-459f-ac6e-58f9a7640628.png">


Here I propose new indexer for rmrk2 called `marck` (Mark from Remark)
It's running on [new dedicated infra by subsquid](https://docs.subsquid.io/deploy-squid/deploy-manifest/) so should be insanely fast, will see

<img width="1253" alt="Screenshot 2023-03-29 at 19 29 50" src="https://user-images.githubusercontent.com/22471030/228620575-3d6e00f4-b751-413f-bdd0-f0e5c886b013.png">
