### PR TITLE
fix: Followup Transfer Redesign

### DIFF
--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -7,6 +7,7 @@ export default function (to) {
     'prefix-explore-items',
     'prefix-explore-collectibles',
     'prefix-u-id',
+    'prefix-transfer',
   ]
 
   if (disableScrollToTop.includes(toPath)) {

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -350,7 +350,7 @@ const onAmountFieldChange = (target: TargetAddress) => {
     : 0
 
   // update targetAddresses
-  targetAddresses.value = targetAddresses.value.slice(0)
+  targetAddresses.value = [...targetAddresses.value]
 
   if (sendSameAmount.value) {
     unifyAddressAmount(target)
@@ -367,7 +367,7 @@ const onUsdFieldChange = (target: TargetAddress) => {
     : 0
 
   // update targetAddresses
-  targetAddresses.value = targetAddresses.value.slice(0)
+  targetAddresses.value = [...targetAddresses.value]
 
   if (sendSameAmount.value) {
     unifyAddressAmount(target)

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -349,6 +349,9 @@ const onAmountFieldChange = (target: TargetAddress) => {
       )
     : 0
 
+  // update targetAddresses
+  targetAddresses.value = targetAddresses.value.slice(0)
+
   if (sendSameAmount.value) {
     unifyAddressAmount(target)
   }
@@ -362,6 +365,9 @@ const onUsdFieldChange = (target: TargetAddress) => {
         Number(target.usd)
       )
     : 0
+
+  // update targetAddresses
+  targetAddresses.value = targetAddresses.value.slice(0)
 
   if (sendSameAmount.value) {
     unifyAddressAmount(target)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6529
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8dcdccd</samp>

This pull request fixes a bug in the `Transfer.vue` component and enables scrolling to the top of the page on the transfer route. These changes improve the user experience of the NFT transfer feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8dcdccd</samp>

> _`Transfer.vue` fixed_
> _NFTs can change owners now_
> _Autumn of tokens_
