### PR TITLE
style: update gallery item previewer

### DIFF
--- a/components/gallery/GalleryItemPreviewer.vue
+++ b/components/gallery/GalleryItemPreviewer.vue
@@ -54,6 +54,7 @@ const isFullscreen = useVModel(props, 'value', emit)
     height: calc(100% - $navbar-desktop-min-height + 1px) !important;
     margin-top: calc($navbar-desktop-min-height - 1px) !important;
     border: none !important;
+    width: 100%;
     @include mobile {
       height: calc(100% - $navbar-mobile-min-height + 1px) !important;
       margin-top: calc($navbar-mobile-min-height - 1px) !important;
@@ -71,9 +72,12 @@ const isFullscreen = useVModel(props, 'value', emit)
   }
   .back-button {
     position: absolute;
-    right: 2rem;
+    left: 0.75rem;
     top: 2rem;
     z-index: 99;
+    @include desktop {
+      left: $fluid-container-padding;
+    }
   }
   &-container {
     @include ktheme() {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #6072
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=12zQP2JviSyZzAX2j31F2TR5uSvDNerruSJBWxEZXjW3KMaN)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1806" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/a79852bc-e90d-47e4-8c51-2323460d83db">
<img width="897" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/22f6b1d3-4373-4040-9e96-c99b145c76db">
<img width="488" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/639fc69c-dddf-4117-8d56-1ef4e97ddecf">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 990f26e</samp>

Enhanced the UI of the `GalleryItemPreviewer` component to fit different screen sizes and improve the user experience.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 990f26e</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `GalleryItemPreviewer`, a wondrous component of the web,_
> _And made it more responsive and well-aligned,_
> _Like Hephaestus shaping metal with his hammer on his anvil._

