### PR TITLE
fix: Sidebar strip when active

### DIFF
--- a/libs/ui/src/components/NeoModalExtend/plugin.js
+++ b/libs/ui/src/components/NeoModalExtend/plugin.js
@@ -18,6 +18,7 @@ const ModalProgrammatic = {
 
     const defaultParam = {
       programmatic: { instances },
+      scroll: 'clip',
     }
     if (params.parent) {
       parent = params.parent


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6762
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1e23c8</samp>

Added a scroll option to the `NeoModalExtend` component to handle modal content overflow. This improves the modal UI and UX for the NFT gallery app.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a1e23c8</samp>

> _`modal` component_
> _adds a scroll option now_
> _clips the overflow_
