### PR TITLE
🔧 invalid props

### DIFF
--- a/libs/ui/src/components/NeoModal/NeoModal.vue
+++ b/libs/ui/src/components/NeoModal/NeoModal.vue
@@ -6,8 +6,6 @@
     :destroy-on-hide="destroyOnHide"
     :can-cancel="canCancel"
     :full-screen="fullScreen"
-    :content-class="contentClass"
-    :root-class="rootClass"
     @close="updateClose">
     <slot />
   </o-modal>
@@ -22,15 +20,11 @@ const props = withDefaults(
     destroyOnHide?: boolean
     canCancel?: boolean
     fullScreen?: boolean
-    contentClass?: boolean
-    rootClass?: boolean
   }>(),
   {
     destroyOnHide: true,
     canCancel: true,
     fullScreen: false,
-    contentClass: false,
-    rootClass: false,
   }
 )
 

--- a/libs/ui/src/components/NeoModal/NeoModal.vue
+++ b/libs/ui/src/components/NeoModal/NeoModal.vue
@@ -6,6 +6,8 @@
     :destroy-on-hide="destroyOnHide"
     :can-cancel="canCancel"
     :full-screen="fullScreen"
+    :content-class="contentClass"
+    :root-class="rootClass"
     @close="updateClose">
     <slot />
   </o-modal>
@@ -20,11 +22,15 @@ const props = withDefaults(
     destroyOnHide?: boolean
     canCancel?: boolean
     fullScreen?: boolean
+    contentClass?: string
+    rootClass?: string
   }>(),
   {
     destroyOnHide: true,
     canCancel: true,
     fullScreen: false,
+    contentClass: '',
+    rootClass: '',
   }
 )
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5947
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=v)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6f43f6</samp>

Refactored the `NeoModal` component to remove unnecessary code and improve readability. Used the `class` prop to allow custom styles for different modal types.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b6f43f6</samp>

> _Oh we're the crew of the NeoModal, we like to keep things neat_
> _We don't need no redundant props or data to repeat_
> _We heave away and simplify the template and the script_
> _We only use the `class` prop to give our modal some zip_
