### PR TITLE
fix: add alt tags to landing page images - lighthouse

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -152,7 +152,7 @@
         </ul>
       </div>
     </div>
-    <img src="/blurred-landing-footer.png" class="left-blurred-image" />
+    <img src="/blurred-landing-footer.png" class="left-blurred-image" alt="" />
   </footer>
 </template>
 

--- a/components/landing/SearchLanding.vue
+++ b/components/landing/SearchLanding.vue
@@ -1,7 +1,10 @@
 <template>
   <section class="landing-search is-flex is-align-items-center">
-    <img src="/landing-blurred-header-left.png" class="landing-search-left" />
-    <img :src="landingImage[0]" class="landing-shapes" />
+    <img
+      src="/landing-blurred-header-left.png"
+      class="landing-search-left"
+      alt="" />
+    <img :src="landingImage[0]" class="landing-shapes" alt="" />
     <div
       class="is-flex is-flex-direction-column is-align-items-center search-info">
       <h1
@@ -36,8 +39,11 @@
       </div>
       <UnlockableLandingTag />
     </div>
-    <img src="/landing-blurred-header-right.png" class="landing-search-right" />
-    <img :src="landingImage[1]" class="landing-shapes" />
+    <img
+      src="/landing-blurred-header-right.png"
+      class="landing-search-right"
+      alt="" />
+    <img :src="landingImage[1]" class="landing-shapes" alt="" />
   </section>
 </template>
 

--- a/components/navbar/ShoppingCartButton.vue
+++ b/components/navbar/ShoppingCartButton.vue
@@ -4,7 +4,10 @@
     @click="toggleShoppingCartModal">
     <span v-if="props.showLabel">{{ $t('shoppingCart.label') }}</span>
     <div class="is-relative" :class="{ 'ml-2': showLabel }">
-      <img :src="shoppingCartIcon" class="image is-24x24 align" />
+      <img
+        :src="shoppingCartIcon"
+        class="image is-24x24 align"
+        alt="open shopping cart" />
       <ActiveCount
         v-if="numberOfItems"
         :count="numberOfItems"

--- a/components/search/SearchBar.vue
+++ b/components/search/SearchBar.vue
@@ -48,11 +48,13 @@
     <img
       class="search-bar-keyboard-icon"
       :class="{ 'is-invisible': name || inputFocused }"
-      src="/search-k-keyboard.svg" />
+      src="/search-k-keyboard.svg"
+      alt="press k to focus search input" />
     <img
       class="search-bar-keyboard-icon"
       :class="{ 'is-invisible': !name && !inputFocused }"
-      src="/k-search-enter.svg" />
+      src="/k-search-enter.svg"
+      alt="press enter to start search" />
   </div>
 </template>
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6797 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- Added alt tags for required by lighthouse and empty alt tags for decorative images.
- Alt tags on functional images have functional descriptions for screen readers.
- Desktop & Mobile have been checked.

### Lighthouse report
![image](https://github.com/kodadot/nft-gallery/assets/22052693/80f4561a-49d6-444c-ba79-491528a10828)

### Tags used
| Images | Alt tag | Comment |
| -------- | ------- | ----------- |
| ![image](https://github.com/kodadot/nft-gallery/assets/22052693/e29b8df0-480e-4b91-9948-08542ba75c3c) |  open shopping cart  |
| ![image](https://github.com/kodadot/nft-gallery/assets/22052693/90df3430-01c9-4381-8a81-22d16d0b525b) | press k to focus search input |
| ![image](https://github.com/kodadot/nft-gallery/assets/22052693/39b3f0a4-1e17-4dfb-8bca-71c9f7b12f2e) | press enter to start search |
| ![image](https://github.com/kodadot/nft-gallery/assets/22052693/79503ebb-e7c4-4dcf-aee9-1ef7f8ee7f85) | / | decorative |
| ![image](https://github.com/kodadot/nft-gallery/assets/22052693/14c8a4aa-b362-458d-90a5-07f5be0f366c) | / | decorative |

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a883a52</samp>

Added or improved `alt` attributes for `img` elements in various components to enhance accessibility and provide meaningful information for screen readers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a883a52</samp>

> _Oh we're the `alt` attribute crew_
> _We make the web more friendly and true_
> _For every `img` we have a task_
> _We heave away and haul on the `alt`_