### PR TITLE
fix: neo button hover color

### DIFF
--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -18,6 +18,7 @@
   &:hover {
     @include ktheme() {
       background: theme('k-accentHover');
+      color: theme('text-color');
     }
   }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6749
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="587" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/64573ecb-4289-428d-8b0f-5ad831c45fe6">
<img width="573" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/45f88bc0-c25b-4068-955d-afabed2999b0">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3211467</samp>

Added theme-based color to button text in `NeoButton.scss`. This improves the appearance and accessibility of the `NeoButton` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3211467</samp>

> _`color` for button_
> _theme function sets the hue_
> _dark mode adapts it_
