### PR TITLE
fix: Add Mushroom Topia to sidebar in explorer

### DIFF
--- a/components/shared/filters/modules/constants.ts
+++ b/components/shared/filters/modules/constants.ts
@@ -25,6 +25,8 @@ export const POPULAR_COLLECTIONS = {
     '3629a3ff458d113e25-PUNK', //RMRK Punks
     '3a4100ce6c6ae0292c-KDGN', // Kusama Dragons
     '7e982817a2d2575031-C6N4I', // Ku*
+    'c8d5ea648c93514667-MSHRMTPIA', // Mushroom Topia
+    '8453d0ccb4cb7e9e59-A51', // Alien Ant Pharm
   ],
   bsx: [
     '1865909717', //Berliner


### PR DESCRIPTION

## PR Type

- [x] Bugfix

## Context

- [x] Closes #5943

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="310" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/b9d7d023-c60b-47cd-b705-58450b95eea6">

