### PR TITLE
🎉 New production endpoint for SNEK

### DIFF
--- a/libs/static/src/indexers.ts
+++ b/libs/static/src/indexers.ts
@@ -10,7 +10,7 @@ export const INDEXERS: Config<SquidEndpoint> = {
   rmrk: 'https://squid.subsquid.io/rubick/graphql',
   movr: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
   ksm: 'https://squid.subsquid.io/marck/v/v2/graphql',
-  snek: 'https://squid.subsquid.io/snekk/v/004/graphql',
+  snek: 'https://squid.subsquid.io/sneck/graphql',
   stmn: 'https://squid.subsquid.io/stick/v/v1/graphql',
   dot: 'https://squid.subsquid.io/rubick/graphql', // TODO: change to dot indexer when available
   stt: 'https://squid.subsquid.io/speck/v/v1/graphql',

--- a/libs/static/src/types.ts
+++ b/libs/static/src/types.ts
@@ -18,6 +18,7 @@ export type Squid =
   | 'marck'
   | 'stick'
   | 'speck'
+  | 'sneck'
 
 export type Config<T = boolean> = Record<Prefix, T>
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -44,7 +44,7 @@ export const URLS = {
     seoCard: 'https://og-image-green-seven.vercel.app/',
     rubick: 'https://squid.subsquid.io/rubick/graphql',
     snek: 'https://squid.subsquid.io/snekk/graphql',
-    snekRococo: 'https://squid.subsquid.io/snekk/v/004/graphql',
+    snekRococo: 'https://squid.subsquid.io/sneck/graphql',
     click: 'https://squid.subsquid.io/click/v/002/graphql',
     antick: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
     marck: 'https://squid.subsquid.io/marck/graphql',


### PR DESCRIPTION
- :wrench: sneck instead of snek@004
- :wrench: sneck instead of snek@004

### Promise I will write article about indexers ;D

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring

## Context

- [ ] REF https://github.com/kodadot/snek/pull/179
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/dot/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![Screenshot 2023-05-28 at 15 55 31](https://github.com/kodadot/nft-gallery/assets/22471030/c4e5574e-f194-49ab-94bd-924ac65a1b8d)


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6974d95</samp>

Updated the URLs and types for the snek indexer, which is used to fetch NFT data from the Substrate blockchain. This ensures compatibility with the latest version of the indexer and the squid query parameter.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6974d95</samp>

> _Snek indexer `URL`_
> _Updated to latest version_
> _Squid type welcomes it_
