### PR TITLE
fix: Enable RMRK2 on production - kodadot.xyz

### DIFF
--- a/libs/static/src/chains.ts
+++ b/libs/static/src/chains.ts
@@ -36,7 +36,7 @@ export const CHAINS: Config<ChainProperties> = {
   glmr: toChainProperty(1284, 18, 'GLMR', 'https://moonbeam.subscan.io/'),
 }
 
-export const DEFAULT_PREFIX: Prefix = 'bsx'
+export const DEFAULT_PREFIX: Prefix = 'ksm'
 
 export const chainPrefixes: Prefix[] = [
   'bsx',

--- a/utils/chain.ts
+++ b/utils/chain.ts
@@ -96,21 +96,11 @@ export const disableChainListOnBetaEnv = [
   'glmr',
   'snek',
 ]
-export const disableChainListOnProductionEnv = [
-  ...disableChainListOnBetaEnv,
-  'ksm',
-]
 
 export const availablePrefixes = (): Option[] => {
   const chains = chainList()
 
-  if (isProduction) {
-    return chains.filter(
-      (chain) => !disableChainListOnProductionEnv.includes(String(chain.value))
-    )
-  }
-
-  if (isBeta) {
+  if (isProduction || isBeta) {
     return chains.filter(
       (chain) => !disableChainListOnBetaEnv.includes(String(chain.value))
     )


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5887
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b2b892</samp>

Simplified the logic for filtering out chains based on the environment in `utils/chain.ts`. Removed the unused `disableChainListOnProductionEnv` variable and condition.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b2b892</samp>

> _`disableChainList`_
> _gone, only one check remains_
> _code is simpler now_
