### PR TITLE
fix: Searchbar see all arrow on NFT tab

### DIFF
--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -114,7 +114,18 @@
             query: { ...$route.query },
           }">
           <div :class="loadMoreItemClassName" @click="seeAllButtonHandler">
-            {{ $t('search.seeAll') }} <span class="info-arrow">--></span>
+            {{ $t('search.seeAll') }}
+            <svg
+              class="ml-1"
+              width="28"
+              height="8"
+              viewBox="0 0 28 8"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M27.3536 4.35355C27.5488 4.15829 27.5488 3.84171 27.3536 3.64645L24.1716 0.464466C23.9763 0.269204 23.6597 0.269204 23.4645 0.464466C23.2692 0.659728 23.2692 0.976311 23.4645 1.17157L26.2929 4L23.4645 6.82843C23.2692 7.02369 23.2692 7.34027 23.4645 7.53553C23.6597 7.7308 23.9763 7.7308 24.1716 7.53553L27.3536 4.35355ZM0 4.5H27V3.5H0V4.5Z"
+                fill="currentColor" />
+            </svg>
           </div>
         </nuxt-link>
       </b-tab-item>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5747
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="544" alt="image" src="https://user-images.githubusercontent.com/31397967/233703646-260ddbe2-7c4f-4c02-98c8-40791b06dede.png">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 054486c</samp>

Replaced text arrow with SVG icon for `seeAll` button in `SearchSuggestion.vue`. This improves the UI design and consistency of the search suggestion component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 054486c</samp>

> _`seeAll` button changed_
> _From text arrow to icon_
> _A fresh look for spring_
