### PR TITLE
style: update table padding

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="gallery-activity-events-wrapper is-flex is-flex-direction-column">
-    <div class="events p-5 is-flex is-flex-direction-column">
+    <div class="events py-5 px-6 is-flex is-flex-direction-column">
       <div
         class="events-filter is-flex is-flex-wrap-wrap"
         data-cy="events-filter">

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -4,7 +4,7 @@
       v-if="events.length"
       :data="events"
       hoverable
-      class="p-5 padding-top-mobile">
+      class="py-5 padding-top-mobile">
       <!-- event name -->
       <NeoTableColumn
         v-slot="props"
@@ -167,6 +167,9 @@ const formatPrice = (price) => {
 
 .gallery-item-activity-table {
   overflow-y: auto;
+  :deep table tr > *:first-child {
+    padding-left: 2rem;
+  }
 }
 
 @include touch {

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -4,7 +4,7 @@
       v-if="events.length"
       :data="events"
       hoverable
-      class="py-5 padding-top-mobile">
+      class="py-5 padding-top-mobile px-5">
       <!-- event name -->
       <NeoTableColumn
         v-slot="props"

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -4,7 +4,7 @@
       v-if="events.length"
       :data="events"
       hoverable
-      class="py-5 padding-top-mobile px-5">
+      class="p-5 padding-top-mobile">
       <!-- event name -->
       <NeoTableColumn
         v-slot="props"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6743
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1516" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/c1f5afcc-dc2c-4b99-9910-d5bf7d4cb054">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e62bb13</samp>

Increased the padding of some components in the `GalleryItemActivity` tab to improve the layout and alignment with the design. Modified `GalleryItemActivity.vue` and `GalleryItemActivityTable.vue` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e62bb13</samp>

> _`padding` adjusts_
> _more space and consistency_
> _autumn design breathes_
