### PR TITLE
#6708 - how to use images in code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,10 +49,15 @@ module.exports = {
         'layouts/**/*.{js,ts,vue}',
         'pages/**/*.vue',
         'components/**/*.{js,ts,vue}',
+        'utils/**/*.ts',
+        'stores/**/*.ts',
+        'services/**/*.ts',
+        'plugins/**/*.ts',
+        'composables/**/*.ts',
       ],
       rules: {
         'no-restricted-imports': [
-          'warn',
+          'error',
           {
             patterns: [
               {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,33 @@ module.exports = {
   ignorePatterns: ['*.md'],
   overrides: [
     {
-      files: ['layouts/**/*.{js,ts,vue}', 'pages/**/*.vue'],
+      files: [
+        'layouts/**/*.{js,ts,vue}',
+        'pages/**/*.vue',
+        'components/**/*.{js,ts,vue}',
+      ],
+      rules: {
+        'no-restricted-imports': [
+          'warn',
+          {
+            patterns: [
+              {
+                group: [
+                  '*.png',
+                  '*.jpg',
+                  '*.jpeg',
+                  '*.gif',
+                  '*.bmp',
+                  '*.svg',
+                  '*.webp',
+                ],
+                message:
+                  'It is recommended to utilize HTML tags and using a URL path, instead of directly importing images using JavaScript',
+              },
+            ],
+          },
+        ],
+      },
     },
   ],
 }

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -17,6 +17,7 @@ With a few exceptions, code and comments should be written in **English** only.
 - **Typescript**, **Javascript** and **GraphQL** files use **camelCase** (`globalVariables.ts`, `getKey.js`, `collectionById.graphql`)
 - **SCSS** files use **kebab-case** (`initial-variables.scss`)
 - **JSON** files use **snake_case** (`all_lang.json`) while **Markdown** files use **SCREAMING_SNAKE_CASE** (`CONTRIBUTING.md`)
+- **Image** files use **kebab-case** (`my-image.webp`) and **.webp** is the preffered image format
 
 ## SFC Conventions
 ### Skeleton
@@ -237,4 +238,24 @@ list.forEach(element => ...)
 for (const element of array) {
   // your statement
 }
+```
+
+### images
+
+When working with images, it is recommended to utilize HTML tags and using a URL path,
+instead of directly importing images using JavaScript
+
+❗ bad
+```js
+// bad
+import logo from './path/to/my-image.webp'
+```
+
+✅ good
+```html
+<img src="/my-image.webp" alt="my-image" />
+
+<!-- or -->
+
+<img src="https://cdn.com/my-image.webp" alt="my-image" />
 ```


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes [#6708](https://github.com/kodadot/nft-gallery/issues/6708)
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

## Screenshot
- Added lint warning when importing common image file types in page, layouts & component directories.
![image](https://github.com/kodadot/nft-gallery/assets/22052693/d72801bb-f998-420f-bd67-efcd681cea8a)

- Updated STYLE_GUIDE.md with new conventions as mentioned in #6707 & #6708
![image](https://github.com/kodadot/nft-gallery/assets/22052693/9f306637-c894-4636-976d-3660b6619cfb)
![image](https://github.com/kodadot/nft-gallery/assets/22052693/fec14143-335a-42c8-a9cd-8ad8a1f4099f)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 50d178b</samp>

This pull request enhances the style guide for image handling and adds a linting rule to enforce it. It aims to improve the performance and accessibility of the NFT gallery website by using HTML tags and URL paths for images instead of JavaScript imports.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 50d178b</samp>

> _`ESLint` warns us_
> _Images in JavaScript_
> _Harm the web in spring_