### PR TITLE
:art: rounded radio button

### DIFF
--- a/libs/ui/src/components/NeoRadio/NeoRadioButton.vue
+++ b/libs/ui/src/components/NeoRadio/NeoRadioButton.vue
@@ -34,6 +34,7 @@ export default {
       default: 'is-primary',
     },
     expanded: Boolean,
+    rounded: Boolean,
   },
   data() {
     return {
@@ -52,6 +53,8 @@ export default {
           'is-selected': this.isSelected,
           'is-disabled': this.disabled,
           'is-focused': this.isFocused,
+          'is-loading': this.loading,
+          'is-rounded': this.rounded,
         },
       ]
     },
@@ -61,6 +64,7 @@ export default {
 
 <style lang="scss">
 @import '../../scss/_theme.scss';
+@import '../../scss/variable.scss';
 
 .neo-radio-button {
   input[type='radio'] {
@@ -83,6 +87,10 @@ export default {
       @include ktheme() {
         background-color: theme('k-primary');
       }
+    }
+
+    &.is-rounded {
+      border-radius: $radius-rounded;
     }
   }
 }

--- a/libs/ui/src/scss/variable.scss
+++ b/libs/ui/src/scss/variable.scss
@@ -8,3 +8,5 @@
 .light-mode {
   --card-box-shadow: 4px 4px hsl(0deg, 0%, 4%);
 }
+
+$radius-rounded: 9999px;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] REF #6062
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="510" alt="Screenshot 2023-05-22 at 18 46 48" src="https://github.com/kodadot/nft-gallery/assets/22471030/16dad33a-97bf-41dc-82be-8d26f1d401f4">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa415ba</samp>

Added a circular option to the `NeoRadioButton` component and a global variable for the circle radius. This enhances the UI library with more flexibility and consistency for radio buttons.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fa415ba</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A new feature for the NeoRadioButton, a component wise_
> _And versatile, that can now assume a circular shape_
> _Like the radiant sun or the full moon, with a simple `$radius-rounded` escape_
