### PR TITLE
quick and dirty  mobile

### DIFF
--- a/components/collection/unlockable/CollectionBanner.vue
+++ b/components/collection/unlockable/CollectionBanner.vue
@@ -31,8 +31,11 @@ import unloackableBanner from '@/assets/unlockable-banner.svg'
 .collection-banner {
   background-repeat: no-repeat;
   background-size: cover;
-  height: 560px;
   position: relative;
+
+  @include desktop {
+    height: 560px;
+  }
 
   @include ktheme() {
     border-bottom: 1px solid theme('border-color');

--- a/components/collection/unlockable/CollectionInfo.vue
+++ b/components/collection/unlockable/CollectionInfo.vue
@@ -2,11 +2,11 @@
   <div
     class="is-flex is-justify-content-space-between mobile-flex-direction-column gap">
     <div class="is-flex is-flex-direction-column is-flex-grow-1 max-width">
-      <HeroButtons class="is-hidden-tablet" />
-      <div class="is-flex mb-2">
-        <div class="mr-2 has-text-weight-bold is-size-5 mt-6 mb-1">
+      <div class="is-flex mt-6 is-justify-content-space-between mb-2">
+        <div class="mr-2 has-text-weight-bold is-size-5 mb-1">
           About Collection
         </div>
+        <HeroButtons class="is-hidden-tablet" />
       </div>
       <div class="overflow-wrap">
         <Markdown :source="visibleDescription" />
@@ -17,11 +17,12 @@
           class="no-shadow is-text has-text-left p-0"
           :label="seeAllDescription ? $t('showLess') : $t('showMore')"
           @click.native="toggleSeeAllDescription" />
+        <div v-else />
 
         <nuxt-link
           :to="`/${urlPrefix}/collection/${collectionId}`"
           target="_blank">
-          <NeoButton variant="unlockable" class="has-text-left">
+          <NeoButton variant="unlockable" class="has-text-left mt-4">
             View Collection
             <svg
               width="12"

--- a/components/collection/unlockable/ImageSlider.vue
+++ b/components/collection/unlockable/ImageSlider.vue
@@ -109,6 +109,14 @@ const sliderSettings = computed(() => {
 
 .unlockable-image-slider {
   width: 580px;
+
+  @include mobile {
+    width: 100%;
+    max-width: 560px;
+  }
+  @include tablet-only {
+    width: 768px;
+  }
   img {
     @include ktheme() {
       border: 1px solid theme('border-color');
@@ -117,14 +125,32 @@ const sliderSettings = computed(() => {
   .keen-slider__slide {
     height: 580px;
     width: 580px;
+    object-fit: cover;
+    @include tablet-only {
+      width: 768px;
+    }
+    @include mobile {
+      width: 100%;
+    }
   }
   .thumbnail .keen-slider__slide {
     margin-top: 10px;
     height: 136px;
     width: 136px;
+    @include tablet-only {
+      width: calc(768px / 4);
+    }
+    @include mobile {
+      width: 25%;
+      max-width: 136px;
+    }
     img {
       height: 136px;
       width: 136px;
+      @include touch {
+        width: calc(100% - 8px);
+      }
+      object-fit: cover;
     }
     &.active {
       img {

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -112,12 +112,9 @@
         </div>
       </div>
       <hr class="text-color my-4" />
-      <div class="is-flex columns">
-        <div class="column is-6">
-          <img :src="unloackableBanner" alt="Unlockable" />
-        </div>
+      <div class="columns is-desktop">
         <div
-          class="column is-6 is-flex is-flex-direction-column is-justify-content-center">
+          class="column is-half-desktop is-flex is-flex-direction-column is-justify-content-center order-1">
           <div
             class="is-flex is-align-items-center has-text-weight-bold is-size-6 mb-2">
             <svg
@@ -140,6 +137,9 @@
             move object scale bold stroke ima
           </div>
           <NeoButton variant="unlockable" class="mt-2"> Learn More </NeoButton>
+        </div>
+        <div class="column">
+          <img :src="unloackableBanner" alt="Unlockable" />
         </div>
       </div>
     </div>
@@ -272,5 +272,9 @@ const handleSubmitMint = async () => {
     width: 14rem;
     height: 3.5rem;
   }
+}
+
+.order-1 {
+  order: 1;
 }
 </style>

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -4,8 +4,8 @@
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid">
-      <div class="is-flex columns">
-        <div class="column is-6 mobile-padding">
+      <div class="columns is-desktop">
+        <div class="column is-half-desktop mobile-padding">
           <UnlockableCollectionInfo />
           <hr class="mb-4" />
 
@@ -104,7 +104,7 @@
           </div>
           <!-- <UnlockableSchedule /> -->
         </div>
-        <div class="column is-6 pt-5 is-flex is-justify-content-center">
+        <div class="column pt-5 is-flex is-justify-content-center">
           <ImageSlider
             v-if="imageList.length"
             :image-list="imageList"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs Visual check

- @exezbcz  please review

## Context

- [x] Closes #6164
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/22791238/744a5d72-acaf-47b7-b1fa-f13f59985f14)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 998cd91</samp>

Improved the responsiveness and layout of the unlockable collection components. Adjusted the size and position of the image slider, thumbnails, banner, and columns in `ImageSlider.vue`, `UnlockableContainer.vue`, and `CollectionBanner.vue` using media queries and Bulma modifiers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 998cd91</samp>

> _Sing, O Muse, of the skillful web developers_
> _Who made the collection banner and the image slider_
> _Responsive and adaptive to the varied devices of mortals_
> _With media queries and object-fit, like Hephaestus shaping metal_
