### PR TITLE
fix: Statemine properties not showing

### DIFF
--- a/composables/useNft.ts
+++ b/composables/useNft.ts
@@ -52,7 +52,7 @@ async function getProcessMetadata(nft: NFTWithMetadata) {
   const getAttributes = () => {
     const hasMetadataAttributes =
       metadata.attributes && metadata.attributes.length > 0
-    const attr = nft?.meta?.attributes || []
+    const attr = nft?.attributes || nft?.meta?.attributes || []
     const hasEmptyNftAttributes = attr.length === 0
 
     return hasMetadataAttributes && hasEmptyNftAttributes

--- a/composables/useNft.ts
+++ b/composables/useNft.ts
@@ -2,7 +2,7 @@ import type { NFT, NFTMetadata } from '@/components/rmrk/service/scheme'
 import { sanitizeIpfsUrl } from '@/utils/ipfs'
 import { processSingleMetadata } from '@/utils/cachingStrategy'
 import { getMimeType } from '@/utils/gallery/media'
-
+import unionBy from 'lodash/unionBy'
 export type NftResources = {
   id: string
   src?: string
@@ -52,7 +52,10 @@ async function getProcessMetadata(nft: NFTWithMetadata) {
   const getAttributes = () => {
     const hasMetadataAttributes =
       metadata.attributes && metadata.attributes.length > 0
-    const attr = nft?.attributes || nft?.meta?.attributes || []
+    const attr = unionBy(
+      nft?.attributes?.concat(...(nft?.meta?.attributes || [])),
+      (item) => item.trait_type || item.key
+    )
     const hasEmptyNftAttributes = attr.length === 0
 
     return hasMetadataAttributes && hasEmptyNftAttributes

--- a/libs/static/src/indexers.ts
+++ b/libs/static/src/indexers.ts
@@ -11,7 +11,7 @@ export const INDEXERS: Config<SquidEndpoint> = {
   movr: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
   ksm: 'https://squid.subsquid.io/marck/v/v2/graphql',
   snek: 'https://squid.subsquid.io/snekk/v/004/graphql',
-  stmn: 'https://squid.subsquid.io/stick/v/v3/graphql',
+  stmn: 'https://squid.subsquid.io/stick/v/v4/graphql',
   dot: 'https://squid.subsquid.io/rubick/graphql', // TODO: change to dot indexer when available
   stt: 'https://squid.subsquid.io/speck/v/v1/graphql',
 }

--- a/queries/subsquid/stmn/nftById.graphql
+++ b/queries/subsquid/stmn/nftById.graphql
@@ -10,6 +10,10 @@ query nftById($id: String!) {
       id
       name
     }
+    attributes {
+      key: trait
+      value
+    }
     events {
       interaction
       timestamp

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -48,7 +48,7 @@ export const URLS = {
     click: 'https://squid.subsquid.io/click/v/002/graphql',
     antick: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',
     marck: 'https://squid.subsquid.io/marck/graphql',
-    stick: 'https://squid.subsquid.io/stick/v/v3/graphql',
+    stick: 'https://squid.subsquid.io/stick/v/v4/graphql',
     speck: 'https://squid.subsquid.io/speck/v/v1/graphql',
     replicate: 'https://replicate.kodadot.workers.dev/',
     search: 'https://polysearch.w.kodadot.xyz',


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6426
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI


`/stmn/gallery/3-1` 

<img width="446" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/9b73996d-5c47-4550-adf7-4286d54d1f0d">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57c6b3b</samp>

This pull request fixes a bug in displaying NFT attributes and updates the stick indexer URL to use the latest version. It modifies `useNft.ts`, `indexers.ts`, `nftById.graphql`, and `constants.ts` to handle the new NFT attributes format.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 57c6b3b</samp>

> _`stick indexer` v4_
> _fixes NFT attributes_
> _fall is for bug squash_
