### PR TITLE
:bug: name could be null

### DIFF
--- a/components/shared/filters/modules/usePopularCollections.ts
+++ b/components/shared/filters/modules/usePopularCollections.ts
@@ -20,7 +20,7 @@ function handleResult(
     })) || []
   return collections
     .concat(newCollections)
-    .sort((a, b) => a.meta.name.localeCompare(b.meta.name))
+    .sort((a, b) => a.meta.name?.localeCompare(b.meta.name))
 }
 
 function getCollections(chain: string): { [chain: string]: string[] } {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [ ] Closes #<issue_number>
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

![Screenshot 2023-05-11 at 16 30 44](https://github.com/kodadot/nft-gallery/assets/22471030/727a52de-04bd-4bf2-bc3f-e6a03a2049a4)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 765dca1</samp>

Fixed a bug that caused errors when sorting collections by popularity. Used optional chaining on `a.meta.name` in `usePopularCollections.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 765dca1</samp>

> _Sorting collections_
> _`a.meta.name` may be nil_
> _Use optional chain_
