### PR TITLE
fix: redirect rmrk2 prefix to ksm

### DIFF
--- a/middleware/redirects.ts
+++ b/middleware/redirects.ts
@@ -1,5 +1,6 @@
 export default function ({ store, redirect, route }): void {
   const prefix = store.getters.currentUrlPrefix
+
   if (route.path.startsWith(`/${prefix}`)) {
     if (route.path.endsWith('collections')) {
       return redirect(`/${prefix}/explore/collectibles`)
@@ -7,5 +8,9 @@ export default function ({ store, redirect, route }): void {
     if (route.path.endsWith('gallery')) {
       return redirect(`/${prefix}/explore/items`)
     }
+  }
+
+  if (route.path.includes('/rmrk2/')) {
+    return redirect(route.path.replace('/rmrk2/', '/ksm/'))
   }
 }

--- a/middleware/redirects.ts
+++ b/middleware/redirects.ts
@@ -11,6 +11,6 @@ export default function ({ store, redirect, route }): void {
   }
 
   if (route.path.includes('/rmrk2/')) {
-    return redirect(route.path.replace('/rmrk2/', '/ksm/'))
+    return redirect(window.location.href.replace('/rmrk2/', '/ksm/'))
   }
 }

--- a/tests/cypress/e2e/redirect.cy.ts
+++ b/tests/cypress/e2e/redirect.cy.ts
@@ -1,0 +1,17 @@
+describe('redirect middleware', () => {
+  it('should redirect from rmrk2 prefix to ksm', () => {
+    cy.visit(
+      '/rmrk2/gallery/17842583-22708b368d163c8007-CITY-LOWER_ART_DISTRICT-00000006'
+    )
+    cy.url().should(
+      'include',
+      '/ksm/gallery/17842583-22708b368d163c8007-CITY-LOWER_ART_DISTRICT-00000006'
+    )
+
+    cy.visit('/rmrk2/explore/items?listed=true&sort=updatedAt_DESC')
+    cy.url().should(
+      'include',
+      '/ksm/explore/items?listed=true&sort=updatedAt_DESC'
+    )
+  })
+})


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5913
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at https://deploy-preview-5918--koda-canary.netlify.app/rmrk2/gallery/17842583-22708b368d163c8007-CITY-LOWER_ART_DISTRICT-00000006
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=DY4SQF2iD456tH89aQtz5wv1EV3BbSW8wKKuMcwbmXaj1pM)


#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c907ea7</samp>

Improved middleware for network switching and readability. Added feature flag to redirect `rmrk2` to `ksm` routes in `middleware/redirects.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c907ea7</samp>

> _`rmrk2` or `ksm`?_
> _Middleware can switch them_
> _A flag cuts the flow_
