### PR TITLE
fix: Add prefix to the transfer

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -10,4 +10,6 @@ liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-custom: ['https://kodadot.xyz/transfer?target=G29NScLSew5zqwmJAPupvJWDCDkpxKUhDnMeVdD2BBcnHar&usdamount=1000&donation=true' ] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: [
+    'https://kodadot.xyz/ksm/transfer?target=G29NScLSew5zqwmJAPupvJWDCDkpxKUhDnMeVdD2BBcnHar&usdamount=1000&donation=true',
+  ] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: Create a report to help us improve KodaDot
-title: "Be descriptive and short"
-labels: ["bug"]
+title: 'Be descriptive and short'
+labels: ['bug']
 body:
   - type: markdown
     attributes:
@@ -60,8 +60,8 @@ body:
       label: Are you logged in?
       multiple: false
       options:
-        - "Yes"
-        - "No"
+        - 'Yes'
+        - 'No'
   - type: dropdown
     id: chain-selector
     attributes:
@@ -101,7 +101,7 @@ body:
     attributes:
       label: Payment link for reward
       description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward
-      value: "https://kodadot.xyz/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E"
+      value: 'https://kodadot.xyz/ksm/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E'
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_basilisk.yml
+++ b/.github/ISSUE_TEMPLATE/bug_basilisk.yml
@@ -1,7 +1,7 @@
-name: 🐞🐍 Bug Report Basilisk 
+name: 🐞🐍 Bug Report Basilisk
 description: Create a report to help us improve KodaDot on Basilisk
-title: "Be descriptive and short"
-labels: ["A-basilisk", "bug"]
+title: 'Be descriptive and short'
+labels: ['A-basilisk', 'bug']
 body:
   - type: markdown
     attributes:
@@ -59,12 +59,12 @@ body:
       label: Are you logged in?
       multiple: false
       options:
-        - "Yes"
-        - "No"
+        - 'Yes'
+        - 'No'
   - type: dropdown
     id: wallet-selector
     attributes:
-      label: Which wallet you are using? 
+      label: Which wallet you are using?
       multiple: true
       options:
         - PolkadotJS
@@ -84,13 +84,13 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
-      
+
   - type: textarea
     id: rewardaddress
     attributes:
       label: Payment link for reward
-      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward 
-      value: "https://kodadot.xyz/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E"
+      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward
+      value: 'https://kodadot.xyz/ksm/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E'
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_minting.yml
+++ b/.github/ISSUE_TEMPLATE/bug_minting.yml
@@ -1,7 +1,7 @@
 name: 🐞⛏️ Bug Report Minting
 description: Create a report to help us improve minting on KodaDot
-title: "Be descriptive and short"
-labels: ["bug", "A-minting"]
+title: 'Be descriptive and short'
+labels: ['bug', 'A-minting']
 body:
   - type: markdown
     attributes:
@@ -60,8 +60,8 @@ body:
       label: Are you logged in?
       multiple: false
       options:
-        - "Yes"
-        - "No"
+        - 'Yes'
+        - 'No'
   - type: dropdown
     id: chain-selector
     attributes:
@@ -102,7 +102,7 @@ body:
     attributes:
       label: Payment link for reward
       description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward
-      value: "https://kodadot.xyz/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E"
+      value: 'https://kodadot.xyz/ksm/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E'
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_moonbeam.yml
+++ b/.github/ISSUE_TEMPLATE/bug_moonbeam.yml
@@ -1,7 +1,7 @@
-name: 🐞🌔 Bug Report MoonBeam 
+name: 🐞🌔 Bug Report MoonBeam
 description: Create a report to help us improve KodaDot on MoonBeam
-title: "Be descriptive and short"
-labels: ["A-moonbeam", "bug", "p2"]
+title: 'Be descriptive and short'
+labels: ['A-moonbeam', 'bug', 'p2']
 body:
   - type: markdown
     attributes:
@@ -60,12 +60,12 @@ body:
       label: Are you logged in?
       multiple: false
       options:
-        - "Yes"
-        - "No"
+        - 'Yes'
+        - 'No'
   - type: dropdown
     id: wallet-selector
     attributes:
-      label: Which wallet you are using? 
+      label: Which wallet you are using?
       multiple: true
       options:
         - PolkadotJS
@@ -85,13 +85,13 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
-      
+
   - type: textarea
     id: rewardaddress
     attributes:
       label: Payment link for reward
-      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward 
-      value: "https://kodadot.xyz/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E"
+      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward
+      value: 'https://kodadot.xyz/ksm/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E'
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_rmrk2.yml
+++ b/.github/ISSUE_TEMPLATE/bug_rmrk2.yml
@@ -1,7 +1,7 @@
-name: 🐞℞ Bug Report RMRK2 
+name: 🐞℞ Bug Report RMRK2
 description: Create a report to help us improve KodaDot on RMRK2
-title: "Be descriptive and short"
-labels: ["A-rmrk2", "bug", "p2"]
+title: 'Be descriptive and short'
+labels: ['A-rmrk2', 'bug', 'p2']
 body:
   - type: markdown
     attributes:
@@ -60,12 +60,12 @@ body:
       label: Are you logged in?
       multiple: false
       options:
-        - "Yes"
-        - "No"
+        - 'Yes'
+        - 'No'
   - type: dropdown
     id: wallet-selector
     attributes:
-      label: Which wallet you are using? 
+      label: Which wallet you are using?
       multiple: true
       options:
         - PolkadotJS
@@ -85,13 +85,13 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
-      
+
   - type: textarea
     id: rewardaddress
     attributes:
       label: Payment link for reward
-      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward 
-      value: "https://kodadot.xyz/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E"
+      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward
+      value: 'https://kodadot.xyz/ksm/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E'
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_statemine.yml
+++ b/.github/ISSUE_TEMPLATE/bug_statemine.yml
@@ -1,7 +1,7 @@
-name: 🐞₷ Bug Report Statemine 
+name: 🐞₷ Bug Report Statemine
 description: Create a report to help us improve KodaDot on Statemine
-title: "Be descriptive and short"
-labels: ["A-statemine", "bug", "p2"]
+title: 'Be descriptive and short'
+labels: ['A-statemine', 'bug', 'p2']
 body:
   - type: markdown
     attributes:
@@ -59,12 +59,12 @@ body:
       label: Are you logged in?
       multiple: false
       options:
-        - "Yes"
-        - "No"
+        - 'Yes'
+        - 'No'
   - type: dropdown
     id: wallet-selector
     attributes:
-      label: Which wallet you are using? 
+      label: Which wallet you are using?
       multiple: true
       options:
         - PolkadotJS
@@ -84,13 +84,13 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
-      
+
   - type: textarea
     id: rewardaddress
     attributes:
       label: Payment link for reward
-      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward 
-      value: "https://kodadot.xyz/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E"
+      description: Whenever you will be actively participating to get your bug fixed, helping elaborating and testing to get bug mitigated, you are eliglible for recieving reward. Read more how to share your address for reciving rewards https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#sharing-your-address-to-receive-reward
+      value: 'https://kodadot.xyz/ksm/transfer/?target=%3CMy_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address%3E'
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).
 
-👇 __ Let's make a quick check before the contribution.
+👇 \_\_ Let's make a quick check before the contribution.
 
 ## PR Type
 
@@ -29,7 +29,7 @@
 
 #### Had issue bounty label?
 
-- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)
+- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/ksm/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)
 
 #### Community participation
 
@@ -40,6 +40,7 @@
 - [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
 
 ## Copilot Summary
+
 copilot:summary
 
 copilot:poem

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 ![](https://github.com/kodadot/kodadot-presskit/blob/main/v3/KODA_v3.png?raw=true)
 
 # Contributing
+
 [![Test & Build app](https://github.com/kodadot/nft-gallery/actions/workflows/build.yml/badge.svg)](https://github.com/kodadot/nft-gallery/actions/workflows/build.yml) [![cypress](https://github.com/kodadot/nft-gallery/actions/workflows/e2e.yml/badge.svg)](https://github.com/kodadot/nft-gallery/actions/workflows/e2e.yml) [![Reviewdog](https://github.com/kodadot/nft-gallery/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/kodadot/nft-gallery/actions/workflows/reviewdog.yml) [![Maintainability](https://api.codeclimate.com/v1/badges/7d14fab327c632d5f0ce/maintainability)](https://codeclimate.com/github/kodadot/nft-gallery/maintainability)
 
 ![image](https://user-images.githubusercontent.com/5887929/217076362-464e1293-8a2d-43ee-829f-fba17408e4c3.png)
 
 #### Is this your first time contributing? Set up your local environment [here](FIRST_TIME.md)
+
 Before submitting your pull request, read up on our [documentation](https://docs.kodadot.xyz) and make sure it follows:
 
 - [Code of Conduct](CODE_OF_CONDUCT.md)
@@ -15,13 +17,17 @@ Before submitting your pull request, read up on our [documentation](https://docs
 - [Style Guide](STYLE_GUIDE.md)
 
 ##### **Failure to do so can lead to your PR being rejected**
+
 We [reward](REWARDS.md) our contributors in $KSM for their time and effort with every issue they solve. If you're finding yourself to be more involved with KodaDot, we are always [hiring](HIRING.md).
 
 ### **Check out our repository's [activity](ACTIVITY.md) by our recent contributors!**
+
 <img src="https://contrib.rocks/image?repo=kodadot/nft-gallery" />
 
 # Features Roadmap
+
 You'll find our goals for KodaDot upcoming future!
+
 - [Beta Roadmap](https://github.com/orgs/kodadot/projects/4/views/1)
 - Test out KodaDot's [Beta](https://beta.kodadot.xyz/)
 
@@ -33,12 +39,14 @@ You'll find our goals for KodaDot upcoming future!
 - Read up on our efforts to be a [public good](https://medium.com/kodadot/on-sustaining-open-source-as-a-public-good-a3e8c36e67d6)
 - Get a glimpse into our [contributor culture](https://medium.com/kodadot/contributor-culture-at-kodadot-665243d3d6a6)
 
-
 # Support KodaDot
+
 #### Please ⭐️ **star** and **share** this repository! This exposes us to other builders and creators in the space.
-#### Feel free to donate to our [KodaDot_Guild_Rewards](https://beta.kodadot.xyz/transfer?target=G29NScLSew5zqwmJAPupvJWDCDkpxKUhDnMeVdD2BBcnHar&usdamount=1000&donation=true) which already funded over $200k ([~1740 $KSM](https://dotscanner.com/Kusama/account/G29NScLSew5zqwmJAPupvJWDCDkpxKUhDnMeVdD2BBcnHar)) to notable contributing members
+
+#### Feel free to donate to our [KodaDot_Guild_Rewards](https://beta.kodadot.xyz/ksm/transfer?target=G29NScLSew5zqwmJAPupvJWDCDkpxKUhDnMeVdD2BBcnHar&usdamount=1000&donation=true) which already funded over $200k ([~1740 $KSM](https://dotscanner.com/Kusama/account/G29NScLSew5zqwmJAPupvJWDCDkpxKUhDnMeVdD2BBcnHar)) to notable contributing members
 
 # Stay Tuned for Updates!
+
 - Follow us on [Twitter](https://twitter.com/KodaDot), [Youtube](https://www.youtube.com/channel/UCEULduld5NrqOL49k1KVjoA), [SubStack](https://kodadot.substack.com/) and [Medium](https://blog.kodadot.xyz), [Instagram](https://instagram.com/kodadot.xyz),
 - Join our [Telegram KodaDot Ecosystem](https://t.me/kodadot_eco), [Discord](https://discord.gg/u6ymnbz4PR)
-- [Pick your T-shirt in KodaDot Swag Shop](https://shop.kodadot.xyz), use voucher `readme100` to get 100% OFF, first 10 redemptions only. 
+- [Pick your T-shirt in KodaDot Swag Shop](https://shop.kodadot.xyz), use voucher `readme100` to get 100% OFF, first 10 redemptions only.

--- a/REWARDS.md
+++ b/REWARDS.md
@@ -1,6 +1,6 @@
 ## Rewards
 
-To scale our development and operations, we prefer paid trials to know developers better and fit the team. The more your PRs gets merged to `main` branch,the  **more-likely you'll be part of the inner team.**
+To scale our development and operations, we prefer paid trials to know developers better and fit the team. The more your PRs gets merged to `main` branch,the **more-likely you'll be part of the inner team.**
 On-demand or part-time contributions are welcome, and we will reward them in $KSM.
 
 KodaDot has started on [Kusama.network](https://kusama.network), and we prefer to pay out for your work in $KSM, which is the native cryptocurrency of Kusama network, [Polkadot's Canary network](https://polkadot.network) with bearing value.
@@ -11,11 +11,11 @@ To create your KSM address in safely and long-term manner, we recommend you to g
 
 ### Sharing your address to receive the reward
 
-After creating an account, you can visit [KodaDot Transfer](https://kodadot.xyz/transfer) to make a payment link. Entering an amount like 100 USD and clicking the button **COPY REWARD ME LINK** will copy the link to your clipboard, and you can share it with us, like whenever you are filling up a bug report or submitting pull-request
+After creating an account, you can visit [KodaDot Transfer](https://kodadot.xyz/ksm/transfer) to make a payment link. Entering an amount like 100 USD and clicking the button **COPY REWARD ME LINK** will copy the link to your clipboard, and you can share it with us, like whenever you are filling up a bug report or submitting pull-request
 
 your receiving address should be looks like this
 
-`https://kodadot.xyz/transfer?target=${your address}&usdamount=100&donation=true`
+`https://kodadot.xyz/ksm/transfer?target=${your address}&usdamount=100&donation=true`
 
 ### Switching account/network
 
@@ -31,7 +31,7 @@ Check `balances` under your _[accounts](https://polkadot.js.org/apps/#/accounts)
 
 Our typical payout structure for bounties is per label on the issue. Here is the table for an overview
 
-***The reward amount is in USD, paid in KSM***
+**_The reward amount is in USD, paid in KSM_**
 
 |                              $                               |                          $$                           |                                $$$                                |                              $$$$                               |                                         $$$$$                                          |
 | :----------------------------------------------------------: | :---------------------------------------------------: | :---------------------------------------------------------------: | :-------------------------------------------------------------: | :------------------------------------------------------------------------------------: |

--- a/components/navbar/ProfileDropdown.vue
+++ b/components/navbar/ProfileDropdown.vue
@@ -45,7 +45,9 @@
           <nuxt-link :to="`/${urlPrefix}/assets`">{{ $t('assets') }}</nuxt-link>
         </b-dropdown-item>
         <b-dropdown-item has-link aria-role="menuitem">
-          <nuxt-link to="/transfer">{{ $t('transfer') }}</nuxt-link>
+          <nuxt-link :to="`/${urlPrefix}/transfer`">{{
+            $t('transfer')
+          }}</nuxt-link>
         </b-dropdown-item>
         <b-dropdown-item has-link aria-role="menuitem">
           <nuxt-link to="/teleport-bridge"

--- a/middleware/redirects.ts
+++ b/middleware/redirects.ts
@@ -13,4 +13,7 @@ export default function ({ store, redirect, route }): void {
   if (route.path.includes('/rmrk2/')) {
     return redirect(window.location.href.replace('/rmrk2/', '/ksm/'))
   }
+  if (route.path.startsWith('/transfer')) {
+    return redirect(window.location.href.replace('/transfer', '/ksm/transfer'))
+  }
 }

--- a/pages/_prefix/transfer.vue
+++ b/pages/_prefix/transfer.vue
@@ -448,7 +448,7 @@ export default class Transfer extends mixins(
     } else {
       addressQueryString = new URLSearchParams(this.targets).toString()
     }
-    return `${window.location.origin}/transfer?${addressQueryString}&usdamount=${this.usdValue}&donation=true`
+    return `${window.location.origin}/${this.urlPrefix}/transfer?${addressQueryString}&usdamount=${this.usdValue}&donation=true`
   }
 
   protected shareInTweet() {

--- a/pages/teleport.vue
+++ b/pages/teleport.vue
@@ -370,7 +370,7 @@ export default class Transfer extends mixins(
   }
 
   protected generatePaymentLink(): string {
-    return `${window.location.origin}/transfer?target=${this.destinationAddress}&usdamount=${this.usdValue}&donation=true`
+    return `${window.location.origin}/${this.urlPrefix}/transfer?target=${this.destinationAddress}&usdamount=${this.usdValue}&donation=true`
   }
 
   protected shareInTweet() {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5957
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


<img width="1347" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/db1c4e8d-6836-452b-aa46-17131f7ae8e7">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d9fa2e</samp>

This pull request updates various files related to the payment link and the network prefix for the Kusama chain. It fixes quotation marks, whitespace, and formatting issues in the issue and pull request templates, the README, and the REWARDS files. It also adds a middleware function to redirect `/transfer` routes to `/ksm/transfer` and makes the transfer and teleport pages use dynamic network prefixes. These changes improve the consistency, functionality, and user experience of the NFT gallery.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4d9fa2e</samp>

> _`urlPrefix` prop_
> _helps to avoid redirection_
> _cutting through the web_
