### PR TITLE
fix: menu buttons resseting scroll position on mobile

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -255,7 +255,11 @@ const openWalletConnectModal = (): void => {
 }
 
 const showMobileNavbar = () => {
+  document.body.classList.toggle('is-clipped')
   isMobileNavbarOpen.value = !isMobileNavbarOpen.value
+  if (!isMobileNavbarOpen.value) {
+    document.documentElement.scrollTop = lastScrollPosition.value
+  }
 }
 
 const closeBurgerMenu = () => {

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -140,6 +140,7 @@
             data-cy="chain-select" />
 
           <NotificationBoxButton
+            v-if="account"
             :show-label="isMobile"
             @closeBurgerMenu="showMobileNavbar" />
 

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -140,7 +140,6 @@
             data-cy="chain-select" />
 
           <NotificationBoxButton
-            v-if="account"
             :show-label="isMobile"
             @closeBurgerMenu="showMobileNavbar" />
 
@@ -255,7 +254,6 @@ const openWalletConnectModal = (): void => {
 }
 
 const showMobileNavbar = () => {
-  document.body.classList.toggle('is-clipped')
   isMobileNavbarOpen.value = !isMobileNavbarOpen.value
 }
 


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6667 #6669 #6668 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

Refactored the code for opening the shopping cart modal from the navbar. Moved the logic and configuration from `ShoppingCartModalConfig.ts` and `ShoppingCartButton.vue` to `Navbar.vue` to improve code organization and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

> _`ShoppingCartButton`_
> _Simpler, no more `emit` -_
> _Autumn leaves falling_
