### PR TITLE
fix(useRedirectModal): Switch button items and activity at collection view opens new page and cart button on explorer too

### DIFF
--- a/components/redirect/useRedirectModal.ts
+++ b/components/redirect/useRedirectModal.ts
@@ -6,7 +6,7 @@ import {
   isExternal,
 } from '@/utils/url'
 import { useEventListener } from '@vueuse/core'
-import { Ref } from 'vue/types'
+import type { Ref } from 'vue/types'
 
 function isWhiteList(url: string) {
   const urlObj = new URL(url)

--- a/components/redirect/useRedirectModal.ts
+++ b/components/redirect/useRedirectModal.ts
@@ -6,6 +6,7 @@ import {
   isExternal,
 } from '@/utils/url'
 import { useEventListener } from '@vueuse/core'
+import { Ref } from 'vue/types'
 
 function isWhiteList(url: string) {
   const urlObj = new URL(url)
@@ -37,9 +38,8 @@ const showModal = (url: string, i18n: VueI18n, modal) => {
   })
 }
 
-export const useRedirectModal = (target: string) => {
+export const useRedirectModal = (element: Ref<HTMLElement | null>) => {
   const { $i18n, $neoModal } = useNuxtApp()
-  const _dom = computed(() => document.querySelector(target) || document.body)
 
   const handleLink = (event: Event) => {
     let ele = event.target as HTMLLinkElement
@@ -56,7 +56,7 @@ export const useRedirectModal = (target: string) => {
     }
   }
 
-  useEventListener(_dom.value, 'click', handleLink)
+  useEventListener(element, 'click', handleLink)
 }
 
 export default useRedirectModal

--- a/components/shared/Markdown.vue
+++ b/components/shared/Markdown.vue
@@ -1,5 +1,6 @@
 <template>
   <VueMarkdown
+    ref="markdown"
     :source="source"
     :options="highlightOptions"
     class="content-markdown" />
@@ -10,11 +11,13 @@ import VueMarkdown from 'vue-markdown-render'
 import hljs from 'highlight.js'
 import { useRedirectModal } from '@/components/redirect/useRedirectModal'
 
+const markdown = ref<HTMLElement | null>(null)
+
 defineProps<{
   source: string
 }>()
 
-useRedirectModal('.content-markdown')
+useRedirectModal(markdown)
 
 const highlightOptions = {
   html: true,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

The event listener inside `useRedirectModal` was affecting the entire website and not just the items inside the target node in this case the .content-markdown

- [x] Closes #6817
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸


https://github.com/kodadot/nft-gallery/assets/44554284/8810b840-d0b7-4091-8225-c04b2af9ff11



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7afa09a</samp>

Improved the `useRedirectModal` function to use element references and added a link confirmation feature to the `Markdown` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7afa09a</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who made the code more swift and error-free_
> _By using `ref` and `useRedirectModal`_
> _To handle links with grace and clarity_


