### PR TITLE
fix: Disabled BUY button on bsx

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
@@ -120,6 +120,8 @@ const label = computed(() =>
 const balance = computed<string>(() => {
   if (['rmrk', 'ksm', 'stmn'].includes(urlPrefix.value)) {
     return identityStore.getAuthBalance
+  } else if (urlPrefix.value === 'bsx') {
+    return identityStore.multiBalances.chains.basilisk?.ksm?.nativeBalance
   }
   return identityStore.getTokenBalanceOf(getKusamaAssetId(urlPrefix.value))
 })

--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
@@ -118,12 +118,19 @@ const label = computed(() =>
 )
 
 const balance = computed<string>(() => {
-  if (['rmrk', 'ksm', 'stmn'].includes(urlPrefix.value)) {
-    return identityStore.getAuthBalance
-  } else if (urlPrefix.value === 'bsx') {
-    return identityStore.multiBalances.chains.basilisk?.ksm?.nativeBalance
+  switch (urlPrefix.value) {
+    case 'rmrk':
+    case 'ksm':
+    case 'stmn':
+      return identityStore.getAuthBalance
+    case 'bsx':
+      return identityStore.multiBalances.chains.basilisk?.ksm?.nativeBalance
+    case 'snek':
+      return identityStore.multiBalances.chains['basilisk-testnet']?.ksm
+        ?.nativeBalance
+    default:
+      return identityStore.getTokenBalanceOf(getKusamaAssetId(urlPrefix.value))
   }
-  return identityStore.getTokenBalanceOf(getKusamaAssetId(urlPrefix.value))
 })
 const disabled = computed(() => {
   if (!(props.nftPrice && balance.value) || !connected.value) {

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -7,7 +7,7 @@
     :style="{
       '--font-size': fontSize,
       '--multiline-width': multilineWidth,
-      width: fullWidth ? '100%' : 'auto',
+      width: fullWidth ? '100%' : '',
     }"
     :position="position"
     :label="label"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context
1. style on the disabled button is wired. 
- [x] Closes #6309

2. KSM Balance does not load correctly on the bsx, so the button is always disabled.
- [x] Closes #6411

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

<img width="815" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/9b47ae85-c46e-4346-9d1b-7d5e594360f2">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ded8a70</samp>

This pull request adds support for buying NFTs with KSM on the Basilisk chain in `GalleryItemBuy.vue` and fixes a tooltip overflow issue in `NeoTooltip.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ded8a70</samp>

> _`urlPrefix` checks_
> _Basilisk and Kusama_
> _Autumn NFTs_
