### PR TITLE
fix: pass env on generate

### DIFF
--- a/script/generate.mjs
+++ b/script/generate.mjs
@@ -17,7 +17,11 @@ async function runScript() {
 
   console.log(pnpmPath)
 
-  const generate = spawn(pnpmPath, ['generate:script'])
+  const generate = spawn(pnpmPath, ['generate:script'], {
+    env: {
+      ...process.env,
+    },
+  })
 
   generate.stdout.on('data', (data) => {
     console.log(`stdout: ${data}`)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #6811
- [x] root cause https://github.com/kodadot/nft-gallery/pull/6690. need to pass env params in `spawn` commands

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
copilot:summary

copilot:poem
