### PR TITLE
feat: removing the extra padding above the first event on mobile

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -4,7 +4,7 @@
       v-if="events.length"
       :data="events"
       hoverable
-      class="py-5 activity-table-container">
+      class="py-5 padding-top-mobile">
       <!-- event name -->
       <o-table-column
         v-slot="props"

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="gallery-item-activity-table is-flex is-flex-direction-column">
-    <o-table v-if="events.length" :data="events" hoverable>
+    <o-table
+      v-if="events.length"
+      :data="events"
+      hoverable
+      class="py-5 activity-table-container">
       <!-- event name -->
       <o-table-column
         v-slot="props"
@@ -158,14 +162,11 @@ const formatPrice = (price) => {
 
 .gallery-item-activity-table {
   overflow-y: auto;
+}
 
-  & .o-table__root {
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
-
-    @include mobile {
-      padding-top: 0;
-    }
+@include mobile {
+  .activity-table-container {
+    padding-top: 0 !important;
   }
 }
 </style>

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="gallery-item-activity-table is-flex is-flex-direction-column">
-    <o-table v-if="events.length" :data="events" hoverable class="py-5">
+    <o-table v-if="events.length" :data="events" hoverable>
       <!-- event name -->
       <o-table-column
         v-slot="props"
@@ -154,7 +154,18 @@ const formatPrice = (price) => {
 }
 </script>
 <style lang="scss" scoped>
+@import '@/styles/abstracts/variables';
+
 .gallery-item-activity-table {
   overflow-y: auto;
+
+  & .o-table__root {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+
+    @include mobile {
+      padding-top: 0;
+    }
+  }
 }
 </style>

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -165,7 +165,7 @@ const formatPrice = (price) => {
 }
 
 @include mobile {
-  .activity-table-container {
+  .padding-top-mobile {
     padding-top: 0 !important;
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Feature

## Context

- [x] Closes #5612 

 > @leo-anderson-x I would lower the padding a bit - mby something like 16, just on top, keep the padding between the elements.
> _Originally posted by @exezbcz in https://github.com/kodadot/nft-gallery/issues/5612#issuecomment-1505260335_

Removing the extra padding above makes this place look a little more compact.

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=DzUbHCk3Fr3XdCPNKo7uCJvtBH7YfgiFbn4Gr3VmCMiFy1C)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![localhost_9090_ksm_gallery_13833400-7e34eeb5e6bc90bd63-%20%20%20%E2%9D%82%E2%80%BF%E2%9D%82-KUSAMA_ACID_SUPER_HERO_PILL-00000006(iPhone SE) (2)](https://user-images.githubusercontent.com/128157824/231753037-dbb2c403-11d4-4ded-9048-6aa4e24744e5.png)
