### PR TITLE
File import not working in massmint

### DIFF
--- a/composables/massmint/useZipValidator.ts
+++ b/composables/massmint/useZipValidator.ts
@@ -87,7 +87,7 @@ async function checkZipFileValidity(entries: {
       isEntryValid = false
     }
 
-    if (isEntryValid && (entry.isDirectory || name.includes('/'))) {
+    if (isEntryValid && entry.isDirectory) {
       warnings.push({
         name,
         reason: 'is a directory',


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

Images nested inside a folder are ignored this pr fixes that 

This first zip has the images nested inside a folder 
[nested images.zip](https://github.com/kodadot/nft-gallery/files/12259691/export.quire.zip)

this one they are not 
[just images.zip](https://github.com/kodadot/nft-gallery/files/12259711/Archive.zip)


- [x] Closes #6532
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

zip with nested folder
![CleanShot 2023-08-06 at 07 40 35](https://github.com/kodadot/nft-gallery/assets/44554284/cddd3bcb-7f50-42b6-b2eb-5e81c90b4eef)

zip with just images
![CleanShot 2023-08-06 at 07 42 30](https://github.com/kodadot/nft-gallery/assets/44554284/32099cf9-28de-45b9-baa7-46a53a2ec2f0)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1281dab</samp>

Simplified the warning condition for zip file entries in `useZipValidator.ts` to improve readability and avoid false positives.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1281dab</samp>

> _`isDirectory` /_
> _No need for slash check now /_
> _Code is simpler - spring_


