### PR TITLE
feat: make only 2 filters active by default

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
@@ -40,15 +40,11 @@ defineProps<{
   nftId: string
 }>()
 
-const defaultInteractions = [
-  'MINTNFT',
-  'BUY',
-  'LIST',
-  'SEND',
-  'CONSUME',
-  'UNLIST',
-]
-const interactions = ref(defaultInteractions) // default to all
+const defaultInteractions = ['BUY', 'LIST']
+
+const allInteractions = ['MINTNFT', 'BUY', 'LIST', 'SEND', 'CONSUME', 'UNLIST']
+
+const interactions = ref(defaultInteractions)
 const filters = {
   mints: 'MINTNFT',
   sales: 'BUY',
@@ -58,7 +54,7 @@ const filters = {
 }
 
 const checkAll = () => {
-  interactions.value = defaultInteractions
+  interactions.value = allInteractions
 }
 
 const cssActive = (value) => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #5545 
- [ ] Requires deployment <>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

#### Optional

- [x] I've tested it at </bsx/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=DzUbHCk3Fr3XdCPNKo7uCJvtBH7YfgiFbn4Gr3VmCMiFy1C)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

https://user-images.githubusercontent.com/128157824/230698150-ec93b8a1-6d40-43d1-b28b-3576573e9628.mp4

