### PR TITLE
🔧 explore filterMenuButton size and pack

### DIFF
--- a/components/explore/FilterMenuButton.vue
+++ b/components/explore/FilterMenuButton.vue
@@ -1,31 +1,28 @@
 <template>
   <div class="has-addons is-flex is-align-items-center" data-cy="tabs">
-    <div>
-      <a
-        class="is-hidden-mobile"
-        :class="{ disabled: disabled }"
-        @click="toggleSidebarFilters">
-        <NeoIcon
-          :icon="isSidebarFiltersOpen && !disabled ? 'times' : 'bars'"
-          size="medium" />
-      </a>
-      <div class="is-hidden-tablet is-relative">
-        <NeoButton
-          :disabled="disabled"
-          icon="bars"
-          @click.native="openMobileFilters" />
-        <ActiveCount v-if="numOfActiveFilters" :count="numOfActiveFilters" />
-      </div>
+    <a
+      :class="[{ disabled: disabled }, 'is-hidden-mobile']"
+      @click="toggleSidebarFilters">
+      <NeoIcon
+        :icon="isSidebarFiltersOpen && !disabled ? 'times' : 'bars'"
+        pack="far"
+        size="medium" />
+    </a>
+    <div class="is-hidden-tablet is-relative">
+      <NeoButton
+        :disabled="disabled"
+        icon="bars"
+        @click.native="openMobileFilters" />
+      <ActiveCount v-if="numOfActiveFilters" :count="numOfActiveFilters" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { NeoButton } from '@kodadot1/brick'
+import { NeoButton, NeoIcon } from '@kodadot1/brick'
 import ActiveCount from './ActiveCount.vue'
 import { usePreferencesStore } from '@/stores/preferences'
 import useActiveRouterFilters from '@/composables/useActiveRouterFilters'
-import { NeoIcon } from '@kodadot1/brick'
 
 const route = useRoute()
 const preferencesStore = usePreferencesStore()

--- a/components/explore/FilterMenuButton.vue
+++ b/components/explore/FilterMenuButton.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="has-addons is-flex is-align-items-center" data-cy="tabs">
     <a
-      :class="[{ disabled: disabled }, 'is-hidden-mobile']"
+      :class="[
+        { disabled: disabled },
+        'is-hidden-mobile is-flex is-align-items-center',
+      ]"
       @click="toggleSidebarFilters">
       <NeoIcon
         :icon="isSidebarFiltersOpen && !disabled ? 'times' : 'bars'"
-        pack="far"
+        pack="fa-sharp"
         size="medium" />
     </a>
     <div class="is-hidden-tablet is-relative">

--- a/libs/ui/src/components/NeoIcon/NeoIcon.scss
+++ b/libs/ui/src/components/NeoIcon/NeoIcon.scss
@@ -1,17 +1,7 @@
 @import '../../scss/theme';
+
 .o-icon--success {
   @include ktheme() {
     color: theme('k-green');
   }
-}
-
-.o-icon--small {
-  font-size: 16px;
-}
-
-.o-icon--medium {
-  font-size: 24px;
-}
-.o-icon--large {
-  font-size: 32px;
 }


### PR DESCRIPTION
closes #6216 

- remove NeoIcon forced size px... (please use `customSize` if you want to set custom size)
- small refactor component
- fix icon alignment
- fix icon pack

![Screenshot 2023-06-14 at 12-55-18 Low minting fees and carbonless NFTs KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/ee5df7b3-fda0-4b09-b680-b819e0232faa)
