### PR TITLE
feat: Follow up for success drop notification

### DIFF
--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -192,7 +192,6 @@ const resultList = ref<any[]>([])
 const selectedImage = ref('')
 const MAX_PER_WINDOW = 10
 const { urlPrefix } = usePrefix()
-const { redesign } = useExperiments()
 
 const isLoading = ref(false)
 const { accountId, isLogIn } = useAuth()
@@ -203,14 +202,6 @@ onMounted(async () => {
   const res = await getLatestWaifuImages()
   imageList.value = res.result.map((item) => item.output)
   resultList.value = res.result
-
-  // for test
-  if (redesign.value) {
-    isLoading.value = true
-    setTimeout(() => {
-      justMinted.value = '8-90'
-    }, 5000)
-  }
 })
 
 const leftTime = computed(() => {

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -194,7 +194,7 @@ const MAX_PER_WINDOW = 10
 const { urlPrefix } = usePrefix()
 const { redesign } = useExperiments()
 
-const isLoading = ref(redesign.value || false)
+const isLoading = ref(false)
 const { accountId, isLogIn } = useAuth()
 const { hours, minutes, seconds } = useCountDown(countDownTime)
 const justMinted = ref('')
@@ -206,6 +206,7 @@ onMounted(async () => {
 
   // for test
   if (redesign.value) {
+    isLoading.value = true
     setTimeout(() => {
       justMinted.value = '8-90'
     }, 5000)

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -192,7 +192,9 @@ const resultList = ref<any[]>([])
 const selectedImage = ref('')
 const MAX_PER_WINDOW = 10
 const { urlPrefix } = usePrefix()
-const isLoading = ref(false)
+const { redesign } = useExperiments()
+
+const isLoading = ref(redesign.value || false)
 const { accountId, isLogIn } = useAuth()
 const { hours, minutes, seconds } = useCountDown(countDownTime)
 const justMinted = ref('')
@@ -201,6 +203,13 @@ onMounted(async () => {
   const res = await getLatestWaifuImages()
   imageList.value = res.result.map((item) => item.output)
   resultList.value = res.result
+
+  // for test
+  if (redesign.value) {
+    setTimeout(() => {
+      justMinted.value = '8-90'
+    }, 5000)
+  }
 })
 
 const leftTime = computed(() => {

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -15,8 +15,8 @@
         <div v-if="minted" class="mt-4">
           Share your success
           <a :href="postTwitterUrl" target="_blank" class="has-text-link"
-            >on Twitter</a
-          >
+            >on Twitter
+          </a>
         </div>
         <NeoButton
           class="mb-2 mt-4 loading-button is-size-6"

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -7,23 +7,25 @@
         class="is-flex is-flex-direction-column is-align-items-center px-5 has-text-centered is-capitalized">
         <div class="has-text-weight-bold mb-2">{{ $t('mint.success') }}</div>
         <div>
-          Get ready for the big reveal! Your NFT
-
+          {{ $t('mint.unlockable.loader.viewNFT1') }}
           <span v-if="minted">
-            is
-            <span class="has-text-weight-bold"> visible now.</span>
+            {{ $t('mint.unlockable.loader.viewNFTNow2') }}
+            <span class="has-text-weight-bold">
+              {{ $t('mint.unlockable.loader.viewNFTNow3') }}</span
+            >
           </span>
           <span v-else>
-            will be visible in
+            {{ $t('mint.unlockable.loader.viewNFTLater2') }}
             <span class="has-text-weight-bold">
-              {{ displaySeconds }} seconds.
+              {{ displaySeconds }}
+              {{ $t('mint.unlockable.loader.viewNFTLater3') }}
             </span>
           </span>
         </div>
         <div class="mt-4">
-          Share your success
+          {{ $t('mint.unlockable.loader.shareSuccess') }}
           <a :href="postTwitterUrl" target="_blank" class="has-text-link"
-            >on Twitter
+            >{{ $t('mint.unlockable.loader.onTwitter') }}
           </a>
         </div>
         <NeoButton
@@ -70,7 +72,7 @@ const displaySeconds = computed(() => {
 
 const twitterText = computed(
   () =>
-    'Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don\'t miss your chance! \n\n https://kodadot.xyz/stmn/unlockable'
+    "Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/unlockable"
 )
 const postTwitterUrl = computed(
   () =>

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -15,7 +15,9 @@
           </span>
           <span v-else>
             will be visible in
-            <span class="has-text-weight-bold"> 30 seconds. </span>
+            <span class="has-text-weight-bold">
+              {{ displaySeconds }} seconds.
+            </span>
           </span>
         </div>
         <div class="mt-4">
@@ -55,6 +57,16 @@ const props = withDefaults(
 const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
 const isLoading = useVModel(props, 'value')
+import { useCountDown } from './utils/useCountDown'
+
+const COUNT_DOWN_SECONDS = 30
+const { seconds } = useCountDown(
+  new Date().getTime() + COUNT_DOWN_SECONDS * 1000
+)
+
+const displaySeconds = computed(() => {
+  return seconds.value >= 0 ? seconds.value : 0
+})
 
 const twitterText = computed(
   () =>

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -3,11 +3,20 @@
     <div class="loading-container py-2">
       <NeoIcon class="close-icon" icon="close" @click.native="closeLoading" />
       <img :src="unloackableLoaderImg" />
-      <div class="is-flex is-flex-direction-column is-align-items-center px-7">
-        <div class="has-text-weight-bold my-2">Congratulations</div>
-        <div>
-          Get ready for the big reveal! Your NFT will be visible in just
-          <span class="has-text-weight-bold">30 seconds</span> on your profile.
+      <div
+        class="is-flex is-flex-direction-column is-align-items-center px-5 has-text-centered is-capitalized">
+        <div class="has-text-weight-bold mb-2">Congratulations</div>
+        <div class="">
+          Get ready for the big reveal! Your NFT will be visible
+          <span class="has-text-weight-bold">{{
+            minted ? 'by now.' : 'in just 30 seconds.'
+          }}</span>
+        </div>
+        <div v-if="minted" class="mt-4">
+          Share your success
+          <a :href="postTwitterUrl" target="_blank" class="has-text-link"
+            >on Twitter</a
+          >
         </div>
         <NeoButton
           class="mb-2 mt-4 loading-button is-size-6"
@@ -41,6 +50,14 @@ const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
 
 const isLoading = useVModel(props, 'value')
+
+const postTwitterUrl = computed(
+  () =>
+    `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      `Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/gallery/${props.minted}`
+    )}`
+)
+
 const emit = defineEmits(['input'])
 
 const closeLoading = () => {
@@ -61,7 +78,7 @@ const buttonLabel = computed(() =>
   backdrop-filter: $frosted-glass-backdrop-filter;
   margin: 0rem 1rem;
   width: 385px;
-  min-height: 336px;
+  min-height: 356px;
 
   @include ktheme() {
     box-shadow: theme('primary-shadow');

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -70,7 +70,7 @@ const displaySeconds = computed(() => {
 
 const twitterText = computed(
   () =>
-    "Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/unlockable"
+    'Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don\'t miss your chance! \n\n https://kodadot.xyz/stmn/unlockable'
 )
 const postTwitterUrl = computed(
   () =>

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -50,13 +50,16 @@ const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
 const isLoading = useVModel(props, 'value')
 
+const twitterText = computed(
+  () =>
+    `Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/gallery/${props.minted}`
+)
 const postTwitterUrl = computed(
   () =>
     `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-      `Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/gallery/${props.minted}`
+      twitterText.value
     )}`
 )
-
 const emit = defineEmits(['input'])
 
 const closeLoading = () => {

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -5,8 +5,8 @@
       <img :src="unloackableLoaderImg" />
       <div
         class="is-flex is-flex-direction-column is-align-items-center px-5 has-text-centered is-capitalized">
-        <div class="has-text-weight-bold mb-2">Congratulations</div>
-        <div class="">
+        <div class="has-text-weight-bold mb-2">{{ $t('mint.success') }}</div>
+        <div>
           Get ready for the big reveal! Your NFT will be visible
           <span class="has-text-weight-bold"
             >{{ minted ? 'by now.' : 'in just 30 seconds.' }}

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -8,9 +8,9 @@
         <div class="has-text-weight-bold mb-2">Congratulations</div>
         <div class="">
           Get ready for the big reveal! Your NFT will be visible
-          <span class="has-text-weight-bold">{{
-            minted ? 'by now.' : 'in just 30 seconds.'
-          }}</span>
+          <span class="has-text-weight-bold"
+            >{{ minted ? 'by now.' : 'in just 30 seconds.' }}
+          </span>
         </div>
         <div v-if="minted" class="mt-4">
           Share your success

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -7,12 +7,18 @@
         class="is-flex is-flex-direction-column is-align-items-center px-5 has-text-centered is-capitalized">
         <div class="has-text-weight-bold mb-2">{{ $t('mint.success') }}</div>
         <div>
-          Get ready for the big reveal! Your NFT will be visible
-          <span class="has-text-weight-bold"
-            >{{ minted ? 'by now.' : 'in just 30 seconds.' }}
+          Get ready for the big reveal! Your NFT
+
+          <span v-if="minted">
+            is
+            <span class="has-text-weight-bold"> visible now.</span>
+          </span>
+          <span v-else>
+            will be visible in
+            <span class="has-text-weight-bold"> 30 seconds. </span>
           </span>
         </div>
-        <div v-if="minted" class="mt-4">
+        <div class="mt-4">
           Share your success
           <a :href="postTwitterUrl" target="_blank" class="has-text-link"
             >on Twitter
@@ -52,7 +58,7 @@ const isLoading = useVModel(props, 'value')
 
 const twitterText = computed(
   () =>
-    `Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/gallery/${props.minted}`
+    "Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/unlockable"
 )
 const postTwitterUrl = computed(
   () =>

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -59,18 +59,18 @@ const { $i18n } = useNuxtApp()
 const isLoading = useVModel(props, 'value')
 import { useCountDown } from './utils/useCountDown'
 
-const COUNT_DOWN_SECONDS = 30
+const COUNT_DOWN_SECONDS = 31
 const { seconds } = useCountDown(
   new Date().getTime() + COUNT_DOWN_SECONDS * 1000
 )
 
 const displaySeconds = computed(() => {
-  return seconds.value >= 0 ? seconds.value : 0
+  return seconds.value >= 0 ? seconds.value : 'few'
 })
 
 const twitterText = computed(
   () =>
-    'Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don\'t miss your chance! \n\n https://kodadot.xyz/stmn/unlockable'
+    "Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/unlockable"
 )
 const postTwitterUrl = computed(
   () =>

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -48,7 +48,6 @@ const props = withDefaults(
 )
 const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
-
 const isLoading = useVModel(props, 'value')
 
 const postTwitterUrl = computed(

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -72,7 +72,7 @@ const displaySeconds = computed(() => {
 
 const twitterText = computed(
   () =>
-    "Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don't miss your chance! \n\n https://kodadot.xyz/stmn/unlockable"
+    'Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don\'t miss your chance! \n\n https://kodadot.xyz/stmn/unlockable'
 )
 const postTwitterUrl = computed(
   () =>

--- a/components/collection/unlockable/utils/useCountDown.ts
+++ b/components/collection/unlockable/utils/useCountDown.ts
@@ -13,6 +13,7 @@ export const useCountDown = (countDownTime: number) => {
     seconds.value = Math.floor((distance % (1000 * 60)) / 1000)
   }
 
+  countdown()
   onMounted(() => {
     timer.value = setInterval(countdown, 1000)
   })

--- a/locales/en.json
+++ b/locales/en.json
@@ -482,7 +482,16 @@
       "takeMe": "Take Me There!",
       "viewItem": "View Item",
       "preparing": "Preparing Your Item...",
-      "alreadyMinted": "🎉 You already have this NFT, check it here"
+      "alreadyMinted": "🎉 You already have this NFT, check it here",
+      "loader": {
+        "shareSuccess": "Share your success",
+        "onTwitter": "on Twitter",
+        "viewNFT1": "Get ready for the big reveal! Your NFT",
+        "viewNFTNow2": "is",
+        "viewNFTNow3": "visible now.",
+        "viewNFTLater2": " will be visible in",
+        "viewNFTLater3": "seconds."
+      }
     }
   },
   "tooltip": {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #6252
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

tested on `/stmn/unlockable?redesign=true`

<img width="421" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/29d9b8dc-ae63-46a5-b622-e436d2c774c8">


<img width="424" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/f763ee7f-c772-404d-b87c-0c6450236c0a">

twitter
![image](https://github.com/kodadot/nft-gallery/assets/31397967/efbf4cb2-f9bc-4f82-b6e3-b0a7866aeae3)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4f1c7b</samp>

Added feature flag and mock code for unlockable NFTs and improved UX for minting and sharing them. The changes affect the `UnlockableContainer` and `UnlockableLoader` components in `components/collection/unlockable`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f4f1c7b</samp>

> _Sing, O Muse, of the skillful code that changed the face of NFTs_
> _How the clever developers added a feature flag and mock code_
> _To test the new design of the `UnlockableContainer` component_
> _And make it easier to mint and share the hidden treasures of art_
