### PR TITLE
refactor(BaseCollectionForm): to compositionApi

### DIFF
--- a/components/base/BaseCollectionForm.vue
+++ b/components/base/BaseCollectionForm.vue
@@ -48,6 +48,7 @@ import { NeoField } from '@kodadot1/brick'
 import Auth from '@/components/shared/Auth.vue'
 import MetadataUpload from '@/components/shared/DropUpload.vue'
 import BasicInput from '@/components/shared/form/BasicInput.vue'
+import { useVModel } from '@vueuse/core'
 
 const props = defineProps({
   label: {
@@ -61,26 +62,11 @@ const props = defineProps({
 })
 const emit = defineEmits(['update:name', 'update:description', 'update:file'])
 
-const vName = computed({
-  get: () => props.name,
-  set: (value) => {
-    emit('update:name', value)
-  },
-})
+const vName = useVModel(props, 'name', emit)
 
-const vDescription = computed({
-  get: () => props.description,
-  set: (value) => {
-    emit('update:description', value)
-  },
-})
+const vDescription = useVModel(props, 'description', emit)
 
-const vFile = computed({
-  get: () => props.file,
-  set: (value) => {
-    emit('update:file', value)
-  },
-})
+const vFile = useVModel(props, 'file', emit)
 
 const collectionName = ref<typeof BasicInput>()
 const collectionImage = ref<typeof MetadataUpload>()

--- a/components/base/BaseCollectionForm.vue
+++ b/components/base/BaseCollectionForm.vue
@@ -44,7 +44,6 @@
 </template>
 
 <script setup lang="ts">
-import { Ref, ref, toRefs } from 'vue'
 import { NeoField } from '@kodadot1/brick'
 import Auth from '@/components/shared/Auth.vue'
 import MetadataUpload from '@/components/shared/DropUpload.vue'

--- a/components/base/BaseCollectionForm.vue
+++ b/components/base/BaseCollectionForm.vue
@@ -43,32 +43,55 @@
   </div>
 </template>
 
-<script lang="ts">
-import { Component, Prop, PropSync, Ref, Vue } from 'nuxt-property-decorator'
+<script setup lang="ts">
+import { Ref, ref, toRefs } from 'vue'
 import { NeoField } from '@kodadot1/brick'
+import Auth from '@/components/shared/Auth.vue'
+import MetadataUpload from '@/components/shared/DropUpload.vue'
+import BasicInput from '@/components/shared/form/BasicInput.vue'
 
-const components = {
-  Auth: () => import('@/components/shared/Auth.vue'),
-  MetadataUpload: () => import('@/components/shared/DropUpload.vue'),
-  BasicInput: () => import('@/components/shared/form/BasicInput.vue'),
-  NeoField,
+const props = defineProps({
+  label: {
+    type: String,
+    default: 'mint.collection.create',
+  },
+  protectiveMargin: Boolean,
+  name: String,
+  description: String,
+  file: Blob,
+})
+const emit = defineEmits(['update:name', 'update:description', 'update:file'])
+
+const vName = computed({
+  get: () => props.name,
+  set: (value) => {
+    emit('update:name', value)
+  },
+})
+
+const vDescription = computed({
+  get: () => props.description,
+  set: (value) => {
+    emit('update:description', value)
+  },
+})
+
+const vFile = computed({
+  get: () => props.file,
+  set: (value) => {
+    emit('update:file', value)
+  },
+})
+
+const collectionName = ref<typeof BasicInput>()
+const collectionImage = ref<typeof MetadataUpload>()
+
+const checkValidity = () => {
+  return (
+    collectionImage.value?.checkValidity() &&
+    collectionName.value?.checkValidity()
+  )
 }
 
-@Component({ components })
-export default class BaseCollectionForm extends Vue {
-  @Prop({ type: String, default: 'mint.collection.create' }) label!: string
-  @Prop(Boolean) protectiveMargin!: boolean
-  @PropSync('name', { type: String }) vName!: string
-  @PropSync('description', { type: String }) vDescription!: string
-  @PropSync('file', { type: Blob }) vFile!: Blob | null
-
-  @Ref('collectionName') readonly collectionName
-  @Ref('collectionImage') readonly collectionImage
-  public checkValidity() {
-    return (
-      this.collectionImage.checkValidity() &&
-      this.collectionName.checkValidity()
-    )
-  }
-}
+defineExpose({ checkValidity })
 </script>


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Related with #4750 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

Refactored the code for opening the shopping cart modal from the navbar. Moved the logic and configuration from `ShoppingCartModalConfig.ts` and `ShoppingCartButton.vue` to `Navbar.vue` to improve code organization and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

> _`ShoppingCartButton`_
> _Simpler, no more `emit` -_
> _Autumn leaves falling_
