### PR TITLE
fix: console warn

### DIFF
--- a/components/landing/FeaturedArticles.vue
+++ b/components/landing/FeaturedArticles.vue
@@ -5,7 +5,7 @@
     <div class="columns">
       <div v-for="article in articles" :key="article.title" class="column">
         <CardArticle
-          v-safe-href="article.link"
+          :href="article.link"
           :description="article.description"
           :image="article.image"
           :title="article.title" />

--- a/components/landing/FeaturedArticles.vue
+++ b/components/landing/FeaturedArticles.vue
@@ -5,7 +5,7 @@
     <div class="columns">
       <div v-for="article in articles" :key="article.title" class="column">
         <CardArticle
-          :href="article.link"
+          :link="article.link"
           :description="article.description"
           :image="article.image"
           :title="article.title" />

--- a/libs/ui/src/components/CardArticle/CardArticle.story.vue
+++ b/libs/ui/src/components/CardArticle/CardArticle.story.vue
@@ -1,7 +1,7 @@
 <template>
   <Story>
     <CardArticle
-      v-safe-href="href"
+      :href="href"
       :description="description"
       :image="image"
       :title="title" />

--- a/libs/ui/src/components/CardArticle/CardArticle.story.vue
+++ b/libs/ui/src/components/CardArticle/CardArticle.story.vue
@@ -1,7 +1,7 @@
 <template>
   <Story>
     <CardArticle
-      :href="href"
+      :link="href"
       :description="description"
       :image="image"
       :title="title" />

--- a/libs/ui/src/components/CardArticle/CardArticle.vue
+++ b/libs/ui/src/components/CardArticle/CardArticle.vue
@@ -1,6 +1,6 @@
 <template>
   <a
-    v-safe-href="href"
+    v-safe-href="link"
     class="article"
     target="_blank"
     rel="nofollow noopener noreferrer">
@@ -20,7 +20,7 @@
 
 <script lang="ts" setup>
 defineProps<{
-  href: string
+  link: string
   image: string
   title: string
   description: string


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

related with prev pr #6709

<img width="595" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/3d451f3d-2c9a-4374-80f3-30e613f46f90">

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [ ] Closes #<issue_number>
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 366ffe4</samp>

Replaced `v-safe-href` directive with `:href` prop in `CardArticle` component and its story. This is to fix broken links and align with the latest `ui` library update.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 366ffe4</samp>

> _`v-safe-href` gone_
> _`CardArticle` uses `:href`_
> _Autumn leaves Storybook_