### PR TITLE
fix: SearchBar component is called multiple times

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -35,6 +35,7 @@
             <div
               class="fixed-stack is-flex is-align-items-center is-justify-content-space-between p-2">
               <Search
+                v-if="isMobile"
                 ref="mobilSearchRef"
                 hide-filter
                 class="is-flex-grow-1 mt-3" />
@@ -71,6 +72,7 @@
         <div class="navbar-start">
           <div v-if="showSearchOnNavbar" class="navbar-item is-expanded">
             <Search
+              v-if="!isMobile"
               class="search-navbar is-flex-grow-1 pb-0 is-hidden-touch"
               hide-filter
               search-column-class="is-flex-grow-1" />


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

the reason that the component is called 2 times is the component is mounted differently with desktop/mobile device in `NavBar.vue`. Should add the `v-if` to mount the component in different scenario. and i just add the test log code in `mounted` like #6359 , and it only display once

<img width="1226" alt="image" src="https://github.com/kodadot/nft-gallery/assets/16473062/1a8835d5-7265-49f2-93d4-6fe3abc3dfcf">


👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6359
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b52621a</samp>

Improved the responsiveness of the `Navbar` component by toggling some elements based on the `isMobile` property.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b52621a</samp>

> _Sing, O Muse, of the skillful coder who updated the `Navbar`_
> _To fit the varied screens of mortals, both near and far_
> _He added a wise condition, to show or hide the `v-menu` and `v-btn`_
> _Like Zeus who veils or unveils the clouds, as he pleases, with his thunder_
