### PR TITLE
Transfer Redesign handover - Transaction confirm & Send Transaction

### DIFF
--- a/ACTIVITY.md
+++ b/ACTIVITY.md
@@ -62,6 +62,10 @@ flowchart TD
 ![Alt](https://repobeats.axiom.co/api/embed/0fb5819705db8bf2be040d140b66f04aaf529a30.svg "Repobeats analytics image")
 
 
+### Crowd.dev - AnalyzeMyRepo
+
+[Verbose version from AnalyzeMyRepo](https://analyzemyrepo.com/analyze/kodadot/nft-gallery)
+
 ## We're constantly growing!
 
 [![Contributors Over Time](https://contributor-overtime-api.git-contributor.com/contributors-svg?chart=contributorOverTime&repo=kodadot/nft-gallery)](https://git-contributor.com?chart=contributorOverTime&repo=kodadot/nft-gallery)

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -182,10 +182,18 @@
         class="is-flex is-flex-1 fixed-height"
         variant="k-accent"
         :disabled="disabled"
-        @click.native="submit"
+        @click.native="handleContinue"
         >{{ $t('redirect.continue') }}</NeoButton
       >
     </div>
+    <TransferConfirmModal
+      :is-modal-active="isTransferModalVisible"
+      :total-token-amount="totalTokenAmount"
+      :total-usd-value="totalUsdValue"
+      :token-icon="tokenIcon"
+      :unit="unit"
+      :target-addresses="targetAddresses"
+      @close="isTransferModalVisible = false" />
   </div>
 </template>
 
@@ -208,7 +216,7 @@ import { useFiatStore } from '@/stores/fiat'
 import { useIdentityStore } from '@/stores/identity'
 import Avatar from '@/components/shared/Avatar.vue'
 import Identity from '@/components/identity/IdentityIndex.vue'
-
+import TransferConfirmModal from '@/components/transfer/TransferConfirmModal.vue'
 import { emptyObject } from '@kodadot1/minimark/utils'
 import {
   NeoButton,
@@ -237,10 +245,11 @@ const { fetchFiatPrice, getCurrentTokenValue } = useFiatStore()
 const { initTransactionLoader, isLoading, resolveStatus } =
   useTransactionStatus()
 const { toast } = useToast()
+const isTransferModalVisible = ref(false)
 
 type Target = 'target' | `target${number}`
 type TargetMap = Record<Target, string>
-type TargetAddress = {
+export type TargetAddress = {
   address?: string
   usd?: number | string
   token?: number | string
@@ -339,6 +348,15 @@ const balanceUsdValue = computed(() =>
     decimals.value
   )
 )
+
+const handleContinue = () => {
+  if (!disabled.value) {
+    targetAddresses.value = targetAddresses.value.filter(
+      (address) => address.address && address.token && address.usd
+    )
+    isTransferModalVisible.value = true
+  }
+}
 const onAmountFieldChange = (target: TargetAddress) => {
   /* calculating usd value on the basis of price entered */
 

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -170,11 +170,13 @@
         $t('spotlight.total')
       }}</span>
       <div class="is-flex is-align-items-center">
-        <span class="is-size-7 has-text-grey mr-1">(${{ totalUsdValue }})</span>
-
-        <span class="has-text-weight-bold is-size-6"
-          >{{ totalTokenAmount }} {{ unit }}</span
+        <span class="is-size-7 has-text-grey mr-1"
+          >({{ displayTotalValue[0] }})</span
         >
+
+        <span class="has-text-weight-bold is-size-6">{{
+          displayTotalValue[1]
+        }}</span>
       </div>
     </div>
 
@@ -183,14 +185,13 @@
         class="is-flex is-flex-1 fixed-height"
         variant="k-accent"
         :disabled="disabled"
-        @click.native="handleContinue"
+        @click.native="handleOpenConfirmModal"
         >{{ $t('redirect.continue') }}</NeoButton
       >
     </div>
     <TransferConfirmModal
       :is-modal-active="isTransferModalVisible"
-      :total-token-amount="totalTokenAmount"
-      :total-usd-value="totalUsdValue"
+      :display-total-value="displayTotalValue"
       :token-icon="tokenIcon"
       :unit="unit"
       :target-addresses="targetAddresses"
@@ -266,6 +267,12 @@ const targetAddresses = ref<TargetAddress[]>([{}])
 
 const hasValidTarget = computed(() =>
   targetAddresses.value.some((item) => isAddress(item.address) && item.token)
+)
+
+const displayTotalValue = computed(() =>
+  displayUnit.value === 'token'
+    ? [`$${totalUsdValue.value}`, `${totalTokenAmount.value} ${unit.value}`]
+    : [`${totalTokenAmount.value} ${unit.value}`, `$${totalUsdValue.value}`]
 )
 
 const balance = getAuthBalance
@@ -391,7 +398,7 @@ const unifyAddressAmount = (target: TargetAddress) => {
   }))
 }
 
-const handleContinue = () => {
+const handleOpenConfirmModal = () => {
   if (!disabled.value) {
     targetAddresses.value = targetAddresses.value.filter(
       (address) => address.address && address.token && address.usd

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -332,10 +332,12 @@ watch(sendSameAmount, (value) => {
 })
 
 const totalTokenAmount = computed(() =>
-  Number(getNumberSumOfObjectField(targetAddresses.value, 'token')).toFixed(4)
+  Number(
+    Number(getNumberSumOfObjectField(targetAddresses.value, 'token')).toFixed(4)
+  )
 )
 const totalUsdValue = computed(() =>
-  getNumberSumOfObjectField(targetAddresses.value, 'usd')
+  calculateUsdFromKsm(totalTokenAmount.value, Number(currentTokenValue.value))
 )
 
 const currentTokenValue = computed(() => getCurrentTokenValue(unit.value))

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -26,7 +26,7 @@
 
     <div class="is-flex mb-5">
       <div class="token-price py-2 px-4 is-flex is-align-items-center">
-        <img class="mr-2 is-20x20" :src="tokenIcon" alt="token" />
+        <img class="mr-2 square-20" :src="tokenIcon" alt="token" />
         {{ unit }} ${{ currentTokenValue }}
       </div>
     </div>
@@ -563,7 +563,10 @@ watch(
     width: 32px;
     height: 32px;
   }
-
+  .square-20 {
+    width: 20px;
+    height: 20px;
+  }
   .fixed-height {
     height: 51px;
   }

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -83,7 +83,7 @@
               <div
                 v-for="(address, index) in targetAddresses"
                 :key="address.address"
-                class="py-4 is-bordered-top is-small-size-text">
+                class="py-4 is-bordered-top is-size-7">
                 <div
                   class="is-flex is-justify-content-space-between is-align-items-center mb-2">
                   <span class="has-text-weight-bold"
@@ -91,7 +91,7 @@
                   >
                   <div class="is-flex is-align-items-center">
                     <Avatar :value="address.address" :size="18" />
-                    <span class="mx-2">
+                    <span class="mx-2 is-size-6">
                       <Identity
                         :address="address.address"
                         hide-identity-popover />
@@ -126,12 +126,11 @@
             $t('transfers.totalAmount')
           }}</span>
           <div class="is-flex is-align-items-center">
-            <span class="has-text-grey mr-1 is-small-size-text"
-              >({{ totalTokenAmount }} {{ unit }})</span
+            <span class="has-text-grey mr-1 is-size-7"
+              >({{ displayTotalValue[0] }})</span
             >
-
             <span class="has-text-weight-bold is-size-5">
-              ${{ totalUsdValue }}</span
+              {{ displayTotalValue[1] }}</span
             >
           </div>
         </div>
@@ -154,10 +153,9 @@ import Identity from '@/components/identity/IdentityIndex.vue'
 import type { TargetAddress } from '@/components/transfer/Transfer.vue'
 const props = defineProps<{
   isModalActive: boolean
-  totalTokenAmount: string
-  totalUsdValue: number
   tokenIcon: string
   unit: string
+  displayTotalValue: string[]
   targetAddresses: TargetAddress[]
 }>()
 
@@ -176,7 +174,10 @@ const confirmTransfer = () => {
 }
 const { accountId } = useAuth()
 
-const network = computed(() => NAMES[urlPrefix.value])
+const network = computed(
+  // naming: rmrk2 -> kusama
+  () => NAMES[urlPrefix.value === 'ksm' ? 'rmrk' : urlPrefix.value]
+)
 const isExpandList = ref(false)
 </script>
 

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -63,6 +63,7 @@
               </span>
               <NeoIcon
                 icon="circle-info"
+                class="is-size-6"
                 pack="far"
                 :title="targetAddresses[0].address" />
             </div>
@@ -86,7 +87,7 @@
                 class="py-4 is-bordered-top is-size-7">
                 <div
                   class="is-flex is-justify-content-space-between is-align-items-center mb-2">
-                  <span class="has-text-weight-bold"
+                  <span class="has-text-grey"
                     >{{ $t('transfers.recipient') }} {{ index + 1 }}</span
                   >
                   <div class="is-flex is-align-items-center">
@@ -98,19 +99,20 @@
                     </span>
                     <NeoIcon
                       icon="circle-info"
+                      class="is-size-6"
                       pack="far"
                       :title="address.address" />
                   </div>
                 </div>
                 <div
                   class="is-flex is-justify-content-space-between is-align-items-center">
-                  <span class="has-text-weight-bold">{{ $t('amount') }}</span>
+                  <span class="has-text-grey">{{ $t('amount') }}</span>
 
                   <div class="is-flex is-align-items-center">
                     <span class="has-text-grey"
                       >({{ address.token }} {{ unit }})</span
                     >
-                    <span class="ml-1">${{ address.usd }}</span>
+                    <span class="ml-1 is-size-6">${{ address.usd }}</span>
                   </div>
                 </div>
               </div>
@@ -138,6 +140,7 @@
         <NeoButton
           :label="$t('teleport.send')"
           variant="k-accent"
+          no-shadow
           class="fixed-button-height is-flex is-flex-1"
           @click.native="confirmTransfer" />
       </div>

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -7,6 +7,7 @@
           class="is-flex is-justify-content-center is-align-items-center header px-6 py-3">
           <span class="is-size-5 has-text-weight-bold">
             {{ $t('teleport.send') }}
+            <span class="is-uppercase">{{ unit }}</span>
           </span>
           <NeoIcon
             class="position-right is-clickable mr-6"
@@ -56,7 +57,10 @@
                   :address="targetAddresses[0].address"
                   hide-identity-popover />
               </span>
-              <NeoIcon icon="circle-info" pack="far" />
+              <NeoIcon
+                icon="circle-info"
+                pack="far"
+                :title="targetAddresses[0].address" />
             </div>
             <div
               v-else
@@ -75,7 +79,7 @@
               <div
                 v-for="(address, index) in targetAddresses"
                 :key="address.address"
-                class="py-4 is-bordered-top is-size-7">
+                class="py-4 is-bordered-top is-small-size-text">
                 <div
                   class="is-flex is-justify-content-space-between is-align-items-center mb-2">
                   <span class="has-text-weight-bold"
@@ -88,7 +92,10 @@
                         :address="address.address"
                         hide-identity-popover />
                     </span>
-                    <NeoIcon icon="circle-info" pack="far" />
+                    <NeoIcon
+                      icon="circle-info"
+                      pack="far"
+                      :title="address.address" />
                   </div>
                 </div>
                 <div
@@ -115,11 +122,11 @@
             $t('transfers.totalAmount')
           }}</span>
           <div class="is-flex is-align-items-center">
-            <span class="is-size-7 has-text-grey mr-1"
+            <span class="has-text-grey mr-1 is-small-size-text"
               >({{ totalTokenAmount }} {{ unit }})</span
             >
 
-            <span class="has-text-weight-bold is-size-6">
+            <span class="has-text-weight-bold is-size-5">
               ${{ totalUsdValue }}</span
             >
           </div>
@@ -188,11 +195,14 @@ const isExpandList = ref(false)
 }
 
 .fixed-button-height {
-  height: 3.5rem;
+  min-height: 55px;
+}
+.is-small-size-text {
+  font-size: 14px;
 }
 
 .is-scrollable {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 .is-bordered-top {
   @include ktheme() {

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -24,60 +24,68 @@
             },
             'px-6 is-scrollable',
           ]">
-          <div
-            class="is-flex is-justify-content-space-between is-align-items-center py-4">
-            <span class="has-text-weight-bold is-size-6">{{
-              $t('activity.network')
-            }}</span>
-            <span class="is-flex is-align-items-center">
-              <img class="mr-2 image is-24x24" :src="tokenIcon" alt="token" />
-              {{ network }}
-            </span>
-          </div>
-          <div
-            class="is-flex is-justify-content-space-between is-align-items-center py-4 is-bordered-top">
-            <span class="has-text-weight-bold is-size-6 is-capitalized">{{
-              $t('general.from')
-            }}</span>
-            <span class="is-flex is-align-items-center">
-              <Avatar :value="accountId" :size="24" />
-              <span class="ml-2 is-size-6">
-                <Identity :address="accountId" hide-identity-popover />
-              </span>
-            </span>
-          </div>
+          <table class="table is-fullwidth table-padding mb-0">
+            <tbody>
+              <tr class="py-4">
+                <td class="has-text-weight-bold is-size-6">
+                  {{ $t('activity.network') }}
+                </td>
+                <td
+                  class="is-flex is-align-items-center is-justify-content-end">
+                  <img
+                    class="mr-2 image is-24x24"
+                    :src="tokenIcon"
+                    alt="token" />
+                  {{ network }}
+                </td>
+              </tr>
+              <tr class="py-4">
+                <td class="has-text-weight-bold is-size-6 is-capitalized">
+                  {{ $t('general.from') }}
+                </td>
+                <td
+                  class="is-flex is-align-items-center is-justify-content-end">
+                  <Avatar :value="accountId" :size="24" />
+                  <span class="ml-2 is-size-6">
+                    <Identity :address="accountId" hide-identity-popover />
+                  </span>
+                </td>
+              </tr>
 
-          <div
-            class="is-flex is-justify-content-space-between is-align-items-center py-4 is-bordered-top">
-            <span class="has-text-weight-bold is-size-6">{{
-              $t('transfers.sendTo')
-            }}</span>
-            <div
-              v-if="targetAddresses.length === 1"
-              class="is-flex is-align-items-center">
-              <Avatar :value="targetAddresses[0].address" :size="24" />
-              <span class="mx-2 is-size-6">
-                <Identity
-                  :address="targetAddresses[0].address"
-                  hide-identity-popover />
-              </span>
-              <NeoIcon
-                icon="circle-info"
-                pack="far"
-                :title="targetAddresses[0].address" />
-            </div>
-            <div
-              v-else
-              class="is-clickable"
-              @click="isExpandList = !isExpandList">
-              <span class="mx-2 is-size-6">
-                {{ targetAddresses.length }} {{ $t('transfers.recipients') }}
-              </span>
-              <NeoIcon
-                :icon="isExpandList ? 'angle-up' : 'angle-down'"
-                pack="far" />
-            </div>
-          </div>
+              <tr class="py-4">
+                <td class="has-text-weight-bold is-size-6">
+                  {{ $t('transfers.sendTo') }}
+                </td>
+                <td
+                  v-if="targetAddresses.length === 1"
+                  class="is-flex is-align-items-center is-justify-content-end">
+                  <Avatar :value="targetAddresses[0].address" :size="24" />
+                  <span class="mx-2 is-size-6">
+                    <Identity
+                      :address="targetAddresses[0].address"
+                      hide-identity-popover />
+                  </span>
+                  <NeoIcon
+                    icon="circle-info"
+                    pack="far"
+                    :title="targetAddresses[0].address" />
+                </td>
+                <td
+                  v-else
+                  class="is-clickable is-flex is-align-items-center is-justify-content-end"
+                  @click="isExpandList = !isExpandList">
+                  <span class="mx-2 is-size-6">
+                    {{ targetAddresses.length }}
+                    {{ $t('transfers.recipients') }}
+                  </span>
+                  <NeoIcon
+                    :icon="isExpandList ? 'angle-up' : 'angle-down'"
+                    pack="far" />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
           <div class="fixed-height">
             <template v-if="isExpandList">
               <div
@@ -207,6 +215,12 @@ const isExpandList = ref(false)
 
 .is-scrollable {
   overflow-y: auto;
+}
+
+.table-padding {
+  td {
+    padding: 1rem 0;
+  }
 }
 .is-bordered-top {
   @include ktheme() {

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -3,44 +3,48 @@
     <div
       class="modal-width is-flex is-flex-direction-column is-justify-content-space-between">
       <div>
-        <div
+        <header
           class="is-flex is-justify-content-center is-align-items-center header px-6 py-3">
           <span class="is-size-5 has-text-weight-bold">
             {{ $t('teleport.send') }}
             <span class="is-uppercase">{{ unit }}</span>
           </span>
-          <NeoIcon
-            class="position-right is-clickable mr-6"
+          <NeoButton
+            class="position-right mr-6"
+            variant="text"
             icon="close"
-            pack="fas"
+            no-shadow
+            icon-pack="fas"
             @click.native="closeModal" />
-        </div>
+        </header>
         <div
-          class="px-6 is-scrollable"
-          :class="{
-            'is-bordered-top': isExpandList,
-          }">
+          :class="[
+            {
+              'is-bordered-top': isExpandList,
+            },
+            'px-6 is-scrollable',
+          ]">
           <div
             class="is-flex is-justify-content-space-between is-align-items-center py-4">
             <span class="has-text-weight-bold is-size-6">{{
-              $t('transfers.network')
+              $t('activity.network')
             }}</span>
-            <div class="is-flex is-align-items-center">
-              <img class="mr-2 is-24x24" :src="tokenIcon" alt="token" />
+            <span class="is-flex is-align-items-center">
+              <img class="mr-2 image is-24x24" :src="tokenIcon" alt="token" />
               {{ network }}
-            </div>
+            </span>
           </div>
           <div
             class="is-flex is-justify-content-space-between is-align-items-center py-4 is-bordered-top">
             <span class="has-text-weight-bold is-size-6 is-capitalized">{{
               $t('general.from')
             }}</span>
-            <div class="is-flex is-align-items-center">
+            <span class="is-flex is-align-items-center">
               <Avatar :value="accountId" :size="24" />
               <span class="ml-2 is-size-6">
                 <Identity :address="accountId" hide-identity-popover />
               </span>
-            </div>
+            </span>
           </div>
 
           <div

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -24,68 +24,60 @@
             },
             'px-6 is-scrollable',
           ]">
-          <table class="table is-fullwidth table-padding mb-0">
-            <tbody>
-              <tr class="py-4">
-                <td class="has-text-weight-bold is-size-6">
-                  {{ $t('activity.network') }}
-                </td>
-                <td
-                  class="is-flex is-align-items-center is-justify-content-end">
-                  <img
-                    class="mr-2 image is-24x24"
-                    :src="tokenIcon"
-                    alt="token" />
-                  {{ network }}
-                </td>
-              </tr>
-              <tr class="py-4">
-                <td class="has-text-weight-bold is-size-6 is-capitalized">
-                  {{ $t('general.from') }}
-                </td>
-                <td
-                  class="is-flex is-align-items-center is-justify-content-end">
-                  <Avatar :value="accountId" :size="24" />
-                  <span class="ml-2 is-size-6">
-                    <Identity :address="accountId" hide-identity-popover />
-                  </span>
-                </td>
-              </tr>
+          <div
+            class="is-flex is-justify-content-space-between is-align-items-center py-4">
+            <span class="has-text-weight-bold is-size-6">{{
+              $t('activity.network')
+            }}</span>
+            <span class="is-flex is-align-items-center">
+              <img class="mr-2 image is-24x24" :src="tokenIcon" alt="token" />
+              {{ network }}
+            </span>
+          </div>
+          <div
+            class="is-flex is-justify-content-space-between is-align-items-center py-4 is-bordered-top">
+            <span class="has-text-weight-bold is-size-6 is-capitalized">{{
+              $t('general.from')
+            }}</span>
+            <span class="is-flex is-align-items-center">
+              <Avatar :value="accountId" :size="24" />
+              <span class="ml-2 is-size-6">
+                <Identity :address="accountId" hide-identity-popover />
+              </span>
+            </span>
+          </div>
 
-              <tr class="py-4">
-                <td class="has-text-weight-bold is-size-6">
-                  {{ $t('transfers.sendTo') }}
-                </td>
-                <td
-                  v-if="targetAddresses.length === 1"
-                  class="is-flex is-align-items-center is-justify-content-end">
-                  <Avatar :value="targetAddresses[0].address" :size="24" />
-                  <span class="mx-2 is-size-6">
-                    <Identity
-                      :address="targetAddresses[0].address"
-                      hide-identity-popover />
-                  </span>
-                  <NeoIcon
-                    icon="circle-info"
-                    pack="far"
-                    :title="targetAddresses[0].address" />
-                </td>
-                <td
-                  v-else
-                  class="is-clickable is-flex is-align-items-center is-justify-content-end"
-                  @click="isExpandList = !isExpandList">
-                  <span class="mx-2 is-size-6">
-                    {{ targetAddresses.length }}
-                    {{ $t('transfers.recipients') }}
-                  </span>
-                  <NeoIcon
-                    :icon="isExpandList ? 'angle-up' : 'angle-down'"
-                    pack="far" />
-                </td>
-              </tr>
-            </tbody>
-          </table>
-
+          <div
+            class="is-flex is-justify-content-space-between is-align-items-center py-4 is-bordered-top">
+            <span class="has-text-weight-bold is-size-6">{{
+              $t('transfers.sendTo')
+            }}</span>
+            <div
+              v-if="targetAddresses.length === 1"
+              class="is-flex is-align-items-center">
+              <Avatar :value="targetAddresses[0].address" :size="24" />
+              <span class="mx-2 is-size-6">
+                <Identity
+                  :address="targetAddresses[0].address"
+                  hide-identity-popover />
+              </span>
+              <NeoIcon
+                icon="circle-info"
+                pack="far"
+                :title="targetAddresses[0].address" />
+            </div>
+            <div
+              v-else
+              class="is-clickable"
+              @click="isExpandList = !isExpandList">
+              <span class="mx-2 is-size-6">
+                {{ targetAddresses.length }} {{ $t('transfers.recipients') }}
+              </span>
+              <NeoIcon
+                :icon="isExpandList ? 'angle-up' : 'angle-down'"
+                pack="far" />
+            </div>
+          </div>
           <div class="fixed-height">
             <template v-if="isExpandList">
               <div
@@ -215,12 +207,6 @@ const isExpandList = ref(false)
 
 .is-scrollable {
   overflow-y: auto;
-}
-
-.table-padding {
-  td {
-    padding: 1rem 0;
-  }
 }
 .is-bordered-top {
   @include ktheme() {

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -1,0 +1,202 @@
+<template>
+  <NeoModal v-model="isModalActive" scroll="clip" @close="emit('close')">
+    <div
+      class="modal-width is-flex is-flex-direction-column is-justify-content-space-between">
+      <div>
+        <div
+          class="is-flex is-justify-content-center is-align-items-center header px-6 py-3">
+          <span class="is-size-5 has-text-weight-bold">
+            {{ $t('teleport.send') }}
+          </span>
+          <NeoIcon
+            class="position-right is-clickable mr-6"
+            icon="close"
+            pack="fas"
+            @click.native="closeModal" />
+        </div>
+        <div
+          class="px-6 is-scrollable"
+          :class="{
+            'is-bordered-top': isExpandList,
+          }">
+          <div
+            class="is-flex is-justify-content-space-between is-align-items-center py-4">
+            <span class="has-text-weight-bold is-size-6">{{
+              $t('transfers.network')
+            }}</span>
+            <div class="is-flex is-align-items-center">
+              <img class="mr-2 is-24x24" :src="tokenIcon" alt="token" />
+              {{ network }}
+            </div>
+          </div>
+          <div
+            class="is-flex is-justify-content-space-between is-align-items-center py-4 is-bordered-top">
+            <span class="has-text-weight-bold is-size-6 is-capitalized">{{
+              $t('general.from')
+            }}</span>
+            <div class="is-flex is-align-items-center">
+              <Avatar :value="accountId" :size="24" />
+              <span class="ml-2 is-size-6">
+                <Identity :address="accountId" hide-identity-popover />
+              </span>
+            </div>
+          </div>
+
+          <div
+            class="is-flex is-justify-content-space-between is-align-items-center py-4 is-bordered-top">
+            <span class="has-text-weight-bold is-size-6">{{
+              $t('transfers.sendTo')
+            }}</span>
+            <div
+              v-if="targetAddresses.length === 1"
+              class="is-flex is-align-items-center">
+              <Avatar :value="targetAddresses[0].address" :size="24" />
+              <span class="mx-2 is-size-6">
+                <Identity
+                  :address="targetAddresses[0].address"
+                  hide-identity-popover />
+              </span>
+              <NeoIcon icon="circle-info" pack="far" />
+            </div>
+            <div
+              v-else
+              class="is-clickable"
+              @click="isExpandList = !isExpandList">
+              <span class="mx-2 is-size-6">
+                {{ targetAddresses.length }} {{ $t('transfers.recipients') }}
+              </span>
+              <NeoIcon
+                :icon="isExpandList ? 'angle-up' : 'angle-down'"
+                pack="far" />
+            </div>
+          </div>
+          <div class="fixed-height">
+            <template v-if="isExpandList">
+              <div
+                v-for="(address, index) in targetAddresses"
+                :key="address.address"
+                class="py-4 is-bordered-top is-size-7">
+                <div
+                  class="is-flex is-justify-content-space-between is-align-items-center mb-2">
+                  <span class="has-text-weight-bold"
+                    >{{ $t('transfers.recipient') }} {{ index + 1 }}</span
+                  >
+                  <div class="is-flex is-align-items-center">
+                    <Avatar :value="address.address" :size="18" />
+                    <span class="mx-2">
+                      <Identity
+                        :address="address.address"
+                        hide-identity-popover />
+                    </span>
+                    <NeoIcon icon="circle-info" pack="far" />
+                  </div>
+                </div>
+                <div
+                  class="is-flex is-justify-content-space-between is-align-items-center">
+                  <span class="has-text-weight-bold">{{ $t('amount') }}</span>
+
+                  <div class="is-flex is-align-items-center">
+                    <span class="has-text-grey"
+                      >({{ address.token }} {{ unit }})</span
+                    >
+                    <span class="ml-1">${{ address.usd }}</span>
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <div class="is-flex is-flex-direction-column px-6 py-5 is-bordered-top">
+        <div
+          class="is-flex is-justify-content-space-between is-align-items-center mb-3">
+          <span class="has-text-weight-bold is-size-6">{{
+            $t('transfers.totalAmount')
+          }}</span>
+          <div class="is-flex is-align-items-center">
+            <span class="is-size-7 has-text-grey mr-1"
+              >({{ totalTokenAmount }} {{ unit }})</span
+            >
+
+            <span class="has-text-weight-bold is-size-6">
+              ${{ totalUsdValue }}</span
+            >
+          </div>
+        </div>
+
+        <NeoButton
+          :label="$t('teleport.send')"
+          variant="k-accent"
+          class="fixed-button-height is-flex is-flex-1"
+          @click.native="confirmTransfer" />
+      </div>
+    </div>
+  </NeoModal>
+</template>
+
+<script setup lang="ts">
+import { NeoButton, NeoIcon, NeoModal } from '@kodadot1/brick'
+import { NAMES } from '@/libs/static/src/names'
+import Avatar from '@/components/shared/Avatar.vue'
+import Identity from '@/components/identity/IdentityIndex.vue'
+import type { TargetAddress } from '@/components/transfer/Transfer.vue'
+const props = defineProps<{
+  isModalActive: boolean
+  totalTokenAmount: string
+  totalUsdValue: number
+  tokenIcon: string
+  unit: string
+  targetAddresses: TargetAddress[]
+}>()
+
+const isModalActive = useVModel(props, 'isModalActive')
+
+const { urlPrefix } = usePrefix()
+const emit = defineEmits(['close', 'confirm'])
+
+const closeModal = () => {
+  emit('close')
+}
+
+const confirmTransfer = () => {
+  closeModal()
+  emit('confirm')
+}
+const { accountId } = useAuth()
+
+const network = computed(() => NAMES[urlPrefix.value])
+const isExpandList = ref(false)
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles/abstracts/variables';
+
+.modal-width {
+  width: 28rem;
+}
+.header {
+  position: relative;
+}
+.position-right {
+  position: absolute;
+  right: 0;
+}
+
+.fixed-height {
+  height: 10rem;
+}
+
+.fixed-button-height {
+  height: 3.5rem;
+}
+
+.is-scrollable {
+  overflow-y: scroll;
+}
+.is-bordered-top {
+  @include ktheme() {
+    border-top: 1px solid theme('k-shade');
+  }
+}
+</style>

--- a/locales/en.json
+++ b/locales/en.json
@@ -98,7 +98,11 @@
     "addAddress": "Add recipient",
     "payMeLink": "Pay me link",
     "setSameAmount": "Set one amount that will be sent to all recipients",
-    "transferable": "Transferable"
+    "network": "Network",
+    "sendTo": "Sending to",
+    "recipients": "recipients",
+    "totalAmount": "Total Amount",
+     "transferable": "Transferable"
   },
   "topCollections": {
     "timeFrames": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -98,11 +98,10 @@
     "addAddress": "Add recipient",
     "payMeLink": "Pay me link",
     "setSameAmount": "Set one amount that will be sent to all recipients",
-    "network": "Network",
     "sendTo": "Sending to",
     "recipients": "recipients",
     "totalAmount": "Total Amount",
-     "transferable": "Transferable"
+    "transferable": "Transferable"
   },
   "topCollections": {
     "timeFrames": {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6466 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

<img width="770" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/117ba0cf-2599-46e7-a269-95690ec2f3b1">

<img width="475" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/4c87fa23-74f4-43e2-8556-f416fcfd6882">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0be1770</samp>

This pull request enhances the Transfer component by adding a confirmation modal and a loader, and refactoring the transfer logic. It also adds a new TransferConfirmModal component and its translations to the en.json file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0be1770</samp>

> _`Transfer` component_
> _Refactored and enhanced_
> _With modal and `loader`_
