### PR TITLE
fix: Price in Units

### DIFF
--- a/tests/unit-testing/components/shared/BalanceInput.test.ts
+++ b/tests/unit-testing/components/shared/BalanceInput.test.ts
@@ -35,6 +35,11 @@ describe('BalanceInput.vue', () => {
             prefix: 'rmrk',
           },
         },
+        usePrefix: () => ({
+          urlPrefix: {
+            value: 'rmrk',
+          },
+        }),
       },
       localVue,
     })

--- a/tests/unit-testing/components/shared/BalanceInput.test.ts
+++ b/tests/unit-testing/components/shared/BalanceInput.test.ts
@@ -14,6 +14,11 @@ describe('BalanceInput.vue', () => {
   vi.useFakeTimers()
 
   beforeAll(() => {
+    ;(window as any).usePrefix = () => ({
+      urlPrefix: {
+        value: 'rmrk',
+      },
+    })
     wrapper = mount(BalanceInput, {
       propsData: {
         min: 10,
@@ -35,11 +40,6 @@ describe('BalanceInput.vue', () => {
             prefix: 'rmrk',
           },
         },
-        usePrefix: () => ({
-          urlPrefix: {
-            value: 'rmrk',
-          },
-        }),
       },
       localVue,
     })

--- a/tests/unit-testing/components/shared/BasicBalanceInput.test.ts
+++ b/tests/unit-testing/components/shared/BasicBalanceInput.test.ts
@@ -13,6 +13,11 @@ describe('BalanceInput.vue', () => {
   vi.useFakeTimers()
 
   beforeAll(() => {
+    ;(window as any).usePrefix = () => ({
+      urlPrefix: {
+        value: 'rmrk',
+      },
+    })
     wrapper = mount(BasicBalanceInput, {
       propsData: {
         min: 10,

--- a/utils/mixins/prefixMixin.ts
+++ b/utils/mixins/prefixMixin.ts
@@ -9,7 +9,7 @@ import { getKusamaAssetId } from '@/utils/api/bsx/query'
 @Component
 export default class PrefixMixin extends Vue {
   get urlPrefix() {
-    return this.$route.params.prefix || this.$store.getters.currentUrlPrefix
+    return usePrefix().urlPrefix.value
   }
 
   get client(): string {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5843
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1815" alt="image" src="https://user-images.githubusercontent.com/31397967/235731816-d3341dc4-1209-476b-beb9-a025e6f0fe4e.png">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 337168e</samp>

Refactored `urlPrefix` getter to use `usePrefix` composable function for simplicity and consistency. Moved `usePrefix` function to a separate file `./composables/usePrefix.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 337168e</samp>

> _`usePrefix` helps_
> _refactor `urlPrefix` getter_
> _autumn of old code_
