### PR TITLE
fix: searchbar dropdown styling

### DIFF
--- a/styles/components/_search.scss
+++ b/styles/components/_search.scss
@@ -130,11 +130,17 @@
     pointer-events: none;
   }
 
-  .o-acp__item {
-    padding: 0;
-    background: unset!important;
-    color: unset!important;
+  .o-acp__menu {
+    max-height: 610px;
+    .o-acp__item {
+      padding: 0;
+      background: unset!important;
+      color: unset!important;
+    }
   }
+
+
+
 }
 
 .gallery-search {
@@ -224,6 +230,7 @@
     max-width: 34ch;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .secondary-info {
@@ -245,26 +252,30 @@
   .tab-content {
     padding-top: 0 !important;
   }
-
-  .tabs li a {
-    display: flex;
-    padding: 10px 0;
-    justify-content: flex-start;
+  .tabs ul {
     @include ktheme() {
       border-bottom-color: theme('placeholder-color');
     }
   }
 
+  .tabs li a {
+    display: flex;
+    padding: 10px 0;
+    justify-content: center;
+
+  }
+
   .tabs li.is-active a {
     font-weight: 700;
     @include ktheme() {
-      border-bottom-color: theme('placeholder-color');
+      border-bottom-color: $lightpink;
       background: theme('background-color');
       color: theme('text-color') !important;
-      &:hover {
-        background: theme('background-color') !important;
-      }
     }
+  }
+
+  .tabs li.is-disabled {
+    opacity: unset;
   }
 
   .b-tabs:not(:last-child) {

--- a/styles/components/_search.scss
+++ b/styles/components/_search.scss
@@ -262,14 +262,13 @@
     display: flex;
     padding: 10px 0;
     justify-content: center;
+    border: none;
 
   }
 
   .tabs li.is-active a {
     font-weight: 700;
     @include ktheme() {
-      border-bottom-color: $lightpink;
-      background: theme('background-color');
       color: theme('text-color') !important;
     }
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #6344
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

before:

<img width="675" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/a8060c1d-c704-4dcb-a588-2e756efb01ef">


after:

<img width="706" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/ab42f3ee-59fd-49ad-a93e-070c56276f9d">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9d4b9b</samp>

This pull request enhances the appearance and functionality of the search feature and the tabs component in the NFT gallery. It applies better `scss` rules to `styles/components/_search.scss` and fixes some layout and color bugs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c9d4b9b</samp>

> _The search input was looking quite drab_
> _And the autocomplete menu was bad_
> _So they tweaked the layout_
> _And the style throughout_
> _And now the tabs component is rad_
