### PR TITLE
fix: Hide collections with empty metadata

### DIFF
--- a/queries/subsquid/general/collectionListWithSearch.graphql
+++ b/queries/subsquid/general/collectionListWithSearch.graphql
@@ -15,6 +15,7 @@ query collectionListWithSearch(
     where: {
       nfts_some: { burned_eq: false, issuer_not_in: $denyList }
       AND: $search
+      metadata_isNull: false
     }
   ) {
     ...collection
@@ -35,6 +36,7 @@ query collectionListWithSearch(
     where: {
       nfts_some: { burned_eq: false, issuer_not_in: $denyList }
       AND: $search
+      metadata_isNull: false
     }
     orderBy: blockNumber_DESC
   ) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5974
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at `/stmn/explore/collectibles`
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/ksm/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1246" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/0aa9fa9f-bab3-4d88-905e-d8c36be2a278">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfdc18d</samp>

Added metadata filters to `collectionList` and `collectionListWithSearch` queries to enable more refined gallery and search features. Updated `queries/subsquid/general/collectionListWithSearch.graphql` file accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfdc18d</samp>

> _We search for the hidden treasures_
> _In the gallery of doom_
> _We filter by the metadata_
> _To reveal the ancient runes_
