### PR TITLE
fix: remove console error

### DIFF
--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -44,7 +44,7 @@ export interface Props {
   multilineWidth?: string | number
   fullWidth?: boolean
   stopEvents?: boolean
-  autoClose?: any | boolean
+  autoClose?: string[] | boolean
   contentClass?: string
 }
 const props = withDefaults(defineProps<Props>(), {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

follow the type definition of oruga ui, that's the reason of the console's error.
<img width="875" alt="image" src="https://github.com/kodadot/nft-gallery/assets/16473062/bb4931f7-4a44-4c3a-aa3c-269e905745bd">

now enjoy the clear console :)

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6706
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3cde46d</samp>

Changed the `autoClose` prop type of the `NeoTooltip` component to accept an array of event names. This allows customizing the tooltip behavior based on different user interactions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3cde46d</samp>

> _`autoClose` prop_
> _array of events or bool_
> _autumn leaves falling_
