### PR TITLE
feat: Drop image examples and carousel

### DIFF
--- a/components/collection/unlockable/ImageSlider.vue
+++ b/components/collection/unlockable/ImageSlider.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="unlockable-image-slider mt-6">
     <div
-      class="unlockable-image-tip border px-4 py-2 theme-background-color has-z-index-1">
+      class="unlockable-image-tip border px-4 py-2 theme-background-color has-z-index-1 no-wrap">
       {{ $t('mint.unlockable.imageTip') }}
     </div>
     <div ref="container" class="keen-slider">
@@ -78,7 +78,6 @@ const [container, slider] = useKeenSlider({
 const [thumbnail] = useKeenSlider(
   {
     initial: 0,
-    loop: true,
     slides: {
       perView: 4,
       spacing: 10,
@@ -147,9 +146,11 @@ const sliderSettings = computed(() => {
     object-fit: cover;
     @include tablet-only {
       width: 768px;
+      height: 100%;
     }
     @include mobile {
       width: 100%;
+      height: 100%;
     }
   }
   .thumbnail .keen-slider__slide {
@@ -158,16 +159,17 @@ const sliderSettings = computed(() => {
     width: 136px;
     @include tablet-only {
       width: calc(768px / 4);
+      height: 100%;
     }
     @include mobile {
       width: 25%;
       max-width: 136px;
     }
     img {
-      height: 136px;
-      width: 136px;
-      @include touch {
-        width: calc(100% - 8px);
+      width: 100%;
+      height: 100%;
+      @include mobile {
+        height: min-content;
       }
       object-fit: cover;
       &:hover {

--- a/components/collection/unlockable/ImageSlider.vue
+++ b/components/collection/unlockable/ImageSlider.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="unlockable-image-slider mt-6">
+    <div
+      class="unlockable-image-tip border px-4 py-2 theme-background-color has-z-index-1">
+      {{ $t('mint.unlockable.imageTip') }}
+    </div>
     <div ref="container" class="keen-slider">
       <img
         v-for="image in imageList"
@@ -10,15 +14,13 @@
 
     <Transition name="fade">
       <div
-        v-if="sliderSettings.leftArrowValid"
-        class="arrow arrow-left"
-        @click="slider?.moveToIdx(sliderSettings.leftCarouselIndex)"></div>
+        class="arrow arrow-left arrow-small-size"
+        @click="slider?.moveToIdx(sliderSettings.leftCarouselIndex)" />
     </Transition>
     <Transition name="fade">
       <div
-        v-if="sliderSettings.rightArrowValid"
-        class="arrow arrow-right"
-        @click="slider?.moveToIdx(sliderSettings.rightCarouselIndex)"></div>
+        class="arrow arrow-right arrow-small-size"
+        @click="slider?.moveToIdx(sliderSettings.rightCarouselIndex)" />
     </Transition>
     <div ref="thumbnail" class="keen-slider thumbnail">
       <div v-for="image in imageList" :key="image" class="keen-slider__slide">
@@ -70,13 +72,16 @@ function ThumbnailPlugin(main) {
   }
 }
 
-const [container, slider] = useKeenSlider({})
+const [container, slider] = useKeenSlider({
+  loop: true,
+})
 const [thumbnail] = useKeenSlider(
   {
     initial: 0,
+    loop: true,
     slides: {
       perView: 4,
-      spacing: 1,
+      spacing: 10,
     },
   },
   [ThumbnailPlugin(slider)]
@@ -89,8 +94,8 @@ const sliderSettings = computed(() => {
     const perView = Number(4)
     const leftArrowValid = abs !== 0
     const rightArrowValid = abs + perView < slides.length
-    const leftCarouselIndex = Math.max(abs - 1, 0)
-    const rightCarouselIndex = Math.min(abs + 1, slides.length - perView)
+    const leftCarouselIndex = (abs - 1 + perView) % perView
+    const rightCarouselIndex = (abs + 1) % perView
 
     return {
       leftArrowValid,
@@ -106,12 +111,15 @@ const sliderSettings = computed(() => {
 
 <style scoped lang="scss">
 @import '@/styles/abstracts/variables';
+@import '@/styles/components/carousel-arrows';
 
 .unlockable-image-slider {
   width: 580px;
+  position: relative;
 
   @include mobile {
-    width: 100%;
+    width: 100% !important;
+    height: 100% !important;
     max-width: 560px;
   }
   @include tablet-only {
@@ -120,6 +128,17 @@ const sliderSettings = computed(() => {
   img {
     @include ktheme() {
       border: 1px solid theme('border-color');
+    }
+  }
+
+  .unlockable-image-tip {
+    border-radius: 3rem;
+    position: absolute;
+    left: 26px;
+    top: -14px;
+    @include mobile {
+      left: 50%;
+      transform: translateX(-50%);
     }
   }
   .keen-slider__slide {
@@ -162,6 +181,18 @@ const sliderSettings = computed(() => {
         }
       }
     }
+  }
+}
+.arrow {
+  display: block;
+  height: 40px;
+  &-left {
+    left: 10px;
+    top: 34%;
+  }
+  &-right {
+    right: 10px;
+    top: 34%;
   }
 }
 </style>

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -171,7 +171,7 @@ import UnlockableSlider from '@/components/collection/unlockable/UnlockableSlide
 import UnlockableSchedule from '@/components/collection/unlockable/UnlockableSchedule.vue'
 import unloackableBanner from '@/assets/unlockable-introduce.svg'
 import { doWaifu, getLatestWaifuImages } from '@/services/waifu'
-import { collectionId, countDownTime } from './const'
+import { DISPLAY_SLIDE_IMAGE_COUNT, collectionId, countDownTime } from './const'
 import { UNLOCKABLE_CAMPAIGN, createUnlockableMetadata } from './utils'
 import { endOfHour, startOfHour } from 'date-fns'
 import type Vue from 'vue'
@@ -200,7 +200,9 @@ const justMinted = ref('')
 
 onMounted(async () => {
   const res = await getLatestWaifuImages()
-  imageList.value = res.result.map((item) => item.output)
+  imageList.value = res.result
+    .slice(0, DISPLAY_SLIDE_IMAGE_COUNT)
+    .map((item) => item.output)
   resultList.value = res.result
 })
 

--- a/components/collection/unlockable/const.ts
+++ b/components/collection/unlockable/const.ts
@@ -5,3 +5,5 @@ export const countDownTime = endOfHour(now).getTime()
 
 export const slidesCountOnTimeCountdown = 10
 export const collectionId = '8'
+
+export const DISPLAY_SLIDE_IMAGE_COUNT = 4

--- a/locales/en.json
+++ b/locales/en.json
@@ -482,6 +482,7 @@
       "viewItem": "View Item",
       "preparing": "Preparing Your Item...",
       "alreadyMinted": "🎉 You already have this NFT, check it here",
+      "imageTip": "Examples Of Possible Drop",
       "loader": {
         "shareSuccess": "Share your success",
         "onTwitter": "on Twitter",

--- a/styles/components/_carousel-arrows.scss
+++ b/styles/components/_carousel-arrows.scss
@@ -2,6 +2,11 @@
   $side-y: 32px;
   $side-x: 55px;
 
+  &-small-size {
+    $side-y: 20px;
+    $side-x: 32px;
+  }
+
   width: $side-x;
   height: $side-x;
   position: absolute;

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -429,3 +429,7 @@ a.has-text-grey {
 .is-flex-1 {
   flex: 1;
 }
+
+.has-z-index-1 {
+  z-index: 1;
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #6280
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

<img width="1271" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/9c2bff50-dbba-42a6-b5bd-a600cdb1fc55">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9dfde4</samp>

This pull request improves the image slider component for the unlockable campaign feature, by adding a looping feature, a text message, and custom styling. It also refactors some code, fixes some bugs, and adds some localization and constants. The main files affected are `ImageSlider.vue`, `UnlockableContainer.vue`, `const.ts`, `en.json`, and some style files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a9dfde4</samp>

> _Sing, O Muse, of the skillful coder who enhanced the image slider_
> _With looping feature, text message, and custom styling for the arrows_
> _He fetched and displayed the latest waifu images, `DISPLAY_SLIDE_IMAGE_COUNT`_
> _And added the `mint.unlockable.imageTip` to the `en.json` file_
