### PR TITLE
🔧 Uncaught ReferenceError: G is not defined

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -137,7 +137,7 @@ export default defineNuxtConfig({
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', ${process.env.GOOGLE_ANALYTICS_ID});
+      gtag('config', '${process.env.GOOGLE_ANALYTICS_ID}');
       `,
         type: 'text/javascript',
       },


### PR DESCRIPTION
- fix error in console `Uncaught ReferenceError: G is not defined`

<img width="729" alt="Capture d’écran 2023-07-03 à 9 20 23 AM" src="https://github.com/kodadot/nft-gallery/assets/9987732/923cb151-a66b-4620-835e-0524471ce09f">
