### PR TITLE
fix: rmrk2.kodadot.xyz redirect url

### DIFF
--- a/composables/usePrefix.ts
+++ b/composables/usePrefix.ts
@@ -23,6 +23,10 @@ export default function () {
     return prefix.value
   })
 
+  const setUrlPrefix = (prefix) => {
+    storage.value = { selected: prefix }
+  }
+
   const client = computed<string>(() => {
     return urlPrefix.value === 'rmrk' ? 'subsquid' : urlPrefix.value
   })
@@ -35,6 +39,7 @@ export default function () {
 
   return {
     urlPrefix,
+    setUrlPrefix,
     client,
     tokenId,
     assets,

--- a/middleware/prefix.ts
+++ b/middleware/prefix.ts
@@ -3,10 +3,10 @@ import { chainPrefixes } from '@kodadot1/static'
 export const rmrk2ChainPrefixesInHostname = ['rmrk2', 'rmrk']
 
 export default function ({ store, route }): void {
-  const { urlPrefix } = usePrefix()
+  const prefixInPath = route.params.prefix || route.path.split('/')[1]
+  const { setUrlPrefix, urlPrefix } = usePrefix()
 
-  const prefix = urlPrefix.value
-  const isAnyChainPrefixInPath = chainPrefixes.includes(prefix)
+  const isAnyChainPrefixInPath = chainPrefixes.includes(prefixInPath)
   const rmrk2ChainPrefixInHostname = rmrk2ChainPrefixesInHostname.find(
     (prefix) => location.hostname.startsWith(`${prefix}.`)
   )
@@ -14,11 +14,7 @@ export default function ({ store, route }): void {
   if (rmrk2ChainPrefixInHostname) {
     // fixed chain domain (for example: rmrk2.kodadot.xyz)
 
-    if (
-      isAnyChainPrefixInPath &&
-      prefix &&
-      prefix !== rmrk2ChainPrefixInHostname
-    ) {
+    if (isAnyChainPrefixInPath && prefixInPath && prefixInPath !== 'ksm') {
       window.open(
         // multi-chain domain (for example: kodadot.xyz)
         `${window.location.origin.replace(
@@ -27,14 +23,15 @@ export default function ({ store, route }): void {
         )}${route.fullPath}`,
         '_self'
       )
-    } else if (store.getters.currentUrlPrefix !== rmrk2ChainPrefixInHostname) {
+    } else if (urlPrefix.value !== 'ksm') {
       store.dispatch('setUrlPrefix', 'ksm')
+      setUrlPrefix('ksm')
     }
   } else if (
-    store.getters.currentUrlPrefix !== prefix &&
-    prefix &&
+    urlPrefix.value !== prefixInPath &&
+    prefixInPath &&
     isAnyChainPrefixInPath
   ) {
-    store.dispatch('setUrlPrefix', prefix)
+    store.dispatch('setUrlPrefix', prefixInPath)
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5746
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb5d2a0</samp>

This pull request improves the handling of chain prefixes in the NFT gallery app. It uses the `usePrefix` composable to unify and simplify the prefix logic, and fixes some issues in the `prefix.ts` middleware.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fb5d2a0</samp>

> _We are the masters of the chain_
> _We use the prefix to control the domain_
> _We fix the bugs and refactor the code_
> _We use the composable to lighten the load_
