### PR TITLE
After minting, user does not get redirect to NFT and Error when trying to massmint on RMRK2

### DIFF
--- a/composables/transaction/mintToken/transactionMintRmrk.ts
+++ b/composables/transaction/mintToken/transactionMintRmrk.ts
@@ -160,11 +160,7 @@ export async function execMintRmrk({
 
   const arg = isSingle
     ? args
-    : [
-        args
-          .filter((arg) => arg)
-          .map((arg) => asSystemRemark(api, arg as string)),
-      ]
+    : [args.filter(Boolean).map((arg) => asSystemRemark(api, arg as string))]
 
   executeTransaction({
     cb,

--- a/composables/transaction/mintToken/transactionMintRmrk.ts
+++ b/composables/transaction/mintToken/transactionMintRmrk.ts
@@ -157,7 +157,14 @@ export async function execMintRmrk({
 
   const isSingle = args.length === 1
   const cb = isSingle ? api.tx.system.remark : api.tx.utility.batchAll
-  const arg = isSingle ? args : [args]
+
+  const arg = isSingle
+    ? args
+    : [
+        args
+          .filter((arg) => arg)
+          .map((arg) => asSystemRemark(api, arg as string)),
+      ]
 
   executeTransaction({
     cb,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6526 
  - Now it redirects when creating a NFT using the classic UI
  - Redirect inside massmint worked for me 
- [x] Closes #6508
  - I also fixed this , since I couldn't mint tokens via massmint



#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0045a1</samp>

This pull request enables minting NFTs without listing them for sale, and improves the compatibility and validity of the arguments for the batched minting transactions. It refactors the `CreateToken` component and the `transactionMintRmrk` composable.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d0045a1</samp>

> _Sing, O Muse, of the crafty code that the heroes wrought_
> _To mint new tokens of their art, with skill and cunning fraught_
> _They filtered out the false and wrapped the args in `system.remark`_
> _To execute a batch of transactions, swift and smooth as a shark_


