### PR TITLE
fix: don't display modal when download

### DIFF
--- a/components/gallery/GalleryItemDescription.vue
+++ b/components/gallery/GalleryItemDescription.vue
@@ -55,9 +55,7 @@
         <p>{{ $t('tabs.tabDetails.blockchain') }}</p>
         <p>{{ urlPrefix }}</p>
       </div>
-      <div
-        v-if="version"
-        class="is-flex is-justify-content-space-between">
+      <div v-if="version" class="is-flex is-justify-content-space-between">
         <p>{{ $t('tabs.tabDetails.version') }}</p>
         <p>{{ version }}</p>
       </div>
@@ -106,7 +104,6 @@ import { DisablableTab } from '@kodadot1/brick'
 import { useGalleryItem } from './useGalleryItem'
 import { useRedirectModal } from '@/components/redirect/useRedirectModal'
 
-useRedirectModal('.gallery-item-desc-markdown')
 const { urlPrefix } = usePrefix()
 const { nft, nftMimeType, nftMetadata, nftImage, nftAnimation } =
   useGalleryItem()
@@ -147,6 +144,10 @@ const propertiesTabDisabled = computed(() => {
 
 const metadataMimeType = ref('application/json')
 const metadataURL = ref('')
+
+onMounted(() => {
+  useRedirectModal('.gallery-item-desc-markdown')
+})
 
 watchEffect(async () => {
   if (nft.value?.metadata) {

--- a/components/shared/collapse/DescriptionWrapper.vue
+++ b/components/shared/collapse/DescriptionWrapper.vue
@@ -35,6 +35,9 @@ export default class DescriptionWrapper extends mixins(KeyboardEventsMixin) {
     this.initKeyboardEventHandler({
       e: this.bindExpandEvents,
     })
+  }
+
+  public mounted() {
     useRedirectModal('.markdown-wrapper')
   }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5657
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

https://user-images.githubusercontent.com/16473062/233617182-4db7a7ed-172c-47cd-a3a8-aea422ca6852.mp4


- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e90c8d</samp>

Fixed the redirect modal for external links in gallery item descriptions. Added a mounted hook to `DescriptionWrapper` component to use `useRedirectModal` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e90c8d</samp>

> _We're sailing on the web with our `DescriptionWrapper`_
> _We need to show a modal when we click an external link_
> _We use the `useRedirectModal` function in the mounted hook_
> _Heave away, me hearties, heave away and don't you blink_
