### PR TITLE
fix: Collection pfp object fit

### DIFF
--- a/components/collection/CollectionHeader/CollectionBanner.vue
+++ b/components/collection/CollectionHeader/CollectionBanner.vue
@@ -11,6 +11,7 @@
             <img
               v-if="collectionAvatar"
               :src="collectionAvatar"
+              class="object-fit-cover"
               :alt="collectionName" />
             <img v-else :src="placeholder" />
           </div>

--- a/components/collection/unlockable/UnlockableCollectionBanner.vue
+++ b/components/collection/unlockable/UnlockableCollectionBanner.vue
@@ -8,7 +8,7 @@
       <div class="container is-fluid collection-banner-content">
         <div class="is-flex is-flex-direction-column is-align-items-start">
           <div class="collection-banner-avatar">
-            <img :src="image" alt="avatar" />
+            <img :src="image" alt="avatar" class="object-fit-cover" />
           </div>
           <h1 class="collection-banner-name">{{ title }}</h1>
         </div>

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -172,6 +172,10 @@ body {
   border-radius: 50%;
 }
 
+.object-fit-cover {
+  object-fit: cover;
+}
+
 .box {
   .box-container {
     @media screen and (max-width: 768px) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #6718
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI
<img width="865" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/a65fa4d0-b70a-415b-a52f-42b4af1b6d33">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1eeea8</samp>

This pull request updates the image styling for the `CollectionBanner` and `UnlockableCollectionBanner` components by adding the `object-fit-cover` class to the `img` elements. This class is defined in the `global.scss` file, which is also modified to remove an unused class. The goal is to make the banner images fit the containers better and improve the visual appearance of the collections.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1eeea8</samp>

> _To make the banner images fit_
> _The `object-fit-cover` class was a hit_
> _But it had to be moved_
> _To another component improved_
> _And the global styles got a bit of a split_
