### PR TITLE
🩹 Temp fix for balance issue

### DIFF
--- a/components/shared/AccountBalance.vue
+++ b/components/shared/AccountBalance.vue
@@ -14,5 +14,5 @@ const Money = defineAsyncComponent(
 const { urlPrefix } = usePrefix()
 const { accountId } = useAuth()
 const identityStore = useIdentityStore()
-const realBalance = computed(() => identityStore.auth.balance[urlPrefix.value])
+const realBalance = computed(() => identityStore.getAuthBalance)
 </script>

--- a/components/shared/AccountBalance.vue
+++ b/components/shared/AccountBalance.vue
@@ -11,7 +11,7 @@ import { useIdentityStore } from '@/stores/identity'
 const Money = defineAsyncComponent(
   () => import('@/components/shared/format/Money.vue')
 )
-const { urlPrefix } = usePrefix()
+
 const { accountId } = useAuth()
 const identityStore = useIdentityStore()
 const realBalance = computed(() => identityStore.getAuthBalance)

--- a/stores/identity.ts
+++ b/stores/identity.ts
@@ -20,8 +20,7 @@ export interface IdentityMap {
   [address: string]: Registration
 }
 
-type NumericId = `${number}`
-type Key = Prefix | string | NumericId
+type Key = Prefix | string | number
 type BalanceMap<T extends Key = string> = Record<T, string>
 type ChangeAddressRequest = {
   address: string
@@ -32,7 +31,7 @@ export interface Auth {
   address: string
   source?: 'keyring' | 'extension' | 'ledger'
   balance?: BalanceMap<Prefix>
-  tokens?: BalanceMap<NumericId> // <id, amount>
+  tokens?: BalanceMap<number> // <id, amount>
 }
 
 export interface IdentityStruct {

--- a/stores/identity.ts
+++ b/stores/identity.ts
@@ -4,12 +4,25 @@ import { defineStore } from 'pinia'
 import consola from 'consola'
 import { emptyObject } from '@/utils/empty'
 import { formatAddress } from '@/utils/account'
+import { Prefix } from '@kodadot1/static'
+
+const DEFAULT_BALANCE_STATE = {
+  bsx: '0',
+  ksm: '0',
+  rmrk: '0',
+  snek: '0',
+  stmn: '0',
+  glmr: '0',
+  movr: '0',
+}
 
 export interface IdentityMap {
   [address: string]: Registration
 }
 
-type BalanceMap = Record<string, string>
+type NumericId = `${number}`
+type Key = Prefix | string | NumericId
+type BalanceMap<T extends Key = string> = Record<T, string>
 type ChangeAddressRequest = {
   address: string
   apiUrl?: string
@@ -18,8 +31,8 @@ type ChangeAddressRequest = {
 export interface Auth {
   address: string
   source?: 'keyring' | 'extension' | 'ledger'
-  balance?: BalanceMap
-  tokens?: BalanceMap // <id, amount>
+  balance?: BalanceMap<Prefix>
+  tokens?: BalanceMap<NumericId> // <id, amount>
 }
 
 export interface IdentityStruct {
@@ -37,8 +50,11 @@ export const useIdentityStore = defineStore('identity', {
     identities: emptyObject<IdentityMap>(),
     auth: {
       ...emptyObject<Auth>(),
-      balance: emptyObject<BalanceMap>(),
-      tokens: emptyObject<BalanceMap>(),
+      balance: DEFAULT_BALANCE_STATE,
+      tokens: {
+        '1': '0',
+        '5': '0',
+      },
       address: localStorage.getItem('kodaauth') || '',
     },
   }),
@@ -60,7 +76,7 @@ export const useIdentityStore = defineStore('identity', {
     resetAuth() {
       this.auth = {
         ...emptyObject<Auth>(),
-        balance: emptyObject<BalanceMap>(),
+        balance: DEFAULT_BALANCE_STATE,
         tokens: emptyObject<BalanceMap>(),
       }
       localStorage.removeItem('kodaauth')
@@ -72,7 +88,7 @@ export const useIdentityStore = defineStore('identity', {
       }
     },
     async setAuth(authRequest: Auth) {
-      this.auth = { ...authRequest, balance: emptyObject<BalanceMap>() }
+      this.auth = { ...authRequest, balance: DEFAULT_BALANCE_STATE }
       await this.fetchBalance({ address: authRequest.address })
       localStorage.setItem('kodaauth', authRequest.address)
     },


### PR DESCRIPTION
- :adhesive_bandage: balance
- :zap: use getter instead of direct value

## TL;DR

The problem is that nested objects in Pinia are not reactive, so you need to set them beforehand to work smoothly.
The problem is that is really wordy.

I tried to use `Vue.set` as mentioned in https://github.com/vuejs/pinia/issues/43#issuecomment-1373622966 but without any success.

Feel free to fix better

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] ref #5838

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [x] I've found edge cases


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="358" alt="Screenshot 2023-05-17 at 13 07 37" src="https://github.com/kodadot/nft-gallery/assets/22471030/efec67f4-4df3-4a6d-9bf1-37a7f7bd5b5f">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3eed89</samp>

Refactored the `identity.ts` store and the `AccountBalance.vue` component to improve type safety and reactivity of the balance data. Used type aliases, constants, and a getter method to access and manipulate the balance and token maps of the `Auth` interface.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f3eed89</samp>

> _To keep the balance reactive and true_
> _We use a getter method from the store_
> _We also refactor the types_
> _And use some constants nice_
> _For the identity data we adore_
