### PR TITLE
fix(usePrefix): not reactive

### DIFF
--- a/composables/usePrefix.ts
+++ b/composables/usePrefix.ts
@@ -8,15 +8,14 @@ import type { Prefix } from '@kodadot1/static'
 export default function () {
   const route = useRoute()
   const storage = useLocalStorage('urlPrefix', { selected: DEFAULT_PREFIX })
-  const initialPrefixFromPath = getAvailablePrefix(route.path.split('/')[1])
-  const validPrefixFromRoute = getAvailablePrefix(route.params.prefix)
 
   const prefix = computed<Prefix>(
     () =>
-      (validPrefixFromRoute ||
+      (getAvailablePrefix(route.params.prefix) ||
         storage.value.selected ||
-        initialPrefixFromPath) as Prefix
+        getAvailablePrefix(route.path.split('/')[1])) as Prefix
   )
+
   const urlPrefix = computed<Prefix>(() => {
     storage.value = { selected: prefix.value }
     return prefix.value


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6661 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸


Instead of making initialPrefixFromPath and validPrefixFromRoute a computedRef like so to maintain reactivity: 
<img width="873" alt="image" src="https://github.com/kodadot/nft-gallery/assets/3810177/27458f86-678b-48b8-8659-0ecadc7a9685">
and using it like
<img width="449" alt="image" src="https://github.com/kodadot/nft-gallery/assets/3810177/51e0c42d-2cec-47bc-a3aa-13e5c087504a">

I just inlined it here to avoid unnecessary computedRef overhead
<img width="513" alt="image" src="https://github.com/kodadot/nft-gallery/assets/3810177/06e447a9-e85f-42f4-a4d4-2b5a2386a12e">


- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

Refactored the code for opening the shopping cart modal from the navbar. Moved the logic and configuration from `ShoppingCartModalConfig.ts` and `ShoppingCartButton.vue` to `Navbar.vue` to improve code organization and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

> _`ShoppingCartButton`_
> _Simpler, no more `emit` -_
> _Autumn leaves falling_
