### PR TITLE
build: temporary disable source-map

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -402,7 +402,8 @@ export default defineNuxtConfig({
         process.env.NODE_ENV !== 'development' &&
         process.env.SENTRY_AUTH_TOKEN
       ) {
-        config.devtool = 'source-map'
+        // https://community.cloudflare.com/t/recurring-deployment-issue-on-pages-which-works-on-preview-branch-but-doesnt-on-production-branch/540278/10
+        // config.devtool = 'source-map'
 
         config.plugins.push(
           new SentryWebpackPlugin({


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #6518. at least we can put `SENTRY_AUTH_TOKEN` back in the env. ongoing investigation here https://community.cloudflare.com/t/recurring-deployment-issue-on-pages-which-works-on-preview-branch-but-doesnt-on-production-branch/540278/10

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Screenshot 📸

<details><summary>screenshot</summary>
<p>

![Screenshot 2023-08-03 140759](https://github.com/kodadot/nft-gallery/assets/734428/f8629482-6701-4b05-97fe-3ebb1b2c458c)

</p>
</details> 
