### PR TITLE
docs: specified correct node version to avoid --openssl-legacy-provider error

### DIFF
--- a/content/blog/first-time.md
+++ b/content/blog/first-time.md
@@ -15,7 +15,7 @@ We are using a `pnpm` workspace, as installing things via npm **will result in b
 ## Prerequisites 🎒
 
 ```MD
-node >=18
+node >=18.17
 pnpm
 ```
 

--- a/content/blog/first-time.md
+++ b/content/blog/first-time.md
@@ -15,7 +15,7 @@ We are using a `pnpm` workspace, as installing things via npm **will result in b
 ## Prerequisites 🎒
 
 ```MD
-node >=18.17
+node >= 18.16
 pnpm
 ```
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "engines": {
     "npm": "please-use-pnpm",
     "pnpm": "8",
-    "node": "^18"
+    "node": "^18.16"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
With node version 18.13, I am getting this error node: --openssl-legacy-provider is not allowed in NODE_OPTIONS
 ELIFECYCLE  Command failed with exit code 9.
 
 
<img width="722" alt="Pasted Graphic" src="https://github.com/kodadot/nft-gallery/assets/3810177/7ee8ba56-7e8f-4b7f-87ed-830a2c8026fb">


Upgrading to 18.17 fixes the problem for me
<img width="397" alt="Pasted Graphic 1" src="https://github.com/kodadot/nft-gallery/assets/3810177/320eae7e-6e9a-4608-bf64-193b4d77bae2">

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)