### PR TITLE
fix: image download

### DIFF
--- a/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
+++ b/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
@@ -26,7 +26,7 @@
 import { NeoButton, NeoDropdown, NeoDropdownItem } from '@kodadot1/brick'
 import { Interaction } from '@kodadot1/minimark/v1'
 import { downloadImage } from '@/utils/download'
-import { ipfsToCf } from '@/utils/ipfs'
+import { sanitizeIpfsUrl } from '@/utils/ipfs'
 
 const { $route, $i18n } = useNuxtApp()
 const { accountId } = useAuth()
@@ -42,7 +42,8 @@ const props = defineProps<{
 }>()
 
 const downloadMedia = () => {
-  props.ipfsImage && downloadImage(ipfsToCf(props.ipfsImage), props.name)
+  props.ipfsImage &&
+    downloadImage(sanitizeIpfsUrl(props.ipfsImage, 'image'), props.name)
 }
 
 const burn = () => {

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -168,8 +168,3 @@ export const getSanitizer = (
 
   return (link) => link
 }
-
-export const ipfsToCf = (ipfsUrl: string): string => {
-  const cid = extractCid(ipfsUrl)
-  return `${CF_IMAGE_URL}${cid}/public`
-}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [ ] Closes #<issue_number>
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba1fd68</samp>

Improved IPFS media handling and removed unused code. The pull request replaced the `ipfsToCf` function with a more generic `sanitizeIpfsUrl` function in `GalleryItemMoreActionBtn.vue` and `utils/ipfs.ts`. This function ensures the media is loaded and downloaded with the correct URL, format, and extension. The `ipfsToCf` function was removed as it was no longer used.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba1fd68</samp>

> _`ipfsToCf` gone_
> _`sanitizeIpfsUrl` cleans_
> _media in autumn_
