### PR TITLE
:technologist: set that nft can be burned

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -71,6 +71,7 @@
               <div class="name-container">
                 <h1 class="title" data-cy="item-title">
                   {{ nftMetadata?.name }}
+                  <span v-if="nft?.burned" class="has-text-danger">「🔥」</span>
                 </h1>
                 <h2 class="subtitle" data-cy="item-collection">
                   <CollectionDetailsPopover
@@ -86,7 +87,7 @@
                   </CollectionDetailsPopover>
                 </h2>
               </div>
-              <GalleryItemButton />
+              <GalleryItemButton v-if="!nft?.burned" />
             </div>
 
             <div
@@ -110,19 +111,21 @@
 
           <!-- LINE DIVIDER -->
           <hr />
-          <UnlockableTag
-            v-if="isUnlockable && isMobile"
-            :nft="nft"
-            :link="unlockLink"
-            class="mt-4" />
+          <template v-if="!nft?.burned">
+            <UnlockableTag
+              v-if="isUnlockable && isMobile"
+              :nft="nft"
+              :link="unlockLink"
+              class="mt-4" />
 
-          <!-- price section -->
-          <GalleryItemAction :nft="nft" @buy-success="onNFTBought" />
-          <UnlockableTag
-            v-if="isUnlockable && !isMobile"
-            :link="unlockLink"
-            :nft="nft"
-            class="mt-7" />
+            <!-- price section -->
+            <GalleryItemAction :nft="nft" @buy-success="onNFTBought" />
+            <UnlockableTag
+              v-if="isUnlockable && !isMobile"
+              :link="unlockLink"
+              :nft="nft"
+              class="mt-7" />
+          </template>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## TL;DR 

I realized that UI does not show anyhow that the nft is burned

And I can do whatever (it fails on-chain)

<img width="874" alt="Screenshot 2023-05-28 at 19 06 33" src="https://github.com/kodadot/nft-gallery/assets/22471030/529e6bb4-b6ed-46fc-9bc3-f10cb220cc03">


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1133" alt="Screenshot 2023-05-28 at 19 17 02" src="https://github.com/kodadot/nft-gallery/assets/22471030/26e9ff0d-de9b-4492-bdeb-07f3f092c902">



## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b12a9a4</samp>

This pull request enhances the GalleryItem component to display burned NFTs differently. It uses a fire emoji and hides some elements to indicate that the NFT is no longer available.

copilot:poem
