### PR TITLE
fix(cart): text incorrectly truncating at the wrong width

### DIFF
--- a/components/common/shoppingCart/ShoppingCartItemRow.vue
+++ b/components/common/shoppingCart/ShoppingCartItemRow.vue
@@ -11,7 +11,7 @@
       </nuxt-link>
 
       <div
-        class="is-flex is-flex-direction-column is-justify-content-space-between ml-4 limit-width">
+        class="is-flex is-flex-direction-column is-justify-content-space-between ml-4 width-100">
         <nuxt-link
           :to="`/${urlPrefix}/gallery/${nft.id}`"
           class="has-text-weight-bold has-text-color line-height-1 no-wrap is-clipped ellipsis"
@@ -83,8 +83,8 @@ onMounted(() => {
   }
 }
 
-.limit-width {
-  width: 230px;
+.width-100 {
+  width: 100%;
 }
 
 .ellipsis {

--- a/components/common/shoppingCart/ShoppingCartItemRow.vue
+++ b/components/common/shoppingCart/ShoppingCartItemRow.vue
@@ -19,7 +19,11 @@
           {{ nft.name }}
         </nuxt-link>
         <div class="is-flex is-justify-content-space-between">
-          <div class="line-height-1 no-wrap is-clipped ellipsis">
+          <div
+            class="line-height-1 no-wrap is-clipped ellipsis"
+            :style="{
+              'max-width': isHovered ? '190px' : '130px',
+            }">
             {{ nft.collection?.name || nft.collection.id }}
           </div>
           <div

--- a/components/common/shoppingCart/ShoppingCartItemRow.vue
+++ b/components/common/shoppingCart/ShoppingCartItemRow.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    ref="hoverRef"
-    class="is-flex is-justify-content-space-between background-hover">
+  <div ref="hoverRef" style="position: relative" class="background-hover">
     <div class="is-flex pr-2">
       <nuxt-link
         :to="`/${urlPrefix}/gallery/${nft.id}`"
@@ -20,15 +18,20 @@
           @click.native="emit('click-item')">
           {{ nft.name }}
         </nuxt-link>
-        <div class="line-height-1 no-wrap is-clipped ellipsis">
-          {{ nft.collection?.name || nft.collection.id }}
+        <div class="is-flex is-justify-content-space-between">
+          <div class="line-height-1 no-wrap is-clipped ellipsis">
+            {{ nft.collection?.name || nft.collection.id }}
+          </div>
+          <div
+            v-if="!isHovered"
+            class="ml-2 is-flex is-align-items-end no-wrap line-height-1">
+            <CommonTokenMoney :value="nft.price" />
+          </div>
         </div>
       </div>
     </div>
 
-    <div
-      v-if="isHovered"
-      class="is-flex is-justify-content-end is-align-items-center">
+    <div v-if="isHovered" style="position: absolute; top: 25px; right: 50px">
       <NeoButton
         variant="text"
         class="inherit-background-color"
@@ -36,10 +39,6 @@
         icon="trash"
         icon-pack="far"
         @click.native="emit('delete', nft.id)" />
-    </div>
-
-    <div v-else class="is-flex is-align-items-end no-wrap line-height-1">
-      <CommonTokenMoney :value="nft.price" />
     </div>
   </div>
 </template>
@@ -85,7 +84,7 @@ onMounted(() => {
 }
 
 .limit-width {
-  max-width: 130px;
+  width: 230px;
 }
 
 .ellipsis {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6617 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="359" alt="image" src="https://github.com/kodadot/nft-gallery/assets/3810177/9e757a61-6ed6-4e68-a19d-c3854e9ebfba">
<img width="360" alt="image" src="https://github.com/kodadot/nft-gallery/assets/3810177/80ba3874-c38d-4da4-bc6d-7081f20f7d62">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

Refactored the code for opening the shopping cart modal from the navbar. Moved the logic and configuration from `ShoppingCartModalConfig.ts` and `ShoppingCartButton.vue` to `Navbar.vue` to improve code organization and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

> _`ShoppingCartButton`_
> _Simpler, no more `emit` -_
> _Autumn leaves falling_
