### PR TITLE
Custom Link component for NeoNftCard

### DIFF
--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -6,7 +6,9 @@
     :prefix="urlPrefix"
     :show-price="Number(nft?.price) > 0"
     :variant="variant"
-    :unloackable-icon="unlockableIcon" />
+    :unloackable-icon="unlockableIcon"
+    link="nuxt-link"
+    bind-key="to" />
 </template>
 
 <script setup lang="ts">

--- a/components/shared/gallery/NftCard.vue
+++ b/components/shared/gallery/NftCard.vue
@@ -4,7 +4,9 @@
     :prefix="urlPrefix"
     :show-price="showPrice"
     :variant="variant"
-    :placeholder="placeholder" />
+    :placeholder="placeholder"
+    link="nuxt-link"
+    bind-key="to" />
 </template>
 
 <script lang="ts" setup>

--- a/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
+++ b/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="nft-card">
-    <a
-      :href="`/${prefix}/gallery/${nft.id}${
-        unlockable ? '?unlockable=' + unlockable : ''
-      }`">
+    <component :is="link" :[bindKey]="`/${prefix}/gallery/${nft.id}`">
       <img
         v-if="unlockable && unloackableIcon"
         class="unloackable-icon"
@@ -62,7 +59,7 @@
           >
         </div>
       </div>
-    </a>
+    </component>
   </div>
 </template>
 
@@ -83,11 +80,15 @@ withDefaults(
     placeholder: string
     unlockable?: boolean
     unloackableIcon?: string
+    link?: string
+    bindKey?: string
   }>(),
   {
     collectionPopoverShowDelay: 500,
     variant: 'primary',
     unloackableIcon: undefined,
+    link: 'a',
+    bindKey: 'href',
   }
 )
 </script>


### PR DESCRIPTION
- :technologist: neo-nft-card takes custom link component
- :zap: use nuxt-link for neo-nft-card

# TL;DR

I've seen in the PR that @roiLeo asked @praachi00 to replace nuxt-link with a in NeoNftCard

The problem is that it was doing ugly reloads.

The fix is really hacky but serves the purpose 

Commit: 6c05aecc81a14442d9dfe72074afd8fe3f67dd2f
