### PR TITLE
fix: token symbol on carousel

### DIFF
--- a/components/carousel/module/CarouselInfo.vue
+++ b/components/carousel/module/CarouselInfo.vue
@@ -35,22 +35,23 @@
           ? 'is-justify-content-space-between'
           : 'is-justify-content-end',
       ]">
-      <CommonTokenMoney
+      <Money
         v-if="showPrice"
-        :custom-token-id="getTokenId(item.chain)"
-        :value="item.price" />
+        :value="item.price"
+        inline
+        :unit-symbol="unitSymbol" />
       <p class="is-size-7 chain-name">{{ chainName }}</p>
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import CommonTokenMoney from '@/components/shared/CommonTokenMoney.vue'
+import Money from '@/components/shared/format/Money.vue'
 import type { CarouselNFT } from '@/components/base/types'
-import { getKusamaAssetId } from '@/utils/api/bsx/query'
 
 import { useCarouselUrl } from '../utils/useCarousel'
 import { NAMES } from '@/libs/static/src/names'
+import { prefixToToken } from '@/components/common/shoppingCart/utils'
 
 const CollectionDetailsPopover = defineAsyncComponent(
   () =>
@@ -71,7 +72,6 @@ const chainName = computed(() => {
 const showPrice = computed((): boolean => {
   return Number(props.item.price) > 0 && !isCollection
 })
-const getTokenId = (chain?: string) => {
-  return chain && getKusamaAssetId(chain)
-}
+
+const unitSymbol = computed(() => prefixToToken[props.item.chain || 'ksm'])
 </script>

--- a/components/common/shoppingCart/utils.ts
+++ b/components/common/shoppingCart/utils.ts
@@ -10,6 +10,7 @@ export const prefixToToken = {
   bsx: 'KSM',
   snek: 'KSM',
   ahk: 'KSM',
+  ahp: 'DOT',
   dot: 'DOT',
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Related: #6739

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1635735</samp>

Refactored carousel info component to use a more generic money component and simplified currency symbol logic. Removed unused code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1635735</samp>

> _We're sailing on the blockchain, me hearties, yo ho ho_
> _We've got to keep our code clean and tidy, don't you know_
> _We've swapped `CommonTokenMoney` for `Money`, that's the way_
> _We've simplified the currency symbol, hip hooray_
