### PR TITLE
🔧 basicImage responsive to src props changes

### DIFF
--- a/components/shared/view/BasicImage.vue
+++ b/components/shared/view/BasicImage.vue
@@ -36,6 +36,10 @@ const props = withDefaults(
 )
 
 const imageSrc = ref(props.src)
+
+watchEffect(() => {
+  imageSrc.value = props.src
+})
 const loaded = ref(false)
 
 const onImageLoad = () => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #6399
- [ ] Requires deployment <snek/rubick/worker>

## Test
https://deploy-preview-6402--koda-canary.netlify.app/stmn/collection/u-2024?collectionId=u-2024

Hover over the identity link, images will show

#### Did your issue had any of the "$" label on it?
Yes, $

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/22791238/d27c31e2-f658-4125-9037-a7bb6c9a340a)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05f3404</samp>

Added a `watchEffect` function to `BasicImage.vue` to handle dynamic image source changes. This improves the image component's compatibility with IPFS and blockchain data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 05f3404</samp>

> _`watchEffect` listens_
> _`src` prop changes, `imageSrc` too_
> _Dynamic images, like spring_
