### PR TITLE
fix: Clicking on profile should close sidebar

### DIFF
--- a/components/common/ConnectWallet/ConnectWalletModal.vue
+++ b/components/common/ConnectWallet/ConnectWalletModal.vue
@@ -15,7 +15,7 @@
       </a>
     </header>
     <section v-if="showAccount">
-      <WalletAsset @back="setForceWalletSelect" />
+      <WalletAsset />
     </section>
     <section v-else-if="hasUserWalletAuth" class="modal-card-body">
       <div class="buttons m-0">
@@ -95,12 +95,8 @@ const forceWalletSelect = ref(false)
 const identityStore = useIdentityStore()
 const { urlPrefix } = usePrefix()
 
-const setForceWalletSelect = () => {
-  forceWalletSelect.value = true
-}
-
 const account = computed(() => identityStore.auth.address)
-const showAccount = computed(() => account.value && !forceWalletSelect.value)
+const showAccount = computed(() => account.value)
 
 const wallets = SupportedWallets()
 const setAccount = (account: Auth) => {

--- a/libs/ui/src/components/IdentityItem/IdentityItem.vue
+++ b/libs/ui/src/components/IdentityItem/IdentityItem.vue
@@ -8,9 +8,9 @@
       <NeoButton
         no-shadow
         rounded
-        tag="nuxt-link"
+        tag="a"
         size="small"
-        :to="`/${prefix}/u/${account}`"
+        :href="`/${prefix}/u/${account}`"
         icon="arrow-right-long">
         {{ buttonLabel }}
       </NeoButton>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6253
- [x] delete some unused code

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22227ec</samp>

Removed unnecessary logic and fixed navigation bug in `ConnectWalletModal` component. Changed `IdentityItem` component to use regular anchor tag instead of `nuxt-link` tag.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 22227ec</samp>

> _Oh we're the crew of the `IdentityItem`_
> _We sail the web with a nifty trick_
> _We use a plain old anchor tag_
> _To fix the bug and make the modal slick_
