### PR TITLE
6390 shanghai waifu

### DIFF
--- a/components/collection/unlockable/UnlockableCollectionBanner.vue
+++ b/components/collection/unlockable/UnlockableCollectionBanner.vue
@@ -40,7 +40,7 @@ const image = computed(() => {
     case 'dot-drop':
       return 'https://replicate.delivery/pbxt/te3utBZeR4kbi0u1Xrsrz6VhZScDhElj9ZFTKQ3fRPRYHTUiA/out-0.png'
     case 'free-drop':
-      return 'https://replicate.delivery/pbxt/DqeaImcF1W3AcCeBw2EwCxpvss9CBHM2oeZKBBfHMrqSmzpEB/out-0.png'
+      return 'https://replicate.delivery/pbxt/bANqMENrH1LCDdpkhycwYj5nO03pII7TFjpEfTUbTt3uvXmIA/out-2.png'
     default:
       return 'https://replicate.delivery/pbxt/Cxfhi4qeTNvn6kcrrKlvL1YUPBKeAmbNrrf2ATtPVd6o5gDEB/out-1.png'
   }

--- a/components/collection/unlockable/const.ts
+++ b/components/collection/unlockable/const.ts
@@ -4,6 +4,6 @@ const now = new Date()
 export const countDownTime = endOfHour(now).getTime()
 
 export const slidesCountOnTimeCountdown = 10
-export const collectionId = '30'
+export const collectionId = '32'
 
 export const DISPLAY_SLIDE_IMAGE_COUNT = 4

--- a/components/collection/unlockable/utils.ts
+++ b/components/collection/unlockable/utils.ts
@@ -2,15 +2,15 @@ import { createMetadata, unSanitizeIpfsUrl } from '@kodadot1/minimark/utils'
 import { preheatFileFromIPFS } from '@/utils/ipfs'
 import { pinJson } from '@/services/nftStorage'
 
-export const UNLOCKABLE_CAMPAIGN = 'cph'
-export const UNLOCKABLE_NAME = 'Copenhagen Waifu'
+export const UNLOCKABLE_CAMPAIGN = 'sha'
+export const UNLOCKABLE_NAME = 'Shanghai Waifu'
 export const unlockableDesc = (value: number) => `
   This anime waifu is a demonstration of unlockables at [KodaDot](https://kodadot.xyz)
 
   Owner of this item has **access to $${value} voucher**, which can be claimed in **[KodaShop](https://shop.kodadot.xyz)**.
   KodaMerch is then shipped right to your door step.
 
-  It's **limited supply** and **only first 150 can claim** this voucher.
+  It's **limited supply** and **only first 100 can claim** this voucher.
 
   Enjoy and be quick 😉
 `


### PR DESCRIPTION
- :wrench: initial settings
- :art: banner

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #6390

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b591ff</samp>

Updated the unlockable campaign components to use the new Shanghai Waifu theme and collection. Changed the collectionId, image URL, and voucher supply in `components/collection/unlockable/` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b591ff</samp>

> _Oh we're the crew of the `unlockable` ship_
> _And we sail the seas of code_
> _We change the `collectionId` and the `image URL`_
> _To match the Shanghai Waifu mode_
