### PR TITLE
fix: Loading preview for NFTs in search doesnt work

### DIFF
--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -21,7 +21,7 @@
             :value="item"
             :class="`link-item ${idx === selectedIndex ? 'selected-item' : ''}`"
             @click="gotoCollectionItem(item)">
-            <SearchResultItem :image="item.image || item.mediaUri">
+            <SearchResultItem :image="item.image">
               <template #content>
                 <div
                   class="is-flex is-flex-direction-row is-justify-content-space-between pt-2 pr-2">
@@ -211,7 +211,7 @@ import {
   CollectionWithMeta,
   NFTWithMeta,
 } from '@/components/rmrk/service/scheme'
-import { getSanitizer } from '@/utils/ipfs'
+import { sanitizeIpfsUrl } from '@/utils/ipfs'
 import PrefixMixin from '~/utils/mixins/prefixMixin'
 import { logError, mapNFTorCollectionMetadata } from '~/utils/mappers'
 import { processMetadata } from '~/utils/cachingStrategy'
@@ -361,7 +361,10 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
             collectionResult.push({
               ...collections[i],
               ...meta,
-              image: getSanitizer(meta.image || '', 'image')(meta.image || ''),
+              image: sanitizeIpfsUrl(
+                meta.image || meta.mediaUri || '',
+                'image'
+              ),
             })
           }
         )
@@ -545,9 +548,9 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
         nftResult.push({
           ...nftList[i],
           ...meta,
-          image: getSanitizer(meta.image || '', 'image')(meta.image || ''),
-          animation_url: getSanitizer(meta.animation_url || '')(
-            meta.animation_url || ''
+          image: sanitizeIpfsUrl(
+            meta.image || meta.animation_url || meta.mediaUri || '',
+            'image'
           ),
         })
       })
@@ -585,8 +588,7 @@ export default class SearchSuggestion extends mixins(PrefixMixin) {
         collectionWithImages.push({
           ...collections[i],
           ...meta,
-          image: getSanitizer(meta.image || '', 'image')(meta.image || ''),
-          mediaUri: getSanitizer(meta.mediaUri || '')(meta.mediaUri || ''),
+          image: sanitizeIpfsUrl(meta.image || meta.mediaUri || '', 'image'),
         })
       })
       this.collectionResult = collectionWithImages


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5740
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="613" alt="image" src="https://user-images.githubusercontent.com/31397967/233413455-22dc636e-7a0b-460d-a6e2-790b3e4fdd61.png">

<img width="613" alt="image" src="https://user-images.githubusercontent.com/31397967/233413542-8c97f45f-3d41-402f-b57f-1d3cad2d2c0b.png">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ee4e97</samp>

Refactor and improve image handling in `SearchSuggestion` component. Use `sanitizeIpfsUrl` function to support different media types and fallbacks, and simplify component props and data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6ee4e97</samp>

> _To display images from IPFS_
> _The code needed some fixes_
> _It used `sanitizeIpfsUrl`_
> _To handle media well_
> _And simplified the component's prefixes_
