### PR TITLE
fix: No tooltip displayed on buy button

### DIFF
--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
@@ -6,7 +6,6 @@
     $tooltip-distance: calc(16px + 100%);
   }
   .o-tip__trigger{
-    width: fit-content;
      > * {
     height: 100%;
     font-size: inherit;


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [x] Closes #5766

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="926" alt="image" src="https://user-images.githubusercontent.com/31397967/233797030-61adc566-47ea-4a18-9a5f-90b027cbb87f.png">



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd9af48</samp>

Fixed tooltip overflow issue by removing `width: fit-content` from `.tooltip` class in `NeoTooltip.scss` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bd9af48</samp>

> _`.tooltip` fixed_
> _No more overflow issues_
> _Autumn leaves adapt_
