### PR TITLE
fix: Change order on Newest List and Sales

### DIFF
--- a/components/carousel/utils/useCarousel.ts
+++ b/components/carousel/utils/useCarousel.ts
@@ -67,6 +67,8 @@ const useChainEvents = (chain, type) => {
   }
 }
 
+const sortNftByTime = (data) => data.sort((a, b) => b.unixTime - a.unixTime)
+
 const flattenNFT = async (data, chain) => {
   if (!data?.events.length) {
     return []
@@ -74,7 +76,8 @@ const flattenNFT = async (data, chain) => {
 
   const events = data.events.map(convertLastEventFlatNft)
   const listOfNfts = await formatNFT(events, chain)
-  return setCarouselMetadata(listOfNfts)
+  const listOfNftsWithMetadata = await setCarouselMetadata(listOfNfts)
+  return sortNftByTime(listOfNftsWithMetadata)
 }
 
 export const useCarouselNftEvents = ({ type }: Types) => {
@@ -96,14 +99,14 @@ export const useCarouselNftEvents = ({ type }: Types) => {
     const stmnNfts = await flattenNFT(dataStmn.value, 'stmn')
 
     const data = [
-      ...rmrkNfts,
-      ...bsxNfts,
-      ...snekNfts,
-      ...rmrk2Nfts,
       ...stmnNfts,
+      ...rmrk2Nfts,
+      ...snekNfts,
+      ...bsxNfts,
+      ...rmrkNfts,
     ]
 
-    nfts.value = data.sort((a, b) => b.unixTime - a.unixTime).slice(0, 30)
+    nfts.value = data.slice(0, 30)
   })
 
   return {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6007
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/ksm/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1094" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/ec45d877-1131-43db-b1c1-6a443f50e1fd">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1c5778</samp>

Improved carousel sorting and performance by adding a `sortNftsByLatestEvent` function and using it for all chains and sources. Removed redundant sorting and favored newer chains in `useCarousel.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1c5778</samp>

> _To improve the carousel component_
> _We added a function to sort NFTs by event_
> _We removed some sorting that was redundant_
> _And gave newer chains more prominence_
> _Now the carousel shows the most relevant content_
