### PR TITLE
🔧 NeoButton icon pack

### DIFF
--- a/components/base/SubmitButton.vue
+++ b/components/base/SubmitButton.vue
@@ -7,6 +7,7 @@
       :disabled="disabled"
       :loading="loading"
       :expanded="expanded"
+      icon-pack="far"
       outlined
       @click.native="$emit('click')">
       <slot>
@@ -29,7 +30,7 @@ export interface Props {
   size?: 'small' | 'medium' | 'large'
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   loading: false,
   disabled: false,
   type: 'is-primary',

--- a/libs/ui/src/components/NeoButton/NeoButton.vue
+++ b/libs/ui/src/components/NeoButton/NeoButton.vue
@@ -10,7 +10,7 @@
     :variant="variant"
     :disabled="disabled"
     :expanded="expanded"
-    :icon-pack="iconPack"
+    :icon-pack="iconPack || 'fas'"
     :label="label"
     class="is-neo"
     :rounded="rounded"
@@ -24,7 +24,7 @@
 import { OButton } from '@oruga-ui/oruga'
 import { NeoButtonVariant } from '@kodadot1/brick'
 
-const props = defineProps<{
+defineProps<{
   size?: 'small' | 'medium' | 'large'
   disabled?: boolean
   expanded?: boolean
@@ -38,8 +38,6 @@ const props = defineProps<{
   rounded?: boolean
   tag?: string
 }>()
-
-const iconPack = computed(() => props?.iconPack || 'fa-sharp')
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
<img width="439" alt="Capture d’écran 2023-06-14 à 1 52 57 PM" src="https://github.com/kodadot/nft-gallery/assets/9987732/b93bb9a3-454d-462b-a94e-72e11ec855c4">

Same as #6170 but for `NeoButton` component

⚠️ some buttons might have icon changed, ping me if you see something strange