### PR TITLE
➖ remove b-progress component

### DIFF
--- a/components/metadata/Metadata.vue
+++ b/components/metadata/Metadata.vue
@@ -2,43 +2,24 @@
   <div>
     <DisabledInput
       label="Address Prefix"
-      :value="loading ? '' : chainProperties.ss58Format.toString()" />
+      :value="chainProperties.ss58Format.toString() || ''" />
     <DisabledInput
       label="Decimals"
-      :value="loading ? '' : chainProperties.tokenDecimals.toString()" />
+      :value="chainProperties.tokenDecimals.toString() || ''" />
     <DisabledInput
       label="Unit"
-      :value="loading ? '' : chainProperties.tokenSymbol.toString()" />
+      :value="chainProperties.tokenSymbol.toString() || ''" />
     <DisabledInput
       v-if="chainProperties.blockExplorer"
       label="Block Explorer"
-      :value="loading ? '' : chainProperties.blockExplorer?.toString()" />
+      :value="chainProperties.blockExplorer?.toString() || ''" />
     <DisabledInput
       v-if="chainProperties.genesisHash"
       label="Genesis Hash"
-      :value="loading ? '' : chainProperties.genesisHash?.toString()" />
-    <b-progress v-if="loading" size="is-large" type="is-primary" show-value>
-      Connecting
-    </b-progress>
+      :value="chainProperties.genesisHash?.toString() || ''" />
   </div>
 </template>
 
-<script lang="ts">
-import { Component, Watch, mixins } from 'nuxt-property-decorator'
-import DisabledInput from '@/components/shared/DisabledInput.vue'
-import ChainMixin from '@/utils/mixins/chainMixin'
-
-@Component({
-  components: {
-    DisabledInput,
-  },
-})
-export default class Summary extends mixins(ChainMixin) {
-  public loading = false
-
-  @Watch('$store.state.loading')
-  public mapLoading(): void {
-    this.loading = this.$store.state.loading
-  }
-}
+<script setup lang="ts">
+const { chainProperties } = useChain()
 </script>


### PR DESCRIPTION
For now removing this component since it isn't used (and never shown)
If we will need a progress bar component, wait for design and use [progress](https://developer.mozilla.org/fr/docs/Web/HTML/Element/progress) html tag instead

## PR Type

- [x] Refactoring

## Context

- [x] related with #5852 
- [x] migrate `Metadata` component to Vue3 composition api
- [x] remove auto import

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

## Screenshot 📸

![Capture d’écran 2023-05-10 à 1 55 21 PM](https://github.com/kodadot/nft-gallery/assets/9987732/57f7107a-6885-4676-8688-8418a8b1dbb1)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acf5f26</samp>

Refactor `Metadata.vue` component to use Vue 3 `<script setup>` syntax and `useChain` composable function. Simplify the handling of loading and error states and the display of `chainProperties` fields.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at acf5f26</samp>

> _`<script setup>` now_
> _simplifies components - no_
> _mixins or watchers_
