### PR TITLE
refactor(AttributeInput): to compositionApi

### DIFF
--- a/components/rmrk/Create/AttributeInput.vue
+++ b/components/rmrk/Create/AttributeInput.vue
@@ -21,26 +21,30 @@
   </NeoField>
 </template>
 
-<script lang="ts">
-import { Component, Emit, Prop, PropSync, Vue } from 'nuxt-property-decorator'
+<script setup lang="ts">
 import { NeoButton, NeoField, NeoInput } from '@kodadot1/brick'
+import { useVModel } from '@vueuse/core'
 
-@Component({
-  components: {
-    NeoButton,
-    NeoField,
-    NeoInput,
+const props = defineProps({
+  index: Number,
+  disabled: Boolean,
+  trait_type: {
+    type: String,
+    default: '',
+  },
+  value: {
+    type: [String, Number],
+    default: '',
   },
 })
-export default class AttributeInput extends Vue {
-  @Prop(Number) index!: number
-  @Prop(Boolean) disabled!: boolean
-  @PropSync('trait_type', { type: String }) vKey!: string
-  @PropSync('value', { type: [String, Number] }) vValue!: string | number
 
-  @Emit('remove')
-  protected remove() {
-    return this.index
-  }
+const emit = defineEmits(['remove', 'update:trait_type', 'update:value'])
+
+const vKey = useVModel(props, 'trait_type', emit)
+
+const vValue = useVModel(props, 'value', emit)
+
+const remove = () => {
+  emit('remove', props.index)
 }
 </script>


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Related with #4750 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

Refactored the code for opening the shopping cart modal from the navbar. Moved the logic and configuration from `ShoppingCartModalConfig.ts` and `ShoppingCartButton.vue` to `Navbar.vue` to improve code organization and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 769abca</samp>

> _`ShoppingCartButton`_
> _Simpler, no more `emit` -_
> _Autumn leaves falling_
