### PR TITLE
fix: Change heading text on landing page

### DIFF
--- a/components/landing/SearchLanding.vue
+++ b/components/landing/SearchLanding.vue
@@ -5,15 +5,17 @@
     <div
       class="is-flex is-flex-direction-column is-align-items-center search-info">
       <h1
-        class="title is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered">
-        <span>{{ $t('search.landingTitle1') }}</span>
-        {{ $t('search.landingTitle2') }}
-        <span> {{ $t('search.landingTitle3') }}</span>
+        class="title is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered is-flex is-flex-wrap-wrap is-justify-content-center is-align-items-center">
+        {{ $t('search.landingTitle1') }}
+        <span
+          class="subtitle is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered is-capitalized">
+          {{ $t('search.landingTitle2') }}
+        </span>
       </h1>
-      <span
-        class="subtitle is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered is-capitalized">
-        {{ $t('search.landingSubtitle') }}
-      </span>
+      <h1
+        class="title is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered">
+        {{ $t('search.landingTitle3') }}
+      </h1>
       <LazySearch
         hide-filter
         class="landing-search-bar"

--- a/components/landing/SearchLanding.vue
+++ b/components/landing/SearchLanding.vue
@@ -5,10 +5,10 @@
     <div
       class="is-flex is-flex-direction-column is-align-items-center search-info">
       <h1
-        class="title is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered is-flex is-flex-wrap-wrap is-justify-content-center is-align-items-center">
+        class="title is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered is-flex is-flex-wrap-wrap is-justify-content-center is-align-items-center mb-0">
         {{ $t('search.landingTitle1') }}
         <span
-          class="subtitle is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered is-capitalized">
+          class="subtitle is-size-1 is-size-2-mobile has-text-weight-bold has-text-centered is-capitalized ml-4">
           {{ $t('search.landingTitle2') }}
         </span>
       </h1>

--- a/locales/en.json
+++ b/locales/en.json
@@ -79,10 +79,9 @@
     "rankings": "Rankings",
     "units": "Units",
     "owners": "Owners",
-    "landingTitle1": "Discover,",
-    "landingTitle2": "Collect",
-    "landingTitle3": "And Sell",
-    "landingSubtitle": "Kusama NFTS",
+    "landingTitle1": "Go To",
+    "landingTitle2": "Polkadot NFT",
+    "landingTitle3": "Marketplace",
     "collectionNotFound": "Our search agents did not found anything with \"{0}\" in collection name",
     "nftNotFound": "Our search agents did not found anything with \"{0}\" in NFT name"
   },

--- a/styles/components/_search.scss
+++ b/styles/components/_search.scss
@@ -10,7 +10,6 @@
 
   .title {
     word-break: keep-all;
-    gap: 1rem;
   }
 
   .subtitle {

--- a/styles/components/_search.scss
+++ b/styles/components/_search.scss
@@ -10,6 +10,7 @@
 
   .title {
     word-break: keep-all;
+    gap: 1rem;
   }
 
   .subtitle {
@@ -157,7 +158,7 @@
     padding: 0 50px 0 42px !important;
     height: 2.5rem;
     outline: none;
-    
+
     &::placeholder {
       margin-left: 10px;
       font-weight: 400;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #6294
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

<img width="846" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/7ac92535-f838-48b2-83c1-d8a82c22569e">

<img width="365" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/8d65a5d1-210b-4832-99b3-a318e17092de">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dcc37d</samp>

Updated landing page and styles to match new branding and domain name. Changed `SearchLanding.vue`, `_search.scss`, and `en.json` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3dcc37d</samp>

> _The landing page got a new look_
> _With title and subtitle from a book_
> _They used `flex` to center_
> _And `gap` to indent `search-info`_
> _And cleaned up the `search-input` nook_
