### PR TITLE
:wastebasket: remove on-finality RPC nodes

### DIFF
--- a/libs/static/src/endpoints.ts
+++ b/libs/static/src/endpoints.ts
@@ -8,7 +8,6 @@ const KUSAMA_ENDPOINTS: WS_URL[] = [
   'wss://rpc.ibp.network/kusama',
   'wss://rpc.dotters.network/kusama',
   'wss://1rpc.io/ksm',
-  'wss://kusama.api.onfinality.io/public-ws',
   'wss://kusama-rpc.dwellir.com',
 ]
 
@@ -18,7 +17,6 @@ const POLKADOT_ENDPOINTS: WS_URL[] = [
   'wss://rpc.ibp.network/polkadot',
   'wss://rpc.dotters.network/polkadot',
   'wss://1rpc.io/dot',
-  'wss://polkadot.api.onfinality.io/public-ws',
   'wss://polkadot-rpc.dwellir.com',
 ]
 
@@ -36,7 +34,6 @@ export const ALTERNATIVE_ENDPOINT_MAP: Config<WS_URL[]> = {
     'wss://sys.ibp.network/statemine',
     'wss://sys.dotters.network/statemine',
     'wss://rpc-asset-hub-kusama.luckyfriday.io',
-    'wss://statemine.api.onfinality.io/public-ws',
     'wss://statemine.public.curie.radiumblock.co/ws',
   ],
   dot: POLKADOT_ENDPOINTS,
@@ -46,7 +43,6 @@ export const ALTERNATIVE_ENDPOINT_MAP: Config<WS_URL[]> = {
     'wss://statemint-rpc-tn.dwellir.com',
     'wss://sys.ibp.network/statemint',
     'wss://sys.dotters.network/statemint',
-    'wss://statemint.api.onfinality.io/public-ws',
   ],
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Chore

## Context

<img width="759" alt="Screenshot 2023-08-17 at 14 08 30" src="https://github.com/kodadot/nft-gallery/assets/22471030/087e8d6f-141e-46ab-af34-7aa1dad1229c">



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bec72bb</samp>

Removed OnFinality endpoints from `endpoints.ts` to improve NFT gallery reliability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bec72bb</samp>

> _`OnFinality` is gone, we don't need it anymore_
> _We purge the errors, we enhance the core_
> _Our gallery of NFTs, a shining display of art_
> _We defy the system, we tear it apart_
