### PR TITLE
feat: display collection profile in search result

### DIFF
--- a/components/search/SearchResultItem.vue
+++ b/components/search/SearchResultItem.vue
@@ -49,3 +49,8 @@ export default class SearchResultItem extends Vue {
   @Prop({ type: String, default: '' }) public image!: string
 }
 </script>
+<style scoped>
+.media-left :deep img {
+  max-height: 100%;
+}
+</style>

--- a/components/search/SearchResultItem.vue
+++ b/components/search/SearchResultItem.vue
@@ -5,12 +5,12 @@
         <b-skeleton
           v-if="isLoading"
           circle
-          width="48px"
-          height="48px"></b-skeleton>
+          width="64px"
+          height="64px"></b-skeleton>
         <BasicImage
           v-else
           rounded
-          custom-class="is-48x48 image-outline"
+          custom-class="is-64x64 image-outline"
           :src="image" />
       </div>
       <div

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -33,7 +33,10 @@
                 <div class="is-flex is-justify-content-space-between pr-2">
                   <span>
                     {{ $t('activity.floor') }}:
-                    <Money :value="getFloorPrice(item.nfts)" inline />
+                    <Money
+                      :value="getFloorPrice(item.nfts)"
+                      :unit-symbol="chainSymbol"
+                      inline />
                   </span>
                   <span class="has-text-grey">
                     {{ $t('search.units') }}:
@@ -92,7 +95,10 @@
                   <span class="name">{{ item.collection?.name }}</span>
                   <span v-if="item.price && parseFloat(item.price) > 0">
                     {{ $t('offer.price') }}:
-                    <Money :value="item.price" inline />
+                    <Money
+                      :value="item.price"
+                      :unit-symbol="chainSymbol"
+                      inline />
                   </span>
                 </div>
               </template>
@@ -307,6 +313,11 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
       Collections: this.collectionSuggestion,
       NFTs: this.nftSuggestion,
     }
+  }
+
+  get chainSymbol() {
+    const { chainSymbol } = useChain()
+    return chainSymbol.value
   }
 
   public updateSearchUrl() {

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -30,8 +30,7 @@
                     {{ urlPrefix.toUpperCase() }}
                   </span>
                 </div>
-                <div
-                  class="is-flex is-justify-content-space-between pr-2">
+                <div class="is-flex is-justify-content-space-between pr-2">
                   <span>
                     {{ $t('activity.floor') }}:
                     <Money :value="getFloorPrice(item.nfts)" inline />
@@ -590,7 +589,12 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
     if (!nfts) {
       return 0
     }
-return Math.min(...nfts.map(nft => Number(nft.price)))
+    // floor price should be greater than zero.
+    const priceArr = nfts.filter((nft) => Number(nft.price) > 0)
+    if (priceArr.length === 0) {
+      return 0
+    }
+    return Math.min(...priceArr.map((nft) => Number(nft.price)))
   }
 
   @Watch('name')

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -31,7 +31,7 @@
                   </span>
                 </div>
                 <div
-                  class="is-flex is-flex-direction-row is-justify-content-space-between pr-2">
+                  class="is-flex is-justify-content-space-between pr-2">
                   <span>
                     {{ $t('activity.floor') }}:
                     <Money :value="getFloorPrice(item.nfts)" inline />

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -590,10 +590,7 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
     if (!nfts) {
       return 0
     }
-    return nfts
-      .map((x) => Number(x.price))
-      .sort()
-      .at(0)
+return Math.min(...nfts.map(nft => Number(nft.price)))
   }
 
   @Watch('name')

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -21,7 +21,7 @@
             :value="item"
             :class="`link-item ${idx === selectedIndex ? 'selected-item' : ''}`"
             @click="gotoCollectionItem(item)">
-            <SearchResultItem :image="item.image">
+            <SearchResultItem :image="item.image || item.mediaUri">
               <template #content>
                 <div
                   class="is-flex is-flex-direction-row is-justify-content-space-between pt-2 pr-2">
@@ -584,6 +584,7 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
           ...collections[i],
           ...meta,
           image: getSanitizer(meta.image || '', 'image')(meta.image || ''),
+          mediaUri: getSanitizer(meta.mediaUri || '')(meta.mediaUri || ''),
         })
       })
       this.collectionResult = collectionWithImages

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -26,7 +26,20 @@
                 <div
                   class="is-flex is-flex-direction-row is-justify-content-space-between pt-2 pr-2">
                   <span class="main-title name">{{ item.name }}</span>
-                  <span>{{ urlPrefix.toUpperCase() }}</span>
+                  <span class="has-text-grey">
+                    {{ urlPrefix.toUpperCase() }}
+                  </span>
+                </div>
+                <div
+                  class="is-flex is-flex-direction-row is-justify-content-space-between pr-2">
+                  <span>
+                    {{ $t('activity.floor') }}:
+                    <Money :value="getFloorPrice(item.nfts)" inline />
+                  </span>
+                  <span class="has-text-grey">
+                    {{ $t('search.units') }}:
+                    {{ item.nfts?.length || 0 }}
+                  </span>
                 </div>
               </template>
             </SearchResultItem>
@@ -571,6 +584,16 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
       )
       this.isCollectionResultLoading = false
     }
+  }
+
+  getFloorPrice(nfts) {
+    if (!nfts) {
+      return 0
+    }
+    return nfts
+      .map((x) => Number(x.price))
+      .sort()
+      .at(0)
   }
 
   @Watch('name')

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -33,7 +33,9 @@
                 <div class="is-flex is-justify-content-space-between pr-2">
                   <span>
                     {{ $t('activity.floor') }}:
+                    <span v-if="getFloorPrice(item.nfts) === 0"> -- </span>
                     <Money
+                      v-else
                       :value="getFloorPrice(item.nfts)"
                       :unit-symbol="chainSymbol"
                       inline />
@@ -597,8 +599,8 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
     }
   }
 
-  getFloorPrice(nfts) {
-    if (!nfts) {
+  getFloorPrice(nfts: NFTWithMeta[] | undefined) {
+    if (!nfts || !nfts.length) {
       return 0
     }
     // floor price should be greater than zero.


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #5500 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EZiu1PjV2j2JHKxY6mHnFwwCRCoV27uHKQSkKXATSh1srJT)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/16473062/232864668-8a209322-8d74-4e2a-a69e-0df8a4c30ad3.png">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 120792d</samp>

Improved the appearance and functionality of the search result components, showing larger and better-styled NFT thumbnails and displaying the floor price and the number of units for collections and series. Modified `SearchResultItem.vue` and `SearchSuggestion.vue` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 120792d</samp>

> _`NFT` thumbnails_
> _bigger, styled, informative_
> _showing floor price - spring_
