### PR TITLE
test: fix e2e test for simple mint estimated value

### DIFF
--- a/components/rmrk/Create/SimpleMint.vue
+++ b/components/rmrk/Create/SimpleMint.vue
@@ -233,7 +233,7 @@ const components = {
   Support,
   AttributeTagInput: () => import('./AttributeTagInput.vue'),
   BalanceInput: () => import('@/components/shared/BalanceInput.vue'),
-  Money: () => import('@/components/shared/format/Money.vue'),
+  Money: () => import('@/components/shared/format/BasicMoney.vue'),
   Loader: () => import('@/components/shared/Loader.vue'),
   CollapseWrapper: () =>
     import('@/components/shared/collapse/CollapseWrapper.vue'),

--- a/components/shared/form/BasicInput.vue
+++ b/components/shared/form/BasicInput.vue
@@ -28,7 +28,7 @@ const { $i18n } = useNuxtApp()
 
 withDefaults(
   defineProps<{
-    value: string
+    value?: string
     label: string
     placeholder: string
     expanded?: boolean
@@ -39,6 +39,7 @@ withDefaults(
     disabled?: boolean
   }>(),
   {
+    value: '',
     expanded: false,
     type: '',
     message: '',

--- a/tests/cypress/e2e/rmrk-simple-mint.cy.ts
+++ b/tests/cypress/e2e/rmrk-simple-mint.cy.ts
@@ -13,7 +13,12 @@ describe('simple mint in rmrk', () => {
     cy.waitForNetworkIdle('POST', '*', 1000)
 
     // fee should zero at first
-    cy.get('[data-cy="fee"] span').should('have.text', '\n    0\n    KSM\n  ')
+    cy.get('[data-cy="fee"]')
+      .invoke('text')
+      .then((text) => {
+        const cleanedText = text.trim().replace(/\s+/g, ' ')
+        expect(cleanedText).to.equal('0 KSM')
+      })
 
     // upload
     cy.get('[data-cy="input-upload"] [type="file"]').attachFile(
@@ -104,10 +109,12 @@ describe('simple mint in rmrk', () => {
     cy.get('[data-cy="input-tos"] [type="checkbox"]').check({ force: true })
     cy.get('[data-cy="input-tos"] [type="checkbox"]').should('be.checked')
 
-    // uncomment once this resolved https://github.com/kodadot/nft-gallery/issues/3966
-    // cy.get('[data-cy="fee"] span').should(
-    //   'not.have.text',
-    //   '\n    0\n    KSM\n  '
-    // )
+    // related issue https://github.com/kodadot/nft-gallery/issues/3966
+    cy.get('[data-cy="fee"]')
+      .invoke('text')
+      .then((text) => {
+        const cleanedText = text.trim().replace(/\s+/g, ' ')
+        expect(cleanedText).to.not.equal('0 KSM')
+      })
   })
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #3966
- [x] the fix was by change `Money.vue` to `BasicMoney.vue` on estimated value
- [x] adjust `BasicInput` props for `value`, to remove warning get undefined

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
copilot:summary

copilot:poem
