### PR TITLE
docs: specified correct node version to avoid --openssl-legacy-provid…

### DIFF
--- a/content/blog/first-time.md
+++ b/content/blog/first-time.md
@@ -15,7 +15,7 @@ We are using a `pnpm` workspace, as installing things via npm **will result in b
 ## Prerequisites 🎒
 
 ```MD
-node >=18
+node >= 18.17
 pnpm
 ```
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Documentation
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6646
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2873a2</samp>

Updated the node version to 18.17 in the blog post `content/blog/first-time.md` and the `package.json` file. This change follows the latest node LTS release and improves the project's compatibility and security.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b2873a2</samp>

> _Blog post and code_
> _`node` version harmonized_
> _Fall of LTS_
