### PR TITLE
fix: Long collection name: unable to see it all without openning

### DIFF
--- a/components/collection/CollectionDetail.vue
+++ b/components/collection/CollectionDetail.vue
@@ -13,7 +13,9 @@
           <NeoSkeleton no-margin :rounded="false" full-size />
         </div>
       </div>
-      <span v-if="!isLoading" class="collection-detail__name">{{ name }}</span>
+      <span v-if="!isLoading" class="collection-detail__name" :title="name">{{
+        name
+      }}</span>
       <span v-else class="collection-detail__name">
         <NeoSkeleton no-margin size="medium" width="100px" />
       </span>

--- a/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
+++ b/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
@@ -21,9 +21,12 @@
         class="nft-media-info is-flex is-flex-direction-column"
         :class="`nft-media-info__${variant}`">
         <div class="is-flex is-flex-direction-column">
-          <span class="is-ellipsis has-text-weight-bold" data-cy="nft-name">{{
-            nft.name || '--'
-          }}</span>
+          <span
+            class="is-ellipsis has-text-weight-bold"
+            data-cy="nft-name"
+            :title="name"
+            >{{ nft.name || '--' }}</span
+          >
 
           <CollectionDetailsPopover
             v-if="


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6113
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [x] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="390" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/3d9a4b12-4881-44b5-9cfd-68236e3c61f2">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb16801</samp>

Added `title` attributes to `span` elements that display truncated collection and NFT names. This improves the user experience and accessibility by showing the full names on hover.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb16801</samp>

> _`title` attribute_
> _shows full name on hover_
> _a winter blossom_
