### PR TITLE
feat: set maximum card num to 3

### DIFF
--- a/components/carousel/CarouselIndex.vue
+++ b/components/carousel/CarouselIndex.vue
@@ -40,14 +40,8 @@ const showCarousel = computed(() => props.nfts.length)
 
 const { width } = useWindowSize()
 const steps = computed(() => {
-  if (width.value > 1540) {
-    return 6
-  }
   if (width.value > 1280) {
-    return 5
-  }
-  if (width.value > 1024) {
-    return 4
+    return 3
   }
   if (width.value > 768) {
     return 2

--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -70,7 +70,7 @@ const [wrapper, slider] = useKeenSlider(
         slides: { perView: 2.5, spacing: 32 },
       },
       '(min-width: 1280px)': {
-        slides: { perView: 3.5, spacing: 32 },
+        slides: { perView: 3, spacing: 32 },
       },
     },
     slides: { perView: 1.5, spacing: 32 },

--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -69,14 +69,8 @@ const [wrapper, slider] = useKeenSlider(
       '(min-width: 768px)': {
         slides: { perView: 2.5, spacing: 32 },
       },
-      '(min-width: 1024px)': {
-        slides: { perView: 4, spacing: 32 },
-      },
       '(min-width: 1280px)': {
-        slides: { perView: 5, spacing: 32 },
-      },
-      '(min-width: 1540px)': {
-        slides: { perView: 6, spacing: 32 },
+        slides: { perView: 3.5, spacing: 32 },
       },
     },
     slides: { perView: 1.5, spacing: 32 },


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #6747
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1522" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/b2ea04bb-8b4d-4ec6-ad64-d09672da70fc">

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b63745</samp>

Reduced the number of carousel items at different screen widths and updated the options for both `CarouselIndex.vue` and `CarouselAgnostic.vue` to improve responsiveness and usability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5b63745</samp>

> _`steps` and `slides` change_
> _carousel adapts to screens_
> _autumn leaves align_
