### PR TITLE
fix: empty `to` in SEND event

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -61,6 +61,12 @@
             <Identity :address="props.row.currentOwner" />
           </nuxt-link>
         </div>
+        <nuxt-link
+          v-else-if="props.row.interaction === 'SEND'"
+          :to="`/${urlPrefix}/u/${props.row.meta}`"
+          class="has-text-link">
+          <Identity :address="props.row.meta" />
+        </nuxt-link>
       </o-table-column>
 
       <!-- date -->


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] Closes #5617 

In the SEND event, the meta represents the person receiving the nft.

After fix:
<img width="739" alt="CleanShot 2023-04-13 at 20 30 29@2x" src="https://user-images.githubusercontent.com/128157824/231745951-786ad0c9-6d7c-4fd6-99ba-319c6e720c42.png">

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=DzUbHCk3Fr3XdCPNKo7uCJvtBH7YfgiFbn4Gr3VmCMiFy1C)

