### PR TITLE
fix: Offers tab on kusama bug

### DIFF
--- a/libs/ui/src/components/DisablableTab/DisablableTab.scss
+++ b/libs/ui/src/components/DisablableTab/DisablableTab.scss
@@ -4,10 +4,11 @@
   &--disabled {
     // overide o-tabs-item
     cursor: auto !important;
-    pointer-events: all !important;
     opacity: unset !important;
     // mimick opacity (opacity prevents hover form triggering tooltip)
-
+    .neo-tooltip {
+      pointer-events: all;
+    }
     @include ktheme() {
       color: rgba($color: theme('text-color'), $alpha: 0.5) !important;
     }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5771
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="687" alt="image" src="https://user-images.githubusercontent.com/31397967/235489385-079ec895-d284-4d88-bc83-bcdfbd3c488b.png">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7d9a83</samp>

Fixed tooltip bug for disabled tabs by moving `pointer-events` rule to `.neo-tooltip` class in `DisablableTab.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b7d9a83</samp>

> _`pointer-events` moved_
> _tooltip shows on disabled_
> _a winter bug fixed_
