### PR TITLE
🔥 burn only on active offers

### DIFF
--- a/composables/transaction/transactionBurn.ts
+++ b/composables/transaction/transactionBurn.ts
@@ -43,7 +43,7 @@ export function execBurnTx(item: ActionConsume, api, executeTransaction) {
     )
     const hasOffers = ref(false)
     const { data } = useGraphql({
-      queryName: 'offerListByNftId',
+      queryName: 'acceptableOfferListByNftId',
       queryPrefix: 'chain-bsx',
       variables: {
         id: item.nftId,
@@ -62,7 +62,7 @@ export function execBurnTx(item: ActionConsume, api, executeTransaction) {
         }
       )
       const cb = hasOffers.value
-        ? api.tx.utility.batch
+        ? api.tx.utility.batchAll
         : getApiCall(api, item.urlPrefix, Interaction.CONSUME)
       const arg = hasOffers.value
         ? [[...offerWithdrawArgs, api.tx.nft.burn(collectionId, tokenId)]]

--- a/queries/subsquid/bsx/acceptableOfferListByNftId.graphql
+++ b/queries/subsquid/bsx/acceptableOfferListByNftId.graphql
@@ -1,4 +1,4 @@
-query offerListByNftId($id: String!, $orderBy: [OfferOrderByInput!]) {
+query acceptableOfferListByNftId($id: String!, $orderBy: [OfferOrderByInput!]) {
   offers(where: { nft: { id_eq: $id }, status_eq: ACTIVE }, orderBy: $orderBy) {
     id
     caller

--- a/queries/subsquid/bsx/acceptableOfferListByNftId.graphql
+++ b/queries/subsquid/bsx/acceptableOfferListByNftId.graphql
@@ -1,0 +1,12 @@
+query offerListByNftId($id: String!, $orderBy: [OfferOrderByInput!]) {
+  offers(where: { nft: { id_eq: $id }, status_eq: ACTIVE }, orderBy: $orderBy) {
+    id
+    caller
+    expiration
+    price
+    status
+  }
+  stats: offersConnection(orderBy: id_ASC, where: { nft: { id_eq: $id }, status_eq: ACTIVE }) {
+    total: totalCount
+  }
+}


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Context

- [x] Ref #5125 
- [x] Ref #6048 
- [x] Related with #5541 

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 719537c</samp>

The pull request enhances the NFT burning feature by adding a new query to fetch valid offers and using a safer batch method to execute the transactions. It affects the files `transactionBurn.ts` and `acceptableOfferListByNftId.graphql`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c79fcea</samp>

> _No escape from the burning fate_
> _`acceptableOfferListByNftId` seals your doom_
> _Only the strongest will survive_
> _The atomic `burnWithOffers` consumes the room_
