### PR TITLE
Nuxt-propert-decorator/more-pages

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,18 +3,10 @@
 </template>
 
 <script lang="ts">
-import { Component, mixins } from 'nuxt-property-decorator'
-import PrefixMixin from '@/utils/mixins/prefixMixin'
-
-@Component({
+export default {
   name: 'HomePage',
   components: {
     LandingPage: () => import('@/components/landing/LandingPage.vue'),
   },
-})
-export default class HomePage extends mixins(PrefixMixin) {
-  layout() {
-    return 'full-width-layout'
-  }
 }
 </script>

--- a/pages/snek/assets.vue
+++ b/pages/snek/assets.vue
@@ -3,12 +3,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator'
-
-@Component({
+export default {
+  name: 'AssetPage',
   components: {
     AssetList: () => import('@/components/bsx/Asset/AssetList.vue'),
   },
-})
-export default class AssetPage extends Vue {}
+}
 </script>

--- a/pages/snek/claim.vue
+++ b/pages/snek/claim.vue
@@ -3,10 +3,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator'
 import ClaimForm from '@/components/poap/claim/ClaimForm.vue'
 
-@Component({
+export default {
+  name: 'ClaimPage',
   components: {
     ClaimForm,
   },
@@ -27,6 +27,5 @@ import ClaimForm from '@/components/poap/claim/ClaimForm.vue'
       meta: [...this.$seoMeta(metaData)],
     }
   },
-})
-export default class SimpleMintPage extends Vue {}
+}
 </script>

--- a/pages/snek/incomingOffers.vue
+++ b/pages/snek/incomingOffers.vue
@@ -3,12 +3,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator'
-
-@Component({
+export default {
+  name: 'IncomingOffersPage',
   components: {
     MyOffer: () => import('@/components/bsx/Offer/MyOffer.vue'),
   },
-})
-export default class IncomingOffersPage extends Vue {}
+}
 </script>

--- a/pages/snek/offers.vue
+++ b/pages/snek/offers.vue
@@ -3,13 +3,11 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator'
-
-@Component({
+export default {
+  name: 'OffersPage',
   components: {
     MasterOfferTable: () =>
       import('@/components/bsx/Offer/MasterOfferTable.vue'),
   },
-})
-export default class Offers extends Vue {}
+}
 </script>

--- a/pages/snek/stats.vue
+++ b/pages/snek/stats.vue
@@ -3,12 +3,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator'
-
-@Component({
+export default {
+  name: 'OfferStatsPage',
   components: {
     OfferStats: () => import('@/components/bsx/Offer/OfferStats.vue'),
   },
-})
-export default class OfferStatsPage extends Vue {}
+}
 </script>

--- a/pages/stmn/waifu.vue
+++ b/pages/stmn/waifu.vue
@@ -3,10 +3,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator'
 import GenerativeMint from '@/components/bsx/Create/GenerativeMint.vue'
 
-@Component({
+export default {
+  name: 'GenerativeMintPage',
   components: {
     GenerativeMint,
   },
@@ -27,6 +27,5 @@ import GenerativeMint from '@/components/bsx/Create/GenerativeMint.vue'
       meta: [...this.$seoMeta(metaData)],
     }
   },
-})
-export default class SimpleMintPage extends Vue {}
+}
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Related with #4750

## Pages in this PR
1. home page 
2. snek/assets
3. snek/claim
4. snek/incomingOffers
5. snek/offers
6. snek/stats
7. stmn/waifu


## desired outcome
no change in look and/or behavior


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)
## Screenshot 📸


- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e768e96</samp>

This pull request streamlines the user interface and code structure of the snek NFT minting and trading features. It moves the claim, generative mint, asset, offer, and stats pages to the home page and simplifies the component syntax. It also renames some components and files to avoid confusion.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e768e96</samp>

> _We've moved the pages to the index, me hearties_
> _We've simplified the syntax of the `Component`_
> _We've streamlined the snek NFT experience_
> _So heave away and pull the code with confidence_
