### PR TITLE
fix: re-add dot in sidebar

### DIFF
--- a/components/balance/MultipleBalances.vue
+++ b/components/balance/MultipleBalances.vue
@@ -60,6 +60,7 @@ const identityStore = useIdentityStore()
 const { multiBalances, multiBalanceAssets } = storeToRefs(identityStore)
 
 const mapToPrefix = {
+  polkadot: 'dot',
   kusama: 'ksm',
   basilisk: 'bsx',
   statemine: 'stmn',
@@ -85,11 +86,7 @@ function calculateUsd(amount: string, token = 'KSM') {
 
   return calculateExactUsdFromToken(
     amountToNumber,
-    Number(
-      token === 'KSM'
-        ? fiatStore.getCurrentKSMValue
-        : fiatStore.getCurrentBSXValue
-    )
+    Number(fiatStore.getCurrentTokenValue(token))
   )
 }
 

--- a/components/balance/MultipleBalances.vue
+++ b/components/balance/MultipleBalances.vue
@@ -13,7 +13,7 @@
         :key="key"
         class="is-size-7">
         <div v-for="(detail, token) in chain" :key="token" class="balance-row">
-          <div>{{ key.toUpperCase() }}</div>
+          <div class="is-capitalized">{{ key }}</div>
           <div class="has-text-right">
             {{ detail?.balance }}
           </div>

--- a/stores/identity.ts
+++ b/stores/identity.ts
@@ -15,6 +15,7 @@ const DEFAULT_BALANCE_STATE = {
   stmn: '0',
   glmr: '0',
   movr: '0',
+  dot: '0',
 }
 
 export interface IdentityMap {
@@ -28,7 +29,7 @@ type ChangeAddressRequest = {
   apiUrl?: string
 }
 
-type ChainType = 'kusama' | 'basilisk' | 'statemine'
+type ChainType = 'polkadot' | 'kusama' | 'basilisk' | 'statemine'
 type ChainDetail = {
   balance: string
   nativeBalance: string
@@ -36,7 +37,7 @@ type ChainDetail = {
   selected: boolean
   address: string
 }
-type ChainToken = Partial<Record<'ksm' | 'bsx', ChainDetail>>
+type ChainToken = Partial<Record<'dot' | 'ksm' | 'bsx', ChainDetail>>
 
 interface MultiBalances {
   address: string
@@ -87,6 +88,7 @@ export const useIdentityStore = defineStore('identity', {
     multiBalanceAssets: [
       { chain: 'kusama' },
       { chain: 'statemine' },
+      { chain: 'polkadot', token: 'DOT' },
       { chain: 'basilisk', token: 'BSX' },
       { chain: 'basilisk', token: 'KSM', tokenId: getKusamaAssetId('bsx') },
     ],


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6091 (sorry didnt aware we have dot now. getting overriden when I resolve conflicts in this PR https://github.com/kodadot/nft-gallery/pull/6052)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 878b734</samp>

This pull request adds Polkadot integration to the NFT gallery. It enables the display and fetching of Polkadot balances in the `MultipleBalances.vue` component and the `identity.ts` store.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 878b734</samp>

> _Sing, O Muse, of the code that was changed by the skillful developer_
> _Who added support for the Polkadot chain and its token, the `dot`_
> _And simplified the fiat value calculation with a `tokenMap` clever_
> _And a generic getter to fetch the current price of any token, a lot_
