### PR TITLE
fix: Connect your wallet in create not working

### DIFF
--- a/components/navbar/ProfileDropdown.vue
+++ b/components/navbar/ProfileDropdown.vue
@@ -165,7 +165,7 @@
         class="button-connect-wallet px-4"
         variant="k-accent"
         no-shadow
-        modal-toggle-disabled
+        :modal-toggle-disabled="true"
         @toggleConnectModal="toggleWalletConnectModal" />
     </div>
 

--- a/components/shared/ConnectWalletButton.vue
+++ b/components/shared/ConnectWalletButton.vue
@@ -10,7 +10,6 @@
 import { Component, Prop, Vue } from 'nuxt-property-decorator'
 import { NeoButton, NeoButtonVariant } from '@kodadot1/brick'
 import { ConnectWalletModalConfig } from '../common/ConnectWallet/useConnectWallet'
-import { isMobileDevice } from '@/utils/extension'
 
 @Component({
   components: { NeoButton },
@@ -29,6 +28,7 @@ export default class ConnectWalletButton extends Vue {
     } else {
       this.$emit('toggleConnectModal')
     }
+
     if (!this.modalToggleDisabled) {
       if (this.modal?.isActive) {
         this.modal.close()


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5899
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3691ee</samp>

This pull request enhances the `ConnectWalletButton` component by adding a prop to control the connect modal and removing unnecessary code. This prevents nested modals from appearing when the button is used in other modals, such as in the `CreateCollectionModal`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d3691ee</samp>

> _No more nested modals of doom_
> _We disable the toggle with a prop_
> _`ConnectWalletButton` is improved_
> _We remove the code that makes us flop_
