### PR TITLE
fix: Clicking on Activity while searching different collections shows…

### DIFF
--- a/components/explore/tab/TabOnCollection.vue
+++ b/components/explore/tab/TabOnCollection.vue
@@ -14,6 +14,10 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const toItem = `/${route.params.prefix}/collection/${route.params.id}`
-const toActivity = `/${route.params.prefix}/collection/${route.params.id}/activity`
+const toItem = computed(
+  () => `/${route.params.prefix}/collection/${route.params.id}`
+)
+const toActivity = computed(
+  () => `/${route.params.prefix}/collection/${route.params.id}/activity`
+)
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6424
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4405c5c</samp>

Refactored `TabOnCollection.vue` to use composition API and computed properties for better reactivity and navigation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4405c5c</samp>

> _`toItem`, `toActivity`_
> _now computed properties_
> _react to route changes_
