### PR TITLE
Reverting back to marckV2 for rmrk2

### DIFF
--- a/libs/static/src/indexers.ts
+++ b/libs/static/src/indexers.ts
@@ -9,7 +9,7 @@ export const INDEXERS: Config<SquidEndpoint> = {
   glmr: 'https://squid.subsquid.io/click/v/002/graphql',
   rmrk: 'https://squid.subsquid.io/rubick/graphql',
   movr: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
-  ksm: 'https://squid.subsquid.io/marck/graphql',
+  ksm: 'https://squid.subsquid.io/marck/v/v2/graphql',
   snek: 'https://squid.subsquid.io/snekk/v/004/graphql',
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Toilet Fix
- [x] Related https://github.com/kodadot/nft-gallery/issues/5853

Goal is to prevent that collections are gone or some other failure when we are promoting new indexer to production, **probably would be good to start using numbers in indexers.ts** and not rely on "latest" version, wyt @vikiival  ?

meanwhile @vikiival done rollback to v2 as v3 has something new we don't support in collections.
```
➜  rubick git:(main) npx sqd prod marck@v2
? Your squid "marck" version "v2" will be assigned to the production endpoint https://squid.subsquid.io/marck/graphql. Are you sure? Yes
The squid "marck" is assigned to the production endpoint and will soon be available at https://squid.subsquid.io/marck/graphql.
```

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de8ab7b</samp>

Updated the Kusama indexer to `v2` in `libs/static/src/indexers.ts` to improve blockchain data querying.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at de8ab7b</samp>

> _`INDEXERS` object_
> _Updated to use `v2`_
> _Kusama blooms faster_
