### PR TITLE
fix: opening sidebar resets scroll position

### DIFF
--- a/components/common/ConnectWallet/useConnectWallet.ts
+++ b/components/common/ConnectWallet/useConnectWallet.ts
@@ -4,4 +4,5 @@ export const ConnectWalletModalConfig = {
   component: ConnectWalletModal,
   canCancel: ['escape', 'outside'],
   customClass: 'connect-wallet-modal',
+  autoFocus: false,
 }

--- a/components/common/NotificationBox/useNotificationBox.ts
+++ b/components/common/NotificationBox/useNotificationBox.ts
@@ -4,4 +4,5 @@ export const NotificationBoxModalConfig = {
   component: NotificationBoxModal,
   canCancel: ['outside'],
   customClass: 'notification-box-modal',
+  autoFocus: false,
 }

--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -3,6 +3,7 @@
 }
 
 .modal-background {
+  position: fixed !important;
   background-color: rgba(0, 0, 0, 0.5);
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).

👇 \_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] Closes #5565 

Changes
1. `autoFocus` causes `document.documentElement.scrollTop` to always be reset to 0, so I disabled it first.
2. The changes above may cause the modal-background to go out of view, because the default position of modal-background was previously based on document.body instead of window. Therefore, I changed it to fixed so that no matter where the scrollbar is, it can ensure that the modal-background covers the entire screen.

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=DzUbHCk3Fr3XdCPNKo7uCJvtBH7YfgiFbn4Gr3VmCMiFy1C)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

https://user-images.githubusercontent.com/128157824/232310538-8fadad96-742b-437a-9412-bbbb8f33511b.mp4

