### PR TITLE
Sitemap should include blog posts

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -339,6 +339,13 @@ export default defineNuxtConfig({
 
   sitemap: {
     hostname: process.env.BASE_URL || 'http://localhost:9090',
+    routes() {
+      const posts = fs.readdirSync('content/blog')
+
+      return posts
+        .map((post) => post.split('.')[0])
+        .map((post) => `/blog/${post}`)
+    },
   },
 
   hooks: {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

Check `/sitemap.xml`

- [x] Closes #6513 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

<img width="1128" alt="CleanShot 2023-08-02 at 17 32 15@2x" src="https://github.com/kodadot/nft-gallery/assets/44554284/5a8920d0-7c64-469e-90a7-a8eed68f887f">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91ba2a6</samp>

Added code to `nuxt.config.js` to generate static routes for blog posts. This improves the site's performance and SEO.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 91ba2a6</samp>

> _`generate` routes_
> _for blog posts from Markdown_
> _autumn leaves falling_


