### PR TITLE
fix: Scrolling in profile always kicks me back to top when loading

### DIFF
--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -6,6 +6,7 @@ export default function (to) {
     'prefix-collection-id-activity',
     'prefix-explore-items',
     'prefix-explore-collectibles',
+    'prefix-u-id',
   ]
 
   if (disableScrollToTop.includes(toPath)) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5467
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [ ] I've tested it at </bsx/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

