### PR TITLE
fix: Spotlighted: rmrk2

### DIFF
--- a/components/carousel/utils/useCarouselSpotlight.ts
+++ b/components/carousel/utils/useCarouselSpotlight.ts
@@ -25,6 +25,13 @@ const curatedCollection = {
     // '2075be44ea4b9e422d-🐺', // WolfAngryClub
     // '7cf9daa38281a57331-BSS', // Spaceships (ClownWorldHouse)
   ],
+  ksm: [
+    '3629a3ff458d113e25-PUNK', // RMRK Punks
+    '3e6f301b0a0b1a0e4e-MRWH', // Mr Whitehole
+    '2644199cf3652aaa78-KK01', // Kusama Kings
+    'be15890524c6e9b359-WIZARD', // Manta Wizard
+    'e63e926f7db5997e5c-STGR', // STARGAZER
+  ],
 }
 
 type Collections = CarouselNFT & SomethingWithMeta


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5910
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1372" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/902853bf-324b-4467-a059-de54c1583475">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ff56b4</samp>

Added a new curated collection of Kusama NFTs to the carousel spotlight component. This is part of a larger feature to support Kusama NFTs in the gallery.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3ff56b4</samp>

> _`curatedCollection`_
> _adds Kusama NFTs - wow!_
> _carousel spotlight_
