### PR TITLE
#5697 Clickable nft in holders/flipper tab

### DIFF
--- a/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Flipper.vue
+++ b/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Flipper.vue
@@ -1,8 +1,9 @@
 <template>
   <div v-if="ready" class="">
-    <div
+    <nuxt-link
       v-for="{ avatar, boughtPrice, soldPrice, profit, nft } in displayedFlips"
       :key="nft.id"
+      :to="`/${urlPrefix}/gallery/${nft.id}`"
       class="is-flex py-2 px-5 is-justify-content-start is-hoverable-item is-flex-direction-column">
       <div class="is-flex">
         <img
@@ -45,7 +46,7 @@
           <Money :value="soldPrice" />
         </div>
       </div>
-    </div>
+    </nuxt-link>
     <div ref="target" />
   </div>
 </template>
@@ -68,6 +69,7 @@ const ready = ref(false)
 const target = ref<HTMLElement | null>(null)
 const offset = ref(4)
 
+const { urlPrefix } = usePrefix()
 useIntersectionObserver(target, ([{ isIntersecting }]) => {
   if (isIntersecting) {
     offset.value += 4

--- a/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Flipper.vue
+++ b/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Flipper.vue
@@ -1,11 +1,10 @@
 <template>
   <div v-if="ready" class="">
-    <nuxt-link
+    <div
       v-for="{ avatar, boughtPrice, soldPrice, profit, nft } in displayedFlips"
       :key="nft.id"
-      :to="`/${urlPrefix}/gallery/${nft.id}`"
       class="is-flex py-2 px-5 is-justify-content-start is-hoverable-item is-flex-direction-column">
-      <div class="is-flex">
+      <nuxt-link class="is-flex" :to="`/${urlPrefix}/gallery/${nft.id}`">
         <img
           v-if="avatar"
           :src="avatar"
@@ -20,7 +19,7 @@
           width="40"
           height="40" />
         <span>{{ nft.name }}</span>
-      </div>
+      </nuxt-link>
       <div
         class="is-flex is-flex-direction-column is-justify-content-space-between mt-3">
         <div class="is-flex is-justify-content-space-between no-wrap">
@@ -46,7 +45,7 @@
           <Money :value="soldPrice" />
         </div>
       </div>
-    </nuxt-link>
+    </div>
     <div ref="target" />
   </div>
 </template>

--- a/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Holder.vue
+++ b/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Holder.vue
@@ -4,7 +4,7 @@
       v-for="{ avatar, id, name, updatedAt } in displayedNFTs"
       :key="id"
       :to="`/${urlPrefix}/gallery/${id}`"
-      class="is-flex pt-2 px-5 is-justify-content-start is-hoverable-item">
+      class="is-flex pt-2 px-5 is-justify-content-start is-hoverable-item hoverable-lable-color">
       <div class="mr-5">
         <img
           v-if="avatar"
@@ -91,5 +91,9 @@ watch(
 .image-size {
   width: 40px !important;
   height: 40px !important;
+}
+
+.hoverable-lable-color {
+  color: inherit !important;
 }
 </style>

--- a/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Holder.vue
+++ b/components/collection/activity/ownerInsightsTabs/NFTSDetailsDropdown/Holder.vue
@@ -1,8 +1,9 @@
 <template>
   <div v-if="ready" class="">
-    <div
+    <nuxt-link
       v-for="{ avatar, id, name, updatedAt } in displayedNFTs"
       :key="id"
+      :to="`/${urlPrefix}/gallery/${id}`"
       class="is-flex pt-2 px-5 is-justify-content-start is-hoverable-item">
       <div class="mr-5">
         <img
@@ -25,7 +26,7 @@
           timeAgo(new Date(updatedAt).getTime())
         }}</span>
       </div>
-    </div>
+    </nuxt-link>
     <div ref="target" />
   </div>
 </template>
@@ -52,6 +53,8 @@ useIntersectionObserver(target, ([{ isIntersecting }]) => {
     offset.value += 4
   }
 })
+
+const { urlPrefix } = usePrefix()
 
 const displayedNFTs = computed(() => nfts.value.slice(0, offset.value))
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #5697
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5fa806</samp>

Added links to NFT gallery pages for flips and holders in owner insights tabs. This improves the user experience and navigation for collection owners. Used a common `urlPrefix` variable to handle different network and environment settings in `Flipper.vue` and `Holder.vue` components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5fa806</samp>

> _`urlPrefix` helps_
> _link to NFT galleries_
> _autumn of the flip_
