### PR TITLE
feat: isChain composable

### DIFF
--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -52,7 +52,8 @@ import { NeoIcon } from '@kodadot1/brick'
 import { langsFlags } from '@/utils/config/i18n'
 import { useLangStore } from '@/stores/lang'
 
-const { urlPrefix, isBasilisk } = usePrefix()
+const { urlPrefix } = usePrefix()
+const { isBasilisk } = useIsChain(urlPrefix.value)
 const { toggleColorMode, isDarkMode } = useTheme()
 
 const langStore = useLangStore()

--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -53,7 +53,7 @@ import { langsFlags } from '@/utils/config/i18n'
 import { useLangStore } from '@/stores/lang'
 
 const { urlPrefix } = usePrefix()
-const { isBasilisk } = useIsChain(urlPrefix.value)
+const { isBasilisk } = useIsChain(urlPrefix)
 const { toggleColorMode, isDarkMode } = useTheme()
 
 const langStore = useLangStore()

--- a/components/common/ConnectWallet/WalletAssetPortfolio.vue
+++ b/components/common/ConnectWallet/WalletAssetPortfolio.vue
@@ -22,7 +22,7 @@ import { NeoButton } from '@kodadot1/brick'
 import { RampInstantSDK } from '@ramp-network/ramp-instant-sdk'
 
 const { urlPrefix } = usePrefix()
-const { isBasilisk } = useIsChain(urlPrefix.value)
+const { isBasilisk } = useIsChain(urlPrefix)
 const { accountId } = useAuth()
 
 const showRampSDK = () => {

--- a/components/common/ConnectWallet/WalletAssetPortfolio.vue
+++ b/components/common/ConnectWallet/WalletAssetPortfolio.vue
@@ -21,7 +21,8 @@
 import { NeoButton } from '@kodadot1/brick'
 import { RampInstantSDK } from '@ramp-network/ramp-instant-sdk'
 
-const { urlPrefix, isBasilisk } = usePrefix()
+const { urlPrefix } = usePrefix()
+const { isBasilisk } = useIsChain(urlPrefix.value)
 const { accountId } = useAuth()
 
 const showRampSDK = () => {

--- a/composables/useIsChain.ts
+++ b/composables/useIsChain.ts
@@ -1,9 +1,16 @@
 import type { Prefix } from '@kodadot1/static'
+import type { ComputedRef } from 'vue'
 
-export default function (prefix: Prefix) {
-  const isBasilisk = computed(() => prefix === 'bsx' || prefix === 'snek')
-  const isRemark = computed(() => prefix === 'rmrk' || prefix === 'ksm')
-  const isAssetHub = computed(() => prefix === 'stmn' || prefix === 'stt')
+export default function (prefix: ComputedRef<Prefix>) {
+  const isBasilisk = computed(
+    () => prefix.value === 'bsx' || prefix.value === 'snek'
+  )
+  const isRemark = computed(
+    () => prefix.value === 'rmrk' || prefix.value === 'ksm'
+  )
+  const isAssetHub = computed(
+    () => prefix.value === 'stmn' || prefix.value === 'stt'
+  )
 
   return {
     isBasilisk,

--- a/composables/useIsChain.ts
+++ b/composables/useIsChain.ts
@@ -1,0 +1,13 @@
+import type { Prefix } from '@kodadot1/static'
+
+export default function (prefix: Prefix) {
+  const isBasilisk = computed(() => prefix === 'bsx' || prefix === 'snek')
+  const isRemark = computed(() => prefix === 'rmrk' || prefix === 'ksm')
+  const isAssetHub = computed(() => prefix === 'stmn' || prefix === 'stt')
+
+  return {
+    isBasilisk,
+    isRemark,
+    isAssetHub,
+  }
+}

--- a/composables/usePrefix.ts
+++ b/composables/usePrefix.ts
@@ -40,16 +40,11 @@ export default function () {
     return useAssetsStore().getAssetById(String(id))
   }
 
-  const isBasilisk = computed(
-    () => prefix.value === 'bsx' || prefix.value === 'snek'
-  )
-
   return {
     urlPrefix,
     setUrlPrefix,
     client,
     tokenId,
     assets,
-    isBasilisk,
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #6202
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd93446</samp>

Refactored the chain detection logic by creating a new `useIsChain` composable that returns computed booleans for each chain based on the prefix. Replaced the `isBasilisk` variable from the `usePrefix` composable with the `useIsChain` composable in the `WalletAssetMenu` and `WalletAssetPortfolio` components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dd93446</samp>

> _To check the chain of a prefix_
> _We use a composable suffix_
> _`useIsChain` returns_
> _Booleans that discern_
> _If it's `Basilisk`, `Remark`, or `AssetHub` fix_
