### PR TITLE
fix(ui): gallery item action display tablet & mobile width

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionSlides.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionSlides.vue
@@ -91,8 +91,34 @@ defineProps<{
     &-active {
       width: 100%;
     }
-    &-content {
+    &-content,
+    &-content > * {
       width: 100%;
+    }
+  }
+}
+
+@include until-widescreen {
+  .slide {
+    width: 100%;
+    align-items: stretch;
+    &:not(.slide-active) {
+      .slide-action {
+        flex: 1;
+        button {
+          width: 100%;
+        }
+      }
+      .slide-content {
+        display: none;
+      }
+    }
+    .slide-content {
+      height: auto;
+      & > div,
+      input {
+        height: 100%;
+      }
     }
   }
 }

--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemTransfer.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemTransfer.vue
@@ -1,8 +1,7 @@
 <template>
   <div>
     <Loader v-model="isLoading" :status="status" />
-    <div class="is-flex is-justify-content-space-between">
-      <div>&nbsp;</div>
+    <div class="is-flex gallery-item-transfer">
       <GalleryItemActionSlides ref="actionRef" :active="active">
         <template #action>
           <NeoTooltip
@@ -75,4 +74,15 @@ const actionRef = ref(null)
 onClickOutside(actionRef, () => (active.value = false))
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+@import '@/styles/abstracts/variables';
+.gallery-item-transfer {
+  justify-content: flex-end;
+}
+@include until-widescreen {
+  .gallery-item-transfer {
+    margin-top: 0.5rem;
+    justify-content: flex-start;
+  }
+}
+</style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5684
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=EZiu1PjV2j2JHKxY6mHnFwwCRCoV27uHKQSkKXATSh1srJT)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/16473062/233591299-00148550-3eab-43eb-ba00-a899fa4619f7.png">

<img width="353" alt="image" src="https://user-images.githubusercontent.com/16473062/233591439-d75dc32b-da6c-4621-a4e8-ffbc8eb4dd45.png">

## Copilot Summary
copilot:summary

copilot:poem
