### PR TITLE
implement skeleton default loading dialog

### DIFF
--- a/components/common/EmptyResult.vue
+++ b/components/common/EmptyResult.vue
@@ -1,27 +1,20 @@
 <template>
   <section>
-    <div class="card" aria-id="contentIdForA11y3">
-      <div class="card-header" role="button" aria-controls="contentIdForA11y3">
-        <p class="card-header-title">
-          <template v-if="!loading">Component</template>
-          <b-skeleton size="is-large" :active="loading"></b-skeleton>
-        </p>
-      </div>
-      <footer class="card-footer">
-        <a class="card-footer-item">
-          <template v-if="!loading">Save</template>
-          <b-skeleton size="is-large" :active="loading"></b-skeleton>
-        </a>
-        <a class="card-footer-item">
-          <template v-if="!loading">Edit</template>
-          <b-skeleton size="is-large" :active="loading"></b-skeleton>
-        </a>
-        <a class="card-footer-item">
-          <template v-if="!loading">Delete</template>
-          <b-skeleton size="is-large" :active="loading"></b-skeleton>
-        </a>
-      </footer>
+    <div class="block">
+      <b-field grouped group-multiline>
+        <div class="control">
+          <b-switch v-model="animated">Animated</b-switch>
+        </div>
+      </b-field>
     </div>
+
+    <b-skeleton width="20%" :animated="animated"></b-skeleton>
+
+    <b-skeleton width="40%" :animated="animated"></b-skeleton>
+
+    <b-skeleton width="80%" :animated="animated"></b-skeleton>
+
+    <b-skeleton :animated="animated"></b-skeleton>
   </section>
 </template>
 
@@ -29,14 +22,8 @@
 export default {
   data() {
     return {
-      loading: true,
+      animated: true,
     }
-  },
-  mounted() {
-    setInterval(() => {
-      this.loading = !this.loading
-    }, 10 * 1000)
-    clearInterval()
   },
 }
 </script>

--- a/components/common/EmptyResult.vue
+++ b/components/common/EmptyResult.vue
@@ -1,10 +1,41 @@
 <template>
-  <section class="section has-text-centered">
-    <div class="title is-4">
-      {{ $t('general.searchNoResultsTitle') }}
-    </div>
-    <div class="subtitle is-6">
-      {{ $t('general.searchNoResultsText') }}
+  <section>
+    <div class="card" aria-id="contentIdForA11y3">
+      <div class="card-header" role="button" aria-controls="contentIdForA11y3">
+        <p class="card-header-title">
+          <template v-if="!loading">Component</template>
+          <b-skeleton size="is-large" :active="loading"></b-skeleton>
+        </p>
+      </div>
+      <footer class="card-footer">
+        <a class="card-footer-item">
+          <template v-if="!loading">Save</template>
+          <b-skeleton size="is-large" :active="loading"></b-skeleton>
+        </a>
+        <a class="card-footer-item">
+          <template v-if="!loading">Edit</template>
+          <b-skeleton size="is-large" :active="loading"></b-skeleton>
+        </a>
+        <a class="card-footer-item">
+          <template v-if="!loading">Delete</template>
+          <b-skeleton size="is-large" :active="loading"></b-skeleton>
+        </a>
+      </footer>
     </div>
   </section>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      loading: true,
+    }
+  },
+  mounted() {
+    setInterval(() => {
+      this.loading = !this.loading
+    }, 3 * 1000)
+  },
+}
+</script>

--- a/components/common/EmptyResult.vue
+++ b/components/common/EmptyResult.vue
@@ -35,7 +35,8 @@ export default {
   mounted() {
     setInterval(() => {
       this.loading = !this.loading
-    }, 3 * 1000)
+    }, 10 * 1000)
+    clearInterval()
   },
 }
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [- ] Feature
- [ ] Refactoring

## Context

- [ ] Closes #5479 
- [] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [-] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [- ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [-] Fill up your KSM address: DaJ6DPPTDy7w2vW2pDmDmYaXxvc6yth6Dd7quhuw5woD224(https://beta.kodadot.xyz/transfer/?target=
<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [-] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [-] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3cf10d</samp>

Replaced the EmptyResult component template with a skeleton loading card component to enhance the UX of empty or loading search results. This was part of a PR to add skeleton loading components to `kodadot/nft-gallery`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f3cf10d</samp>

> _`EmptyResult` changed_
> _Skeleton card shows loading_
> _Winter of waiting_
