### PR TITLE
#5757 search empty text

### DIFF
--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -14,6 +14,9 @@
             :key="item"
             is-loading />
         </div>
+        <div v-else-if="!collectionSuggestion.length" class="mx-6 mt-4">
+          {{ $t('search.collectionNotFound', [name]) }}
+        </div>
         <div v-else>
           <div
             v-for="(item, idx) in collectionSuggestion"
@@ -77,6 +80,9 @@
             v-for="item in searchSuggestionEachTypeMaxNum"
             :key="item"
             is-loading />
+        </div>
+        <div v-else-if="!nftSuggestion.length" class="mx-6 mt-4">
+          {{ $t('search.nftNotFound', [name]) }}
         </div>
         <div v-else>
           <div

--- a/locales/en.json
+++ b/locales/en.json
@@ -77,8 +77,8 @@
     "landingTitle2": "Collect",
     "landingTitle3": "And Sell",
     "landingSubtitle": "Kusama NFTS",
-    "collectionNotFound": "Our search agents did not found anything with '{0}' in collection name",
-    "nftNotFound": "Our search agents did not found anything with '{0}' in NFT name"
+    "collectionNotFound": "Our search agents did not found anything with \"{0}\" in collection name",
+    "nftNotFound": "Our search agents did not found anything with \"{0}\" in NFT name"
   },
   "topCollections": {
     "timeFrames": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -76,7 +76,9 @@
     "landingTitle1": "Discover,",
     "landingTitle2": "Collect",
     "landingTitle3": "And Sell",
-    "landingSubtitle": "Kusama NFTS"
+    "landingSubtitle": "Kusama NFTS",
+    "collectionNotFound": "Our search agents did not found anything with  {0} in collection name",
+    "nftNotFound": "Our search agents did not found anything with {0} in NFT name"
   },
   "topCollections": {
     "timeFrames": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -77,7 +77,7 @@
     "landingTitle2": "Collect",
     "landingTitle3": "And Sell",
     "landingSubtitle": "Kusama NFTS",
-    "collectionNotFound": "Our search agents did not found anything with  {0} in collection name",
+    "collectionNotFound": "Our search agents did not found anything with {0} in collection name",
     "nftNotFound": "Our search agents did not found anything with {0} in NFT name"
   },
   "topCollections": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -77,8 +77,8 @@
     "landingTitle2": "Collect",
     "landingTitle3": "And Sell",
     "landingSubtitle": "Kusama NFTS",
-    "collectionNotFound": "Our search agents did not found anything with {0} in collection name",
-    "nftNotFound": "Our search agents did not found anything with {0} in NFT name"
+    "collectionNotFound": "Our search agents did not found anything with '{0}' in collection name",
+    "nftNotFound": "Our search agents did not found anything with '{0}' in NFT name"
   },
   "topCollections": {
     "timeFrames": {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #5757
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: 
[Payout](https://beta.kodadot.xyz/transfer/?target=EzGc4s9PgCPx1YnF3fqzhLzVHpHMTL4LWPScwpDrR8JKgSU)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="798" alt="Screen Shot 2023-04-23 at 7 31 44 PM" src="https://user-images.githubusercontent.com/39299315/233886731-f3d6232c-0af5-4de3-b31c-a43978eca6ca.png">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2fff809</samp>

Add feedback messages for empty search suggestions. The `SearchSuggestion` component now displays localized messages when no suggestions are found for a given query, using margin classes for styling.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2fff809</samp>

> _When the search box has no suggestions_
> _It shows some feedback messages_
> _They are localized_
> _And nicely sized_
> _With margin classes for the edges_
