### PR TITLE
:art: new cool submit button

### DIFF
--- a/components/base/SubmitButton.vue
+++ b/components/base/SubmitButton.vue
@@ -1,6 +1,6 @@
 <template>
-  <b-field>
-    <b-button
+  <NeoField>
+    <NeoButton
       :type="type"
       :icon-left="icon"
       :disabled="disabled"
@@ -11,11 +11,13 @@
       <slot>
         {{ $t(label) }}
       </slot>
-    </b-button>
-  </b-field>
+    </NeoButton>
+  </NeoField>
 </template>
 
 <script setup lang="ts">
+import { NeoButton, NeoField } from '@kodadot1/brick'
+
 export interface Props {
   disabled?: boolean
   expanded?: boolean


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] ref #6062
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="532" alt="Screenshot 2023-05-22 at 20 03 15" src="https://github.com/kodadot/nft-gallery/assets/22471030/e0487238-1e26-440f-9a84-f490a9ca2695">

<img width="496" alt="Screenshot 2023-05-22 at 20 02 54" src="https://github.com/kodadot/nft-gallery/assets/22471030/a2b78320-112e-4f53-8a3b-15321630c0cc">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at effc2a2</samp>

Refactored `SubmitButton` component to use new `brick` library and TypeScript. Simplified code with `script setup` syntax.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at effc2a2</samp>

> _We're sailing on the Vue with TypeScript in tow_
> _We've swapped out Buefy for `NeoField` and `NeoButton` so_
> _On the count of three we'll pull the script setup line_
> _And hoist the `@kodadot1/brick` flag to shine_
