### PR TITLE
:bug: parent not present on rmrk

### DIFF
--- a/queries/subsquid/rmrk/nftById.graphql
+++ b/queries/subsquid/rmrk/nftById.graphql
@@ -6,15 +6,6 @@ query nftById($id: String!) {
   nftEntity: nftEntityById(id: $id) {
     ...nft
     ...nftDetails
-    parent {
-      ...nft
-      ...nftDetails
-      meta {
-        image
-        animation_url: animationUrl
-        ...baseMeta
-      }
-    }
     collection {
       id
       name

--- a/queries/subsquid/rmrk/nftById.graphql
+++ b/queries/subsquid/rmrk/nftById.graphql
@@ -1,6 +1,5 @@
 #import "../../fragments/nft.graphql"
 #import "../../fragments/nftDetails.graphql"
-#import "../../fragments/baseMeta.graphql"
 
 query nftById($id: String!) {
   nftEntity: nftEntityById(id: $id) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring



## Context

- #5735 broke RMRK

![Screenshot 2023-04-25 at 14 44 01](https://user-images.githubusercontent.com/22471030/234280173-a66ba60c-fe8a-4877-a757-313ed9ea3ac1.png)


![Screenshot 2023-04-25 at 14 54 44](https://user-images.githubusercontent.com/22471030/234282934-e7f56762-738b-43a3-ae9e-316b9b5987c5.png)



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 268f5b1</samp>

Removed the `parent` field from the `nftById` query to simplify the query and the response. This field was not needed for fetching the details of a single NFT.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 268f5b1</samp>

> _`nftById` query_
> _simpler without parent field_
> _autumn leaves fall fast_
