### PR TITLE
fix: Add blog to footer

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -227,6 +227,11 @@ const menuKodadot: Menu[] = [
     url: 'https://github.com/kodadot/kodadot-presskit/tree/main/v3',
     external: true,
   },
+  {
+    name: $i18n.t('blog'),
+    url: '/blog',
+    external: false,
+  },
 ]
 
 const socials = [

--- a/locales/en.json
+++ b/locales/en.json
@@ -38,6 +38,7 @@
   "creative": "Creative",
   "multipleNFTS": "Multiple NFT's",
   "about": "About",
+  "blog": "Blog",
   "ambassador program": "Ambassador Program",
   "artist ambassador": "Artist Ambassador",
   "merchshop": "MerchShop",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] Closes #6506

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f74143</samp>

This pull request adds a blog link to the footer navigation menu. It also provides the English translation for the link name and sets up the localization structure for other languages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f74143</samp>

> _`$i18n.t` adds_
> _a new link to the footer_
> _blog for all seasons_
