### PR TITLE
fix: forbiding landing page on DOT

### DIFF
--- a/components/landing/LandingPage.vue
+++ b/components/landing/LandingPage.vue
@@ -41,8 +41,13 @@
 <script lang="ts" setup>
 import type { Prefix } from '@kodadot1/static'
 
-const hiddenCarrouselPrefixes: Prefix[] = ['movr', 'glmr']
-const forbiddenPrefixesForTopCollections: Prefix[] = ['ksm', 'ahk', 'ahp']
+const hiddenCarrouselPrefixes: Prefix[] = ['movr', 'glmr', 'dot']
+const forbiddenPrefixesForTopCollections: Prefix[] = [
+  'ksm',
+  'ahk',
+  'ahp',
+  'dot',
+]
 
 const { urlPrefix } = usePrefix()
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6705 
ref: https://github.com/kodadot/nft-gallery/issues/6705#issuecomment-1677350385

<img width="1847" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/ecbbb041-eb33-4c84-a2d1-dc55886d768d">


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aabb40b</samp>

Updated `hiddenCarrouselPrefixes` and `forbiddenPrefixesForTopCollections` in `LandingPage.vue` to filter out 'dot' collections. This improves the landing page UX and performance by showing only relevant and high-quality collections.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aabb40b</samp>

> _`dot` collections hide_
> _landing page more relevant_
> _autumn leaves fall fast_
