### PR TITLE
fix: close sidebar on network change

### DIFF
--- a/components/common/ConnectWallet/ConnectWalletModal.vue
+++ b/components/common/ConnectWallet/ConnectWalletModal.vue
@@ -91,7 +91,11 @@ const { $i18n } = useNuxtApp()
 const selectedWalletProvider = ref<BaseDotsamaWallet>()
 const hasSelectedWalletProvider = ref(false)
 const forceWalletSelect = ref(false)
+const { $store } = useNuxtApp()
 const identityStore = useIdentityStore()
+
+// urlPrefix from usePrefix() would not update inside modal component
+const urlPrefix = computed(() => $store.getters.currentUrlPrefix)
 
 const setForceWalletSelect = () => {
   forceWalletSelect.value = true
@@ -140,5 +144,9 @@ const toggleShowUninstalledWallet = () => {
 
 watch(account, (account) => {
   setAccount({ address: account })
+})
+
+watch([urlPrefix], () => {
+  emit('close')
 })
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5942
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd02484</samp>

Improved network switching in `ConnectWalletModal.vue` by using URL prefix from store and closing modal on change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dd02484</samp>

> _Oh, we're the brave developers of the Nuxt app_
> _We import the instance and we get the prefix from the store_
> _We close the modal when the network switches, that's a fact_
> _And we heave away and code some more_
