### PR TITLE
Fix/tooltip-blocking-events

### DIFF
--- a/components/rmrk/Profile/ProfileDetail.vue
+++ b/components/rmrk/Profile/ProfileDetail.vue
@@ -81,7 +81,9 @@
         expanded>
         <b-tab-item value="nft" :header-class="{ 'is-hidden': !totalCreated }">
           <template #header>
-            <NeoTooltip :label="`${$t('tooltip.created')} ${labelDisplayName}`">
+            <NeoTooltip
+              :label="`${$t('tooltip.created')} ${labelDisplayName}`"
+              append-to-body>
               {{ $t('profile.created') }}
               <span class="tab-counter">{{ totalCreated }}</span>
             </NeoTooltip>
@@ -99,7 +101,8 @@
           :header-class="{ 'is-hidden': !totalCollections }">
           <template #header>
             <NeoTooltip
-              :label="`${$t('tooltip.collections')} ${labelDisplayName}`">
+              :label="`${$t('tooltip.collections')} ${labelDisplayName}`"
+              append-to-body>
               {{ $t('collections') }}
               <span class="tab-counter">{{ totalCollections }}</span>
             </NeoTooltip>
@@ -156,7 +159,9 @@
         </b-tab-item>
         <b-tab-item value="sold" :header-class="{ 'is-hidden': !totalSold }">
           <template #header>
-            <NeoTooltip :label="`${$t('tooltip.sold')} ${labelDisplayName}`">
+            <NeoTooltip
+              :label="`${$t('tooltip.sold')} ${labelDisplayName}`"
+              append-to-body>
               {{ $t('profile.sold') }}
               <span class="tab-counter">{{ totalSold }}</span>
             </NeoTooltip>
@@ -173,7 +178,8 @@
           :header-class="{ 'is-hidden': !totalCollected }">
           <template #header>
             <NeoTooltip
-              :label="`${$t('tooltip.collected')} ${labelDisplayName}`">
+              :label="`${$t('tooltip.collected')} ${labelDisplayName}`"
+              append-to-body>
               {{ $t('profile.collected') }}
               <span class="tab-counter">{{ totalCollected }}</span>
             </NeoTooltip>
@@ -191,7 +197,8 @@
           :header-class="{ 'is-hidden': !totalHoldings }">
           <template #header>
             <NeoTooltip
-              :label="`${$t('tooltip.holdings')} ${labelDisplayName}`">
+              :label="`${$t('tooltip.holdings')} ${labelDisplayName}`"
+              append-to-body>
               {{ $t('profile.holdings') }}
               <span class="tab-counter">{{ totalHoldings }}</span>
             </NeoTooltip>
@@ -203,7 +210,9 @@
           value="gains"
           :header-class="{ 'is-hidden': !totalGains }">
           <template #header>
-            <NeoTooltip :label="`${$t('tooltip.gains')} ${labelDisplayName}`">
+            <NeoTooltip
+              :label="`${$t('tooltip.gains')} ${labelDisplayName}`"
+              append-to-body>
               {{ $t('profile.gains') }}
               <span class="tab-counter">{{ totalGains }}</span>
             </NeoTooltip>

--- a/libs/ui/src/components/DisablableTab/DisablableTab.vue
+++ b/libs/ui/src/components/DisablableTab/DisablableTab.vue
@@ -1,7 +1,7 @@
 <template>
   <o-tab-item :value="value" class="py-5" :label="label" :disabled="disabled">
     <template #header>
-      <NeoTooltip v-if="disabled" :label="disabledTooltip">
+      <NeoTooltip v-if="disabled" :label="disabledTooltip" stop-events>
         {{ label }}
       </NeoTooltip>
 

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -11,7 +11,7 @@
     :position="position"
     :label="label"
     :delay="delay"
-    @click.native.stop>
+    @click.native="handleClick">
     <slot>
       <div />
     </slot>
@@ -35,6 +35,7 @@ export interface Props {
   delay?: number
   fontSize?: string | number
   multilineWidth?: string | number
+  stopEvents?: boolean
 }
 const props = withDefaults(defineProps<Props>(), {
   position: 'top',
@@ -44,6 +45,7 @@ const props = withDefaults(defineProps<Props>(), {
   delay: undefined,
   fontSize: '1rem',
   multilineWidth: '10rem',
+  stopEvents: false,
 })
 
 const fontSize = computed(() => {
@@ -59,6 +61,12 @@ const multilineWidth = computed(() => {
   }
   return props.multilineWidth
 })
+
+const handleClick = (event: MouseEvent) => {
+  if (props.stopEvents) {
+    event.stopPropagation()
+  }
+}
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6075
- [ ] Requires deployment <snek/rubick/worker>

## How to test

1. go to profile page
2. click on tabs
3. should change tab as expected

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/ksm/transfer/?target=EfmnRhHaQqfT3phm4cUCHCU3gFVDoSPR1U9WXzMRQBMqZ4L)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95faa61</samp>

Improved the behavior and appearance of `NeoTooltip` components in various places. Added a new prop to control the click event propagation from the tooltip. Fixed an issue where clicking on a disabled tab would switch the tab.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 95faa61</samp>

> _To improve the profile detail tabs_
> _We tweaked some `NeoTooltip` props_
> _We added `stop-events`_
> _And `append-to-body` makes sense_
> _To avoid some unwanted mishaps_
