### PR TITLE
fix: responsive ModalWrapper content

### DIFF
--- a/libs/ui/src/components/NeoModal/NeoModal.scss
+++ b/libs/ui/src/components/NeoModal/NeoModal.scss
@@ -3,6 +3,7 @@
 
 .neo-modal {
   .o-modal__content {
+    width: auto;
     @include ktheme() {
       box-shadow: theme('primary-shadow');
       border: 1px solid theme('border-color');


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #5975
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/ksm/transfer/?target=Caiv9TbPz68q5dC8EcHu5xKYPRnremimGzqmEejDFNpWWLG)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="622" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/52e059a3-b7eb-42b6-8d32-e03d7bca50a8">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 987aae5</samp>

Improved the responsiveness and layout of the `NeoModal` component by setting its width to `auto` in `NeoModal.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 987aae5</samp>

> _`Modal` adapts_
> _To its content gracefully_
> _Like a spring blossom_
