### PR TITLE
feat: Show royalty recipient in the Gallery Item

### DIFF
--- a/components/gallery/GalleryItemDescription.vue
+++ b/components/gallery/GalleryItemDescription.vue
@@ -87,7 +87,7 @@
       <div
         v-if="nft?.recipient"
         class="is-flex is-justify-content-space-between">
-        <p>{{ $t('tabs.tabDetails.royaltyRecipient') }}</p>
+        <p>{{ $t('transfers.recipient') }}</p>
         <nuxt-link
           :to="`/${urlPrefix}/u/${nft?.recipient}`"
           class="has-text-link">

--- a/components/gallery/GalleryItemDescription.vue
+++ b/components/gallery/GalleryItemDescription.vue
@@ -83,6 +83,18 @@
         <p>{{ $t('tabs.tabDetails.royalties') }}</p>
         <p>{{ nft?.royalty }}%</p>
       </div>
+
+      <div
+        v-if="nft?.recipient"
+        class="is-flex is-justify-content-space-between">
+        <p>{{ $t('tabs.tabDetails.royaltyRecipient') }}</p>
+        <nuxt-link
+          :to="`/${urlPrefix}/u/${nft?.recipient}`"
+          class="has-text-link">
+          <Identity ref="identity" :address="nft?.recipient" />
+        </nuxt-link>
+      </div>
+
       <hr class="my-2" />
       <div v-if="nftImage" class="is-flex is-justify-content-space-between">
         <p>{{ $t('tabs.tabDetails.media') }}</p>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1051,6 +1051,7 @@
       "version": "Version",
       "tokenStandard": "Token Standard",
       "royalties": "Royalties",
+      "royaltyRecipient": "Royalty recipient",
       "media": "Media",
       "animatedMedia": "Animated Media",
       "metadata": "Metadata"

--- a/locales/en.json
+++ b/locales/en.json
@@ -1051,7 +1051,6 @@
       "version": "Version",
       "tokenStandard": "Token Standard",
       "royalties": "Royalties",
-      "royaltyRecipient": "Royalty recipient",
       "media": "Media",
       "animatedMedia": "Animated Media",
       "metadata": "Metadata"

--- a/queries/subsquid/ahk/nftById.graphql
+++ b/queries/subsquid/ahk/nftById.graphql
@@ -31,5 +31,6 @@ query nftById($id: String!) {
       }
     }
     royalty
+    recipient
   }
 }

--- a/queries/subsquid/general/nftById.graphql
+++ b/queries/subsquid/general/nftById.graphql
@@ -26,5 +26,6 @@ query nftById($id: String!) {
       }
     }
     royalty
+    recipient
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6787
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

<img width="421" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/cf6c0db7-0b27-4a08-84af-d8e2f68f96f1">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96251bc</samp>

This pull request adds a feature to show the royalty recipient of an NFT on the details page. It modifies the `GalleryItemDescription.vue` component, the `en.json` locale file, and the `nftById.graphql` query to display and fetch the recipient data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 96251bc</samp>

> _`recipient` field_
> _added to GraphQL query_
> _autumn of NFTs_
