### PR TITLE
fix: identity and remove persist in wallet store

### DIFF
--- a/components/identity/utils/useIdentity.ts
+++ b/components/identity/utils/useIdentity.ts
@@ -86,6 +86,8 @@ export default function useIdentity({
     address.value = addr
   }
 
+  onMounted(() => address.value && whichIdentity(address.value))
+
   return {
     identity,
     isFetchingIdentity,

--- a/stores/wallet.ts
+++ b/stores/wallet.ts
@@ -20,5 +20,4 @@ export const useWalletStore = defineStore('wallet', {
       this.wallet = Object.assign(this.wallet, payload)
     },
   },
-  persist: true,
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5949
- [x] Closes #5956
- [x] fix identity same with https://github.com/kodadot/nft-gallery/pull/5950/files#diff-b47b7c47a2240d029254629652541a3a5747873eec36f5b11ffa1203cfc64c34R89

![Screenshot 2023-05-14 153509](https://github.com/kodadot/nft-gallery/assets/734428/241a369a-fed4-4d71-aa6e-2dec229a9ff9)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3aff54</samp>

This pull request improves the identity and wallet state management by fetching the identity data on component mount and disabling the local storage persistence of the wallet store. It affects the files `useIdentity.ts` and `wallet.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f3aff54</samp>

> _`useIdentity` calls_
> _`whichIdentity` on mount_
> _identity shown_
