### PR TITLE
:technologist: label in NeoField is optional

### DIFF
--- a/libs/ui/src/components/NeoInput/NeoField.vue
+++ b/libs/ui/src/components/NeoInput/NeoField.vue
@@ -12,7 +12,7 @@
 import { OField } from '@oruga-ui/oruga'
 
 defineProps<{
-  label: string
+  label?: string
   error?: boolean
 }>()
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/ksm/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![Screenshot 2023-05-23 at 09 08 30](https://github.com/kodadot/nft-gallery/assets/22471030/0042136c-f7a2-47ca-88b0-03fe951b4674)


![Screenshot 2023-05-23 at 09 08 34](https://github.com/kodadot/nft-gallery/assets/22471030/1a0ea840-b8a9-46fa-acd0-5da15462f3f3)


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d3f156</samp>

Made `label` prop optional for `NeoField` component to enable more use cases. Updated `NeoInput` component and its stories accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3d3f156</samp>

> _`NeoField` label_
> _optional prop gives freedom_
> _autumn leaves fall off_
