### PR TITLE
#5852 Buefy checkbox to neo checkbox

### DIFF
--- a/components/rmrk/Gallery/Holder/Holder.vue
+++ b/components/rmrk/Gallery/Holder/Holder.vue
@@ -24,15 +24,15 @@
         <div class="is-flex is-justify-content-space-between box-container">
           <b-field grouped group-multiline>
             <div class="control">
-              <b-checkbox v-model="showDetailIcon">NFT Details</b-checkbox>
+              <NeoCheckbox v-model="showDetailIcon">NFT Details</NeoCheckbox>
             </div>
             <div
               v-for="(column, index) in columnsVisible"
               :key="index"
               class="control">
-              <b-checkbox v-model="column.display">
+              <NeoCheckbox v-model="column.display">
                 {{ column.title }}
-              </b-checkbox>
+              </NeoCheckbox>
             </div>
           </b-field>
         </div>
@@ -167,6 +167,7 @@ import { Component, Prop, Watch, mixins } from 'nuxt-property-decorator'
 import { Debounce } from 'vue-debounce-decorator'
 import { Interaction } from '@kodadot1/minimark/v1'
 import { formatDistanceToNow } from 'date-fns'
+import { NeoCheckbox } from '@kodadot1/brick'
 
 import ChainMixin from '@/utils/mixins/chainMixin'
 import KeyboardEventsMixin from '@/utils/mixins/keyboardEventsMixin'

--- a/components/shared/form/BasicCheckbox.vue
+++ b/components/shared/form/BasicCheckbox.vue
@@ -1,13 +1,14 @@
 <template>
   <b-field>
-    <b-checkbox v-model="isChecked" :disabled="disabled">
+    <NeoCheckbox v-model="isChecked" :disabled="disabled">
       {{ $t(label) }}
-    </b-checkbox>
+    </NeoCheckbox>
   </b-field>
 </template>
 
 <script lang="ts">
 import { Component, Prop, VModel, Vue } from 'nuxt-property-decorator'
+import { NeoCheckbox } from '@kodadot1/brick'
 
 @Component
 export default class BasicCheckbox extends Vue {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] related with #5852 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a05013</samp>

Updated checkbox components to use `NeoCheckbox` from `@kodadot1/brick` for better UI design and consistency. Affected files are `Holder.vue` and `BasicCheckbox.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a05013</samp>

> _To make the UI more refined_
> _We replaced Buefy checkboxes in kind_
> _With `NeoCheckbox` from `brick`_
> _Which is custom and slick_
> _And now our components are well-aligned_
