### PR TITLE
ci: fix wretry version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run Cypress
         timeout-minutes: 10
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: pnpm start:static & pnpm wait-on http://localhost:9090 && MATRIX=${{ matrix.index }} node tests/cypress/e2e-run-tests.js
           attempt_limit: 3


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] fix wretry version. newer version being broken https://github.com/Wandalen/wretry.action/actions/runs/5292343788


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a573e19</samp>

Updated `wretry.action` to use a fixed version in `e2e.yml`. This improves the reliability of the Cypress end-to-end tests by avoiding potential issues from the action's updates.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a573e19</samp>

> _`uses` field changed_
> _`wretry.action` pinned_
> _stable tests in fall_
