### PR TITLE
fix: unset openssl-legacy-provider in package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,10 @@ For crafting much better culture and Developer Experience, we reccomend some ext
 
 This repository has a [code of conduct](CODE_OF_CONDUCT.md). This repository has a code of conduct, and I will remove things that do not respect it.
 
+### Getting Error `Error: error:0308010C:digital envelope routines::unsupported`
+
+Ensure to set `NODE_OPTIONS=--openssl-legacy-provider` in your environment variables. Ref: https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
+
 ## Follow us
 
 - [Twitter @KodaDot](https://twitter.com/kodadot)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "version": "3.0.0",
   "private": true,
   "scripts": {
-    "dev": "nuxi prepare && cross-env NODE_OPTIONS=--openssl-legacy-provider PORT=9090 nuxi dev",
+    "dev": "nuxi prepare && cross-env PORT=9090 nuxi dev",
     "dev-docker": "npx nuxi dev",
     "dev-experimental": "nuxi dev --hostname localhost --port 9090",
     "build": "nuxi build --modern",
@@ -27,7 +27,7 @@
     "start": "nuxi preview",
     "start:static": "npx --yes serve@14.2.0 -L -l 9090 -s dist",
     "generate:pnpm": "npx pnpm@latest-8 i --store=node_modules/.pnpm-store && npx pnpm@latest-8 generate",
-    "generate": "node ./script/substack.mjs && cross-env NODE_OPTIONS=--openssl-legacy-provider NITRO_PRESET=netlify nuxi generate",
+    "generate": "node ./script/substack.mjs && cross-env NITRO_PRESET=netlify nuxi generate",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.vue .",
     "lint:quiet": "eslint --quiet --ignore-path .gitignore --ext .js,.ts,.vue .",
     "lint:fix": "eslint --fix --quiet --ignore-path .gitignore --ext .js,.ts,.vue .",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5961

## Todo

- [ ] add `openssl-legacy-provider` in netlify, github actions, and cloudflare pages

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26e52d4</samp>

Removed an obsolete flag from `package.json` scripts and updated `CONTRIBUTING.md` with a troubleshooting tip for OpenSSL errors. These changes improve the compatibility and usability of the project for developers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 26e52d4</samp>

> _Sing, O Muse, of the valiant contributors_
> _Who strive to improve the glorious project_
> _And face with courage the errors and bugs_
> _That lurk in the dark depths of the code._
