### PR TITLE
fix: You can change the network field to any string you want

### DIFF
--- a/composables/usePrefix.ts
+++ b/composables/usePrefix.ts
@@ -1,21 +1,15 @@
 import { DEFAULT_PREFIX } from '@kodadot1/static'
 import { getKusamaAssetId } from '@/utils/api/bsx/query'
 import { useAssetsStore } from '@/stores/assets'
-import { availablePrefixes } from '@/utils/chain'
+import { getAvailablePrefix } from '@/utils/chain'
 
 import type { Prefix } from '@kodadot1/static'
 
 export default function () {
   const route = useRoute()
   const storage = useLocalStorage('urlPrefix', { selected: DEFAULT_PREFIX })
-  const availablePrefixesList = availablePrefixes()
-  const initialPrefixFromPath = availablePrefixesList.find(
-    (prefixValue) => prefixValue.value === route.path.split('/')[1]
-  )?.value
-
-  const validPrefixFromRoute = availablePrefixesList.find(
-    (prefixValue) => prefixValue.value === route.params.prefix
-  )?.value
+  const initialPrefixFromPath = getAvailablePrefix(route.path.split('/')[1])
+  const validPrefixFromRoute = getAvailablePrefix(route.params.prefix)
 
   const prefix = computed<Prefix>(
     () =>

--- a/composables/usePrefix.ts
+++ b/composables/usePrefix.ts
@@ -12,9 +12,14 @@ export default function () {
   const initialPrefixFromPath = availablePrefixesList.find(
     (prefixValue) => prefixValue.value === route.path.split('/')[1]
   )?.value
+
+  const validPrefixFromRoute = availablePrefixesList.find(
+    (prefixValue) => prefixValue.value === route.params.prefix
+  )?.value
+
   const prefix = computed<Prefix>(
     () =>
-      (route.params.prefix ||
+      (validPrefixFromRoute ||
         storage.value.selected ||
         initialPrefixFromPath) as Prefix
   )

--- a/utils/chain.ts
+++ b/utils/chain.ts
@@ -106,3 +106,9 @@ export const availablePrefixes = (): Option[] => {
 
   return chains
 }
+
+export const getAvailablePrefix = (prefix: string): string => {
+  return availablePrefixes().some((chain) => chain.value === prefix)
+    ? prefix
+    : ''
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6563
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cbd5ffb</samp>

Improved prefix selection logic in `usePrefix.ts` by validating the route parameter and using it as the first option.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cbd5ffb</samp>

> _`validPrefixFromRoute`_
> _checks the list, avoids errors_
> _autumn of bugs ends_
