### PR TITLE
ref(redirectAfterChainChange): Refactor redirect function redirectAfterChainChange 

### DIFF
--- a/composables/useChainRedirect.ts
+++ b/composables/useChainRedirect.ts
@@ -4,6 +4,7 @@ import {
   createVisible,
   incomingOfferssVisible,
 } from '@/utils/config/permision.config'
+import { RawLocation } from 'vue-router/types/router'
 
 const NO_REDIRECT_ROUTE_NAMES = [
   'hot',
@@ -14,15 +15,61 @@ const NO_REDIRECT_ROUTE_NAMES = [
   'blog-slug',
 ]
 
+function isNoRedirect(routeName: string): boolean {
+  return NO_REDIRECT_ROUTE_NAMES.includes(routeName)
+}
+
+function getRedirectPathForPrefix({
+  routeName,
+  chain,
+  accountId,
+  route,
+}: {
+  routeName: string
+  chain: Prefix
+  accountId: string
+  route
+}): RawLocation {
+  if (routeName === 'prefix-u-id') {
+    return {
+      params: {
+        prefix: chain,
+        id: accountId,
+      },
+      query: route.query,
+    }
+  }
+
+  if (['prefix-gallery-id', 'prefix-collection-id'].includes(routeName)) {
+    const routeNameToRedirect = routeName.includes('gallery')
+      ? 'prefix-explore-items'
+      : 'prefix-explore-collectibles'
+
+    return {
+      name: routeNameToRedirect,
+      params: {
+        prefix: chain,
+      },
+    }
+  }
+
+  return {
+    params: {
+      prefix: chain,
+    },
+    query: route.query,
+  }
+}
+
 export default function () {
   const route = useRoute()
   const router = useRouter()
   const { accountId } = useAuth()
 
-  const redirectAfterChainChange = (newChain: Prefix) => {
+  const redirectAfterChainChange = (newChain: Prefix): void => {
     const routeName = route.name as string
 
-    if (NO_REDIRECT_ROUTE_NAMES.includes(routeName)) {
+    if (isNoRedirect(routeName)) {
       return
     }
 
@@ -30,53 +77,24 @@ export default function () {
     const isSimpleCreate = routeName.includes('-create')
     const isIncomingOffers = routeName.includes('-incomingOffers')
 
+    let redirectLocation: RawLocation = { path: `/${newChain}` }
+
     if (route.params.prefix) {
-      if (routeName === 'prefix-u-id') {
-        return router.push({
-          params: {
-            prefix: newChain,
-            id: accountId.value,
-          },
-          query: route.query,
-        })
-      }
-
-      if (['prefix-gallery-id', 'prefix-collection-id'].includes(routeName)) {
-        const routeNameToRiredrect = routeName.includes('gallery')
-          ? 'prefix-explore-items'
-          : 'prefix-explore-collectibles'
-
-        return router.push({
-          name: routeNameToRiredrect,
-          params: {
-            prefix: newChain,
-          },
-        })
-      }
-
-      router.push({
-        params: {
-          prefix: newChain,
-        },
-        query: route.query,
+      redirectLocation = getRedirectPathForPrefix({
+        routeName,
+        chain: newChain,
+        accountId: accountId.value,
+        route,
       })
     } else if (isAssets && assetsVisible(newChain)) {
-      router.push({
-        path: `/${newChain}/assets`,
-      })
+      redirectLocation = { path: `/${newChain}/assets` }
     } else if (isSimpleCreate && createVisible(newChain)) {
-      router.push({
-        path: `/${newChain}/create`,
-      })
+      redirectLocation = { path: `/${newChain}/create` }
     } else if (isIncomingOffers && incomingOfferssVisible(newChain)) {
-      router.push({
-        path: `/${newChain}/incomingoffers`,
-      })
-    } else {
-      router.push({
-        path: `/${newChain}`,
-      })
+      redirectLocation = { path: `/${newChain}/incomingoffers` }
     }
+
+    router.push(redirectLocation)
   }
 
   return {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #6746
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0395aed</samp>

Refactored `useChainRedirect` composable to simplify redirection logic for different chains. Added type import and helper functions to `composables/useChainRedirect.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0395aed</samp>

> _We're sailing on the web with `useChainRedirect`_
> _We need to handle routes with different prefixes_
> _So we import a type and add two helpers_
> _And refactor the code to make it simpler_


