### PR TITLE
asset hubs rpcs

### DIFF
--- a/libs/static/src/endpoints.ts
+++ b/libs/static/src/endpoints.ts
@@ -41,7 +41,7 @@ export const ALTERNATIVE_ENDPOINT_MAP: Config<WS_URL[]> = {
   ],
   dot: POLKADOT_ENDPOINTS,
   stt: [
-    'wss://statemint-rpc.polkadot.io',
+    'wss://polkadot-asset-hub-rpc.polkadot.io',
     'wss://statemint-rpc.dwellir.com',
     'wss://statemint-rpc-tn.dwellir.com',
     'wss://sys.ibp.network/statemint',
@@ -59,5 +59,5 @@ export const ENDPOINT_MAP: Config<WS_URL> = {
   snek: 'wss://basilisk-rococo-rpc.play.hydration.cloud',
   stmn: 'wss://kusama-asset-hub-rpc.polkadot.io',
   dot: POLKADOT_ENDPOINTS[0],
-  stt: 'wss://statemint-rpc.polkadot.io',
+  stt: 'wss://polkadot-asset-hub-rpc.polkadot.io',
 }

--- a/libs/static/src/endpoints.ts
+++ b/libs/static/src/endpoints.ts
@@ -4,7 +4,7 @@ type WS_URL = `wss://${string}` | `ws://${string}`
 
 const KUSAMA_ENDPOINTS: WS_URL[] = [
   'wss://kusama-rpc.polkadot.io',
-  'wss://kusama.public.curie.radiumblock.co/ws',
+  // 'wss://kusama.public.curie.radiumblock.co/ws', // https://github.com/polkadot-js/apps/issues/9763
   'wss://rpc.ibp.network/kusama',
   'wss://rpc.dotters.network/kusama',
   'wss://1rpc.io/ksm',
@@ -31,11 +31,11 @@ export const ALTERNATIVE_ENDPOINT_MAP: Config<WS_URL[]> = {
   ksm: KUSAMA_ENDPOINTS,
   snek: ['wss://basilisk-rococo-rpc.play.hydration.cloud'],
   stmn: [
-    'wss://statemine-rpc.polkadot.io',
+    'wss://kusama-asset-hub-rpc.polkadot.io',
     'wss://statemine-rpc.dwellir.com',
     'wss://sys.ibp.network/statemine',
     'wss://sys.dotters.network/statemine',
-    'wss://rpc-statemine.luckyfriday.io',
+    'wss://rpc-asset-hub-kusama.luckyfriday.io',
     'wss://statemine.api.onfinality.io/public-ws',
     'wss://statemine.public.curie.radiumblock.co/ws',
   ],
@@ -57,7 +57,7 @@ export const ENDPOINT_MAP: Config<WS_URL> = {
   movr: 'wss://wss.api.moonriver.moonbeam.network',
   ksm: KUSAMA_ENDPOINTS[0],
   snek: 'wss://basilisk-rococo-rpc.play.hydration.cloud',
-  stmn: 'wss://statemine-rpc.polkadot.io',
+  stmn: 'wss://kusama-asset-hub-rpc.polkadot.io',
   dot: POLKADOT_ENDPOINTS[0],
   stt: 'wss://statemint-rpc.polkadot.io',
 }

--- a/libs/static/src/services.ts
+++ b/libs/static/src/services.ts
@@ -16,9 +16,9 @@ export const EXPLORERS: Record<Prefix, string> = {
   snek: 'https://calamar.play.hydration.cloud/rococo%20basilisk/search?query=',
   movr: 'https://moonriver.subscan.io/account/',
   glmr: 'https://moonbeam.subscan.io/account/',
-  stmn: 'https://statemine.subscan.io/account/',
+  stmn: 'https://assethub-kusama.subscan.io/account/',
   dot: 'https://polkadot.subscan.io/account/',
-  stt: 'https://statemint.subscan.io/account/',
+  stt: 'https://assethub-polkadot.subscan.io/account/',
 }
 
 export const hasExplorer = (prefix: Prefix): boolean => {


### PR DESCRIPTION
- :wrench: rename statemine to KSM AssetHub
- :wrench: rename statemint to DOT AssetHub

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Chore

## Context

Statemin(e/t) were renamed https://github.com/polkadot-js/apps/blob/master/packages/apps-config/src/endpoints/productionRelayPolkadot.ts

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f204bc2</samp>

Updated and fixed `ENDPOINT_MAP` function in `endpoints.ts` to use new Asset Hub RPCs for Statemine and Statemint.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f204bc2</samp>

> _We're breaking the chains of the old RPCs_
> _We're blazing a trail with the Asset Hub keys_
> _We're leaving behind the Kusama endpoint_
> _We're riding the wave of the Statemine mint_
