### PR TITLE
feat: put "Learn" link into navbar

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -75,6 +75,13 @@
           data-cy="explore" />
       </template>
 
+      <a
+        href="https://hello.kodadot.xyz"
+        target="_blank"
+        class="navbar-item"
+        data-cy="learn">
+        {{ $t('learn') }}
+      </a>
       <CreateDropdown
         v-show="isCreateVisible"
         class="navbar-create custom-navbar-item ml-0"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #6281
- [ ] Requires deployment <snek/rubick/worker>

<img width="541" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/47b7a93a-1833-4c03-9bf8-93bba4e3ca4e">

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c178ca</samp>

Added a link to the learning platform in the navbar component. The link supports testing and localization.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c178ca</samp>

> _`Kodadot` link added_
> _Learn NFT art in the fall_
> _`$t` and `data-cy`_
