### PR TITLE
feat: Implement equipable (composable) viewer

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -54,7 +54,8 @@
             is-detail
             :original="isMobile"
             :is-lewd="galleryDescriptionRef?.isLewd"
-            :placeholder="placeholder" />
+            :placeholder="placeholder"
+            :equipped-nft-images="equippedNftImages" />
         </div>
       </div>
 
@@ -174,8 +175,15 @@ const { placeholder } = useTheme()
 const mediaItemRef = ref<{ isLewdBlurredLayer: boolean } | null>(null)
 const galleryDescriptionRef = ref<{ isLewd: boolean } | null>(null)
 
-const { nft, nftMetadata, nftImage, nftAnimation, nftMimeType, nftResources } =
-  useGalleryItem()
+const {
+  nft,
+  nftMetadata,
+  nftImage,
+  nftAnimation,
+  nftMimeType,
+  nftResources,
+  equippedNftImages,
+} = useGalleryItem()
 const collection = computed(() => nft.value?.collection)
 
 const breakPointWidth = 930

--- a/components/gallery/GalleryItemDescription.vue
+++ b/components/gallery/GalleryItemDescription.vue
@@ -105,6 +105,7 @@
             :animation-src="parent?.nftAnimation.value"
             :mime-type="parent?.nftMimeType.value"
             :title="parent?.nftMetadata?.value?.name"
+            :equipped-nft-images="equippedNftImages"
             is-detail />
           <p class="gallery-parent-item__name">
             {{ parent?.nftMetadata?.value?.name }}
@@ -130,8 +131,14 @@ import { resolveMedia } from '@/utils/gallery/media'
 import { replaceSingularCollectionUrlByText } from '@/utils/url'
 
 const { urlPrefix } = usePrefix()
-const { nft, nftMimeType, nftMetadata, nftImage, nftAnimation } =
-  useGalleryItem()
+const {
+  nft,
+  nftMimeType,
+  nftMetadata,
+  nftImage,
+  nftAnimation,
+  equippedNftImages,
+} = useGalleryItem()
 const activeTab = ref('0')
 const { version } = useRmrkVersion()
 

--- a/components/gallery/useGalleryItem.ts
+++ b/components/gallery/useGalleryItem.ts
@@ -40,6 +40,7 @@ export const useGalleryItem = (nftId?: string) => {
   const nftMimeType = ref('')
   const nftMetadata = ref<NFTWithMetadata>()
   const nftResources = ref<NftResources[]>()
+  const equippedNftImages = ref<string[]>([])
 
   const { params } = useRoute()
   const id = nftId || params.id
@@ -84,6 +85,7 @@ export const useGalleryItem = (nftId?: string) => {
 
     nft.value = nftEntity
 
+    await useEquippedNftImages(nftEntity, equippedNftImages)
     nftResources.value = nftEntity.resources?.map((resource) => {
       return {
         ...resource,
@@ -119,5 +121,6 @@ export const useGalleryItem = (nftId?: string) => {
     nftMimeType,
     nftMetadata,
     nftResources,
+    equippedNftImages,
   }
 }

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -8,7 +8,8 @@
       :placeholder="placeholder"
       :original="original"
       :is-lewd="isLewd"
-      :is-detail="isDetail" />
+      :is-detail="isDetail"
+      :equipped-nft-images="equippedNftImages" />
     <div
       v-if="isLewd && isLewdBlurredLayer"
       class="nsfw-blur is-flex is-align-items-center is-justify-content-center is-flex-direction-column">
@@ -23,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { defineAsyncComponent } from 'vue'
+import { PropType, defineAsyncComponent } from 'vue'
 
 import { getMimeType, resolveMedia } from '@/utils/gallery/media'
 import NeoIcon from './../NeoIcon/NeoIcon.vue'
@@ -69,6 +70,10 @@ export default {
     placeholder: {
       type: String,
       default: '',
+    },
+    equippedNftImages: {
+      type: Array as PropType<string[]>,
+      default: () => [],
     },
   },
   data() {

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -1,5 +1,22 @@
 <template>
   <figure
+    v-if="equippedNftImages && equippedNftImages.length !== 0"
+    class="image-container"
+    :class="{
+      'is-square image': !original,
+      'is-detail': isDetail,
+    }">
+    <img
+      v-for="(image, key) in equippedNftImages"
+      :key="key"
+      :src="image"
+      class="is-block image-media__image"
+      :alt="alt"
+      data-cy="type-image"
+      @error="onError" />
+  </figure>
+  <figure
+    v-else
     class="image-container"
     :class="{
       'is-square image': !original,
@@ -24,6 +41,7 @@ const props = defineProps<{
   placeholder: string
   isDetail?: boolean
   isDarkMode?: boolean
+  equippedNftImages?: string[]
 }>()
 
 const onError = (e: Event) => {

--- a/queries/subsquid/ksm/itemInventory.graphql
+++ b/queries/subsquid/ksm/itemInventory.graphql
@@ -1,0 +1,13 @@
+query itemInventory($id: String!) {
+   childListByNftId(id: $id) {
+    id
+    name
+    image
+    media
+    pending
+    resourceMetadata
+    resourceSrc
+    resourceThumb
+    z
+  }
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #5530 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/ksm/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5eb2b6a</samp>

This pull request adds a feature to display equipped NFT images on the gallery item view. It modifies the `GalleryItem`, `MediaItem`, and `ImageMedia` components, as well as the `useGalleryItem` and `useNft` hooks, to pass and render the equipped NFT images data. It also adds a new GraphQL query file `itemInventory.graphql` to fetch the equipped NFTs from the Subsquid API.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5eb2b6a</samp>

> _To show NFTs that are equipped_
> _We added a query and a ref_
> _The `MediaItem` prop_
> _Passes images to the top_
> _And the `ImageMedia` renders the rest_
