### PR TITLE
🔧 migrate oruga package to lib/ui

### DIFF
--- a/components/common/ConnectWallet/WalletAssetPortfolio.vue
+++ b/components/common/ConnectWallet/WalletAssetPortfolio.vue
@@ -6,7 +6,6 @@
         no-shadow
         rounded
         tag="a"
-        size="small"
         :href="`/${urlPrefix}/assets`"
         icon="arrow-right-long">
         Portfolio View

--- a/components/common/NotificationBox/NotificationBoxModal.vue
+++ b/components/common/NotificationBox/NotificationBoxModal.vue
@@ -22,7 +22,7 @@
             class="rounded"
             @click.native="showFilter = !showFilter">
             {{ $t('notification.add') }}
-            <NeoIcon icon="plus" size="small" />
+            <NeoIcon icon="plus" />
           </NeoButton>
           <NeoButton
             v-else
@@ -30,7 +30,7 @@
             class="rounded"
             @click.native="showFilter = !showFilter">
             {{ $t('notification.done') }}
-            <NeoIcon icon="check" size="small" />
+            <NeoIcon icon="check" />
           </NeoButton>
         </div>
         <div v-if="showFilter" class="filter-option">

--- a/components/massmint/ChooseCollectionDropdown.vue
+++ b/components/massmint/ChooseCollectionDropdown.vue
@@ -14,7 +14,6 @@
         <NeoIcon
           v-if="selectedCollection"
           icon="circle-check"
-          size="small"
           variant="success"
           class="ml-3" />
       </NeoButton>
@@ -31,7 +30,7 @@
       <NeoDropdownItem class="dropdown-width">
         <nuxt-link :to="`/${urlPrefix}/create`" class="w-full">
           <div class="w-full">
-            <NeoIcon icon="plus" size="small" class="mr-1" />
+            <NeoIcon icon="plus" class="mr-1" />
             {{ $t('massmint.createNewCollection') }}
           </div>
         </nuxt-link>
@@ -44,7 +43,7 @@
       <NeoDropdownItem class="dropdown-width">
         <nuxt-link :to="`/${urlPrefix}/create`" class="w-full">
           <div class="w-full">
-            <NeoIcon icon="plus" size="small" class="mr-1" />
+            <NeoIcon icon="plus" class="mr-1" />
             {{ $t('massmint.createNewCollection') }}
           </div>
         </nuxt-link>

--- a/components/massmint/Massmint.vue
+++ b/components/massmint/Massmint.vue
@@ -4,7 +4,7 @@
     <div>
       <section class="is-flex controls">
         <NeoButton class="left" @click.native="toOnborading">
-          <NeoIcon icon="arrow-left" size="small" class="mr-1" />
+          <NeoIcon icon="arrow-left" class="mr-1" />
           {{ $t('massmint.backToOnbaording') }}
         </NeoButton>
         <div class="dropdown-container">

--- a/components/massmint/uploadCompressedMedia/UploadCompressedMedia.vue
+++ b/components/massmint/uploadCompressedMedia/UploadCompressedMedia.vue
@@ -6,7 +6,6 @@
         <NeoIcon
           v-if="showCheckmark"
           icon="circle-check"
-          size="small"
           variant="success"
           class="ml-3" />
         <div v-else class="icon-placeholder ml-3" />

--- a/components/massmint/uploadDescription/UploadDescription.vue
+++ b/components/massmint/uploadDescription/UploadDescription.vue
@@ -6,7 +6,6 @@
         <NeoIcon
           v-if="showCheckmark"
           icon="circle-check"
-          size="small"
           variant="success"
           class="ml-3" />
         <div v-else class="icon-placeholder ml-3" />

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@histoire/plugin-vue2": "^0.16.1",
     "@vitejs/plugin-vue2": "^2.2.0",
+    "@oruga-ui/oruga": "^0.6.0",
     "eslint": "^8.45.0",
     "eslint-plugin-vue": "^8.7.1",
     "histoire": "^0.16.2",

--- a/libs/ui/src/components/NeoIcon/NeoIcon.scss
+++ b/libs/ui/src/components/NeoIcon/NeoIcon.scss
@@ -1,5 +1,11 @@
 @import '../../scss/theme';
 
+@import '@oruga-ui/oruga/src/scss/utilities/_expressions.scss';
+@import '@oruga-ui/oruga/src/scss/utilities/_variables.scss';
+@import '@oruga-ui/oruga/src/scss/utilities/_animations.scss';
+@import '@oruga-ui/oruga/src/scss/utilities/_helpers.scss';
+@import '@oruga-ui/oruga/src/scss/components/_icon.scss';
+
 .o-icon--success {
   @include ktheme() {
     color: theme('k-green');

--- a/libs/ui/src/components/NeoIcon/NeoIcon.vue
+++ b/libs/ui/src/components/NeoIcon/NeoIcon.vue
@@ -2,7 +2,7 @@
   <o-icon
     :pack="pack || 'fas'"
     :icon="icon"
-    :size="size || 'small'"
+    :size="size || ''"
     :custom-size="customSize"
     :variant="variant" />
 </template>
@@ -19,6 +19,6 @@ defineProps<{
 }>()
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import './NeoIcon.scss';
 </style>

--- a/libs/ui/src/components/NeoIcon/NeoIcon.vue
+++ b/libs/ui/src/components/NeoIcon/NeoIcon.vue
@@ -2,7 +2,7 @@
   <o-icon
     :pack="pack || 'fas'"
     :icon="icon"
-    :size="size || ''"
+    :size="size || 'default'"
     :custom-size="customSize"
     :variant="variant" />
 </template>

--- a/libs/ui/src/histoire.scss
+++ b/libs/ui/src/histoire.scss
@@ -1,8 +1,6 @@
 /* // @import '@/styles/index.scss'; TODO: how to import this file? */
 @import 'bulma/bulma.sass';
-// @import '@oruga-ui/oruga/dist/oruga.min.css';
-// @import '@oruga-ui/oruga/dist/oruga-full-vars.min.css';
-@import "~@oruga-ui/oruga/src/scss/oruga";
+@import "@oruga-ui/oruga/src/scss/oruga";
 
 @import url('https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 

--- a/libs/ui/src/histoire.scss
+++ b/libs/ui/src/histoire.scss
@@ -1,6 +1,6 @@
 /* // @import '@/styles/index.scss'; TODO: how to import this file? */
 @import 'bulma/bulma.sass';
-@import "@oruga-ui/oruga/src/scss/oruga";
+@import '@oruga-ui/oruga/src/scss/oruga';
 
 @import url('https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 

--- a/libs/ui/src/histoire.scss
+++ b/libs/ui/src/histoire.scss
@@ -1,7 +1,9 @@
 /* // @import '@/styles/index.scss'; TODO: how to import this file? */
 @import 'bulma/bulma.sass';
-@import '@oruga-ui/oruga/dist/oruga.min.css';
-@import '@oruga-ui/oruga/dist/oruga-full-vars.min.css';
+// @import '@oruga-ui/oruga/dist/oruga.min.css';
+// @import '@oruga-ui/oruga/dist/oruga-full-vars.min.css';
+@import "~@oruga-ui/oruga/src/scss/oruga";
+
 @import url('https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@nuxtjs/i18n": "^7.3.1",
     "@nuxtjs/sentry": "^7.3.1",
     "@nuxtjs/sitemap": "thisismydesign/sitemap-module#cd4dc22293b9b67e8ebb5b3c49840e67c108e312",
-    "@oruga-ui/oruga": "^0.6.0",
     "@paraspell/sdk": "^1.1.15",
     "@pinia/nuxt": "^0.4.11",
     "@polkadot/api": "^10.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,6 @@ importers:
       '@nuxtjs/sitemap':
         specifier: thisismydesign/sitemap-module#cd4dc22293b9b67e8ebb5b3c49840e67c108e312
         version: github.com/thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312
-      '@oruga-ui/oruga':
-        specifier: ^0.6.0
-        version: 0.6.0(vue@2.7.14)
       '@paraspell/sdk':
         specifier: ^1.1.15
         version: 1.1.15(@polkadot/api-base@10.6.1)(@polkadot/api@10.6.1)(@polkadot/apps-config@0.130.1)(@polkadot/types@10.6.1)
@@ -408,6 +405,9 @@ importers:
       '@histoire/plugin-vue2':
         specifier: ^0.16.1
         version: 0.16.1(histoire@0.16.2)(vite@3.2.7)(vue@2.7.14)
+      '@oruga-ui/oruga':
+        specifier: ^0.6.0
+        version: 0.6.0(vue@2.7.14)
       '@vitejs/plugin-vue2':
         specifier: ^2.2.0
         version: 2.2.0(vite@3.2.7)(vue@2.7.14)
@@ -5077,7 +5077,7 @@ packages:
       vue: ^2.6.11
     dependencies:
       vue: 2.7.14
-    dev: false
+    dev: true
 
   /@parallel-finance/type-definitions@1.7.17:
     resolution: {integrity: sha512-OFz9sXwlp90xDdKK1gUvpdUsnlUPhhRhzvC0SqOnnT1SCpJgPv4RD5DGBN6wSHuRwNsYnCWH+8RkK7jWVgUvrQ==}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -8,7 +8,6 @@
 // FRAMEWORK (note: don't move this on top)
 @import "~bulma";
 @import "~buefy/src/scss/buefy";
-@import "~@oruga-ui/oruga/src/scss/oruga";
 
 // GLOBAL
 @import "./global.scss";


### PR DESCRIPTION
- In preparation of #5611 
- `@oruga/oruga-ui` is now under `libs/ui` workspace
- fix `NeoIcon` size prop/class

