### PR TITLE
fix: setting persist storage

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
@@ -70,6 +70,7 @@ import { tokenIdToRoute } from '@/components/unique/utils'
 import nftByIdMinimal from '@/queries/rmrk/subsquid/nftByIdMinimal.graphql'
 import { ShoppingActions } from '@/utils/shoppingActions'
 import { ConnectWalletModalConfig } from '@/components/common/ConnectWallet/useConnectWallet'
+import { usePreferencesStore } from '@/stores/preferences'
 
 import Vue from 'vue'
 
@@ -96,6 +97,8 @@ const { urlPrefix, client } = usePrefix()
 const { accountId } = useAuth()
 const root = ref<Vue<Record<string, string>>>()
 const { $store, $apollo, $i18n, $buefy, $route } = useNuxtApp()
+const preferencesStore = usePreferencesStore()
+
 const emit = defineEmits(['buy-success'])
 const actionLabel = $i18n.t('nft.action.buy')
 
@@ -103,7 +106,11 @@ const { transaction, status, isLoading } = useTransaction()
 const connected = computed(() => Boolean(accountId.value))
 const active = ref(false)
 const label = computed(() =>
-  active.value ? $i18n.t('nft.action.confirm') : $i18n.t('nft.action.buy')
+  active.value
+    ? $i18n.t('nft.action.confirm')
+    : $i18n.t(
+        preferencesStore.getReplaceBuyNowWithYolo ? 'YOLO' : 'nft.action.buy'
+      )
 )
 
 const balance = computed<string>(() => {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -141,6 +141,7 @@ export default defineNuxtConfig({
     { src: '~/plugins/icons', mode: 'client' },
     { src: '~/plugins/consola', mode: 'client' },
     { src: '~/plugins/assets', mode: 'client' },
+    { src: '~/plugins/piniaPersistedState', mode: 'client' },
     '~/plugins/filters',
     '~/plugins/globalVariables',
     '~/plugins/pwa',

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "nuxt-edge": "2.16.0-27720022.54e852f",
     "nuxt-property-decorator": "^2.9.1",
     "ohmyfetch": "^0.4.21",
+    "pinia-plugin-persistedstate": "^3.1.0",
     "setimmediate": "^1.0.5",
     "slugify": "^1.6.6",
     "unzipit": "^1.4.3",

--- a/plugins/piniaPersistedState.ts
+++ b/plugins/piniaPersistedState.ts
@@ -1,0 +1,9 @@
+import { createPinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+
+const pinia = createPinia()
+pinia.use(piniaPluginPersistedstate)
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.$pinia.use(piniaPluginPersistedstate)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,7 @@ importers:
       nuxt-edge: 2.16.0-27720022.54e852f
       nuxt-property-decorator: ^2.9.1
       ohmyfetch: ^0.4.21
+      pinia-plugin-persistedstate: ^3.1.0
       prettier: ^2.8.7
       raw-loader: ^4.0.2
       sass: ^1.62.0
@@ -178,6 +179,7 @@ importers:
       nuxt-edge: 2.16.0-27720022.54e852f_stgnfuekanqoxv2sawfe5zt2vu
       nuxt-property-decorator: 2.9.1_vue@2.7.14+vuex@3.6.2
       ohmyfetch: 0.4.21
+      pinia-plugin-persistedstate: 3.1.0
       setimmediate: 1.0.5
       slugify: 1.6.6
       unzipit: 1.4.3
@@ -18970,6 +18972,12 @@ packages:
     resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
     engines: {node: '>=10'}
 
+  /pinia-plugin-persistedstate/3.1.0:
+    resolution: {integrity: sha512-8UN+vYMEPBdgNLwceY08mi5olI0wkYaEb8b6hD6xW7SnBRuPydWHlEhZvUWgNb/ibuf4PvufpvtS+dmhYjJQOw==}
+    peerDependencies:
+      pinia: ^2.0.0
+    dev: false
+
   /pinia/2.0.34_hwpzsh6pnvsm3pjf2zi526hnzq:
     resolution: {integrity: sha512-cgOoGUiyqX0SSgX8XelK9+Ri4XA2/YyNtgjogwfzIx1g7iZTaZPxm7/bZYMCLU2qHRiHhxG7SuQO0eBacFNc2Q==}
     peerDependencies:
@@ -21309,7 +21317,7 @@ packages:
       detect-libc: 2.0.1
       node-addon-api: 5.1.0
       prebuild-install: 7.1.1
-      semver: 7.3.8
+      semver: 7.4.0
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0

--- a/stores/preferences.ts
+++ b/stores/preferences.ts
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia'
-import useLocalStorage from '@/composables/useLocalStorage'
 
 interface State {
   sidebarFilterCollapseOpen: boolean
@@ -28,9 +27,6 @@ interface State {
   // Mass Mint
   visitedOnboarding: boolean
 }
-const massMintLocalStorage = useLocalStorage('massmint', {
-  visitedOnboarding: false,
-})
 
 export const usePreferencesStore = defineStore('preferences', {
   state: (): State => ({
@@ -57,7 +53,7 @@ export const usePreferencesStore = defineStore('preferences', {
     enableAllArtwork: true,
     enableGyroEffect: false,
     gridSize: 'small',
-    visitedOnboarding: massMintLocalStorage.value.visitedOnboarding,
+    visitedOnboarding: false,
   }),
   getters: {
     getsidebarFilterCollapse: (state) => state.sidebarFilterCollapseOpen,
@@ -162,7 +158,7 @@ export const usePreferencesStore = defineStore('preferences', {
     },
     setVisitedOnboarding(payload: boolean) {
       this.visitedOnboarding = payload
-      massMintLocalStorage.value = { visitedOnboarding: payload }
     },
   },
+  persist: true,
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [x] enable persist storage with pinia 
ref: https://prazdevs.github.io/pinia-plugin-persistedstate/guide/why.html

## Context

- [x] Closes #5555
- [x] Closes #5763
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/31397967/233795783-b5385da0-be5f-4138-976a-196bd921549d.png">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 829451f</samp>

This pull request adds a feature that lets users customize the buy button text in the gallery, and implements a plugin that persists the user preferences in the local storage using Pinia. It modifies `components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue`, `pnpm-lock.yaml`, `stores/preferences.ts`, `nuxt.config.js`, and creates `plugins/piniaPersistedState.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 829451f</samp>

> _We're sailing with Nuxt and Pinia on the web_
> _We're saving user prefs with `persistedstate`_
> _We're heaving away on the count of three_
> _We're changing the buy button to say YOLO, matey_
