### PR TITLE
refactor(BaseTokenForm): to compositionApi

### DIFF
--- a/components/base/BaseTokenForm.vue
+++ b/components/base/BaseTokenForm.vue
@@ -85,6 +85,7 @@ import MetadataUpload from '@/components/shared/DropUpload.vue'
 import BasicInput from '@/components/shared/form/BasicInput.vue'
 import BasicNumberInput from '@/components/shared/form/BasicNumberInput.vue'
 import CollectionSelect from '@/components/base/CollectionSelect.vue'
+import { useVModel } from '@vueuse/core'
 
 const props = defineProps({
   label: {
@@ -123,35 +124,17 @@ const emit = defineEmits([
 const nftName = ref<typeof BasicInput>()
 const upload = ref<typeof MetadataUpload>()
 
-const vName = computed({
-  get: () => props.name,
-  set: (value) => emit('update:name', value),
-})
+const vName = useVModel(props, 'name', emit)
 
-const vDescription = computed({
-  get: () => props.description,
-  set: (value) => emit('update:description', value),
-})
+const vDescription = useVModel(props, 'description', emit)
 
-const vFile = computed({
-  get: () => props.file,
-  set: (value) => emit('update:file', value),
-})
+const vFile = useVModel(props, 'file', emit)
 
-const vSelectedCollection = computed({
-  get: () => props.selectedCollection,
-  set: (value) => emit('update:selectedCollection', value),
-})
+const vSelectedCollection = useVModel(props, 'selectedCollection', emit)
 
-const vCopies = computed({
-  get: () => props.copies,
-  set: (value) => emit('update:copies', value),
-})
+const vCopies = useVModel(props, 'copies', emit)
 
-const vSecondFile = computed({
-  get: () => props.secondFile,
-  set: (value) => emit('update:secondFile', value),
-})
+const vSecondFile = useVModel(props, 'secondFile', emit)
 
 const checkValidity = () => {
   const nftNameValid = nftName.value?.checkValidity()

--- a/components/base/BaseTokenForm.vue
+++ b/components/base/BaseTokenForm.vue
@@ -74,61 +74,103 @@
   </div>
 </template>
 
-<script lang="ts">
-import { Component, Prop, PropSync, Ref, Vue } from 'nuxt-property-decorator'
+<script setup lang="ts">
+import { computed, defineEmits, defineProps, ref } from 'vue'
 import { MediaType } from '../rmrk/types'
 import { resolveMedia } from '../rmrk/utils'
 import { BaseMintedCollection as MintedCollection } from './types'
 import { NeoField } from '@kodadot1/brick'
+import Auth from '@/components/shared/Auth.vue'
+import MetadataUpload from '@/components/shared/DropUpload.vue'
+import BasicInput from '@/components/shared/form/BasicInput.vue'
+import BasicNumberInput from '@/components/shared/form/BasicNumberInput.vue'
+import CollectionSelect from '@/components/base/CollectionSelect.vue'
 
-const components = {
-  Auth: () => import('@/components/shared/Auth.vue'),
-  MetadataUpload: () => import('@/components/shared/DropUpload.vue'),
-  BasicInput: () => import('@/components/shared/form/BasicInput.vue'),
-  BasicNumberInput: () =>
-    import('@/components/shared/form/BasicNumberInput.vue'),
-  CollectionSelect: () => import('@/components/base/CollectionSelect.vue'),
-  NeoField,
+const props = defineProps({
+  label: {
+    type: String,
+    default: 'context',
+  },
+  collections: {
+    type: Array,
+    default: () => [],
+  },
+  hasCopies: {
+    type: Boolean,
+    default: true,
+  },
+  showExplainerText: {
+    type: Boolean,
+    default: false,
+  },
+  name: String,
+  description: String,
+  file: Blob,
+  selectedCollection: Object,
+  copies: Number,
+  secondFile: Blob,
+})
+
+const emit = defineEmits([
+  'update:name',
+  'update:description',
+  'update:file',
+  'update:selectedCollection',
+  'update:copies',
+  'update:secondFile',
+])
+
+const nftName = ref<typeof BasicInput>()
+const upload = ref<typeof MetadataUpload>()
+
+const vName = computed({
+  get: () => props.name,
+  set: (value) => emit('update:name', value),
+})
+
+const vDescription = computed({
+  get: () => props.description,
+  set: (value) => emit('update:description', value),
+})
+
+const vFile = computed({
+  get: () => props.file,
+  set: (value) => emit('update:file', value),
+})
+
+const vSelectedCollection = computed({
+  get: () => props.selectedCollection,
+  set: (value) => emit('update:selectedCollection', value),
+})
+
+const vCopies = computed({
+  get: () => props.copies,
+  set: (value) => emit('update:copies', value),
+})
+
+const vSecondFile = computed({
+  get: () => props.secondFile,
+  set: (value) => emit('update:secondFile', value),
+})
+
+const checkValidity = () => {
+  const nftNameValid = nftName.value?.checkValidity()
+  const uploadValid = upload.value?.checkValidity()
+  return nftNameValid && uploadValid
 }
 
-@Component({ components })
-export default class BaseTokenForm extends Vue {
-  @Prop({ type: String, default: 'context' }) label!: string
-  @Prop({ type: Array, default: () => [] }) collections!: MintedCollection[]
-  @Prop({ type: Boolean, default: true }) hasCopies!: boolean
-  @Prop({ type: Boolean, default: false }) showExplainerText!: boolean
-
-  @PropSync('name', { type: String }) vName!: string
-  @PropSync('description', { type: String }) vDescription!: string
-  @PropSync('file', { type: Blob }) vFile!: Blob | null
-  @PropSync('selectedCollection') vSelectedCollection!: MintedCollection | null
-  @PropSync('copies', { type: Number }) vCopies!: number
-  @PropSync('secondFile', { type: Blob }) vSecondFile!: Blob | null
-  @Ref('nftName') readonly nftName
-  @Ref('upload') readonly upload
-
-  public checkValidity() {
-    const nftNameValid = this.nftName.checkValidity()
-    const uploadValid = this.upload.checkValidity()
-    return nftNameValid && uploadValid
-  }
-
-  public onCollectionSelected(collection) {
-    this.vSelectedCollection = collection
-  }
-
-  get clickableMax() {
-    return Infinity
-    // return (this.max || Infinity) - this.alreadyMinted
-  }
-
-  get fileType() {
-    return resolveMedia(this.vFile?.type)
-  }
-
-  get secondaryFileVisible() {
-    const fileType = this.fileType
-    return ![MediaType.UNKNOWN, MediaType.IMAGE].some((t) => t === fileType)
-  }
+const onCollectionSelected = (collection: MintedCollection) => {
+  vSelectedCollection.value = collection
 }
+
+const clickableMax = ref(Infinity)
+
+const fileType = computed(() => resolveMedia(vFile.value?.type))
+
+const secondaryFileVisible = computed(() => {
+  const ft = fileType.value
+  return ![MediaType.UNKNOWN, MediaType.IMAGE].some((t) => t === ft)
+})
+
+defineExpose({ checkValidity })
 </script>

--- a/components/base/BaseTokenForm.vue
+++ b/components/base/BaseTokenForm.vue
@@ -75,7 +75,6 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineEmits, defineProps, ref } from 'vue'
 import { MediaType } from '../rmrk/types'
 import { resolveMedia } from '../rmrk/utils'
 import { BaseMintedCollection as MintedCollection } from './types'


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Related with #4750 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

Refactored the code for opening the shopping cart modal from the navbar. Moved the logic and configuration from `ShoppingCartModalConfig.ts` and `ShoppingCartButton.vue` to `Navbar.vue` to improve code organization and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

> _`ShoppingCartButton`_
> _Simpler, no more `emit` -_
> _Autumn leaves falling_
