### PR TITLE
:wrench: new apollo endpoint to rmrk2

### DIFF
--- a/libs/static/package.json
+++ b/libs/static/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kodadot1/static",
-  "version": "0.0.1-rc.0",
-  "description": "",
+  "version": "0.0.1-rc.1",
+  "description": "Static constants in the KodaDot development",
   "repository": "kodadot/nft-gallery",
   "license": "MIT",
   "sideEffects": false,

--- a/libs/static/src/indexers.ts
+++ b/libs/static/src/indexers.ts
@@ -9,7 +9,7 @@ export const INDEXERS: Config<SquidEndpoint> = {
   glmr: 'https://squid.subsquid.io/click/v/002/graphql',
   ksm: 'https://squid.subsquid.io/rubick/graphql',
   movr: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
-  rmrk2: 'https://squid.subsquid.io/rubick/v/009-rc0/graphql',
+  rmrk2: 'https://squid.subsquid.io/marck/graphql',
   snek: 'https://squid.subsquid.io/snekk/v/004/graphql',
 }
 

--- a/libs/static/src/types.ts
+++ b/libs/static/src/types.ts
@@ -4,7 +4,7 @@ export type Prefix = 'bsx' | 'glmr' | 'ksm' | 'movr' | 'rmrk2' | 'snek'
 
 export type BackwardPrefix = 'rmrk' & Prefix
 
-export type Squid = 'rubick' | 'snekk' | 'click' | 'antick'
+export type Squid = 'rubick' | 'snekk' | 'click' | 'antick' | 'marck'
 
 export type Config<T = boolean> = Record<Prefix, T>
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -45,7 +45,7 @@ export const URLS = {
     snekRococo: 'https://squid.subsquid.io/snekk/v/004/graphql',
     click: 'https://squid.subsquid.io/click/v/002/graphql',
     antick: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
-    rmrk: 'https://squid.subsquid.io/rubick/v/009-rc0/graphql',
+    marck: 'https://squid.subsquid.io/marck/graphql',
     replicate: 'https://replicate.kodadot.workers.dev/',
   },
   providers: {
@@ -63,6 +63,7 @@ export const apolloClientConfig = {
   movr: toApolloEndpoint(URLS.koda.click),
   snek: toApolloEndpoint(URLS.koda.snekRococo),
   glmr: toApolloEndpoint(URLS.koda.antick),
+  rmrk2: toApolloEndpoint(URLS.koda.marck),
 }
 
 export const NFT_SQUID_SORT_CONDITION_LIST: string[] = [


### PR DESCRIPTION
Since Hyper-jpeg does not have @kodadot1/static I need to manually add enpoint

Ref:
- #5425
