### PR TITLE
fix: Wrap text when no collection and item is found in search

### DIFF
--- a/libs/ui/src/components/NeoAutocomplete/NeoAutocomplete.scss
+++ b/libs/ui/src/components/NeoAutocomplete/NeoAutocomplete.scss
@@ -4,12 +4,18 @@
 @import '@oruga-ui/oruga/src/scss/utilities/helpers.scss';
 @import '../../scss/variable.scss';
 
-.o-acp__menu {
-  margin-top: 1rem;
-  @include ktheme() {
-    box-shadow: theme('primary-shadow');
-    border: 1px solid theme('border-color');
-    color: theme('text-color');
-    background: theme('background-color');
+
+.o-acp{
+  &__item {
+    white-space: normal;
+  }
+  &__menu {
+    margin-top: 1rem;
+    @include ktheme() {
+      box-shadow: theme('primary-shadow');
+      border: 1px solid theme('border-color');
+      color: theme('text-color');
+      background: theme('background-color');
+    }
   }
 }


### PR DESCRIPTION


## PR Type

- [x] Bugfix


## Context

- [x] Closes #6097
- [ ] Requires deployment <snek/rubick/worker>

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="611" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/c246eb8d-a4b2-433f-b32d-d6d511db3705">

<img width="484" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/09349e81-a140-4abd-8b8b-48a05dd2d953">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a4bc89</samp>

Improved the style and layout of the autocomplete component by allowing long items to wrap and simplifying the SCSS code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7a4bc89</samp>

> _`.o-acp` styles_
> _wrap long items with normal_
> _white-space in autumn_
