### PR TITLE
fix: Teleport bridge is showing incorrect balances

### DIFF
--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -136,11 +136,12 @@ const allowedTransitiosn = {
   [Chain.STATEMINE]: [Chain.KUSAMA],
 }
 const chainBalances = {
-  [Chain.KUSAMA]: () => identityStore.multiBalances.chains.kusama?.ksm?.balance,
+  [Chain.KUSAMA]: () =>
+    identityStore.multiBalances.chains.kusama?.ksm?.nativeBalance,
   [Chain.BASILISK]: () =>
-    identityStore.multiBalances.chains.basilisk?.ksm?.balance,
+    identityStore.multiBalances.chains.basilisk?.ksm?.nativeBalance,
   [Chain.STATEMINE]: () =>
-    identityStore.multiBalances.chains.statemine?.ksm?.balance,
+    identityStore.multiBalances.chains.statemine?.ksm?.nativeBalance,
 }
 
 const isDisabled = (chain: Chain) => {
@@ -187,7 +188,8 @@ const myKsmBalance = computed(() => {
     throw new Error(`Unsupported chain: ${fromChain.value}`)
   }
   const balance = Number(getBalance()) || 0
-  return balance * Math.pow(10, ksmTokenDecimals.value)
+
+  return balance
 })
 
 const explorerUrl = computed(() => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6433
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 
`/rmrk/teleport`

<img width="773" alt="CleanShot 2023-07-20 at 10 02 13@2x" src="https://github.com/kodadot/nft-gallery/assets/44554284/b1e7f4ce-4305-4fe9-b264-cbad8c936914">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 219f99a</samp>

Improved KSM balance display in `Teleport.vue` component. Used `nativeBalance` for cross-chain compatibility and simplified `balance` calculation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 219f99a</samp>

> _To show KSM balance with ease_
> _We updated `chainBalances` keys_
> _We used `nativeBalance`_
> _And simplified `balance`_
> _To make it consistent across chains, please_
