### PR TITLE
refactor(BasicNumberInput): to composition api

### DIFF
--- a/components/shared/form/BasicNumberInput.vue
+++ b/components/shared/form/BasicNumberInput.vue
@@ -21,30 +21,35 @@
   </NeoField>
 </template>
 
-<script lang="ts">
-import { Component, Prop, VModel, Vue } from 'nuxt-property-decorator'
+<script lang="ts" setup>
 import { NeoField, NeoInput } from '@kodadot1/brick'
 
-@Component({
-  components: {
-    NeoField,
-    NeoInput,
-  },
-})
-export default class BasicNumberInput extends Vue {
-  // Dev: make vValue required
-  @VModel({ type: Number }) vValue!: number
-  @Prop({ type: String, required: true }) label!: string
-  @Prop({ type: String, required: false }) placeholder!: string
-  @Prop({ type: Boolean, default: false }) expanded!: boolean
-  @Prop({ type: String }) message!: string
-  @Prop({ type: Number, required: false }) max!: number
-  @Prop({ type: Number, required: false, default: 1 }) min!: number
-  @Prop({ type: Number, required: false, default: 1 }) step!: number
-  @Prop({ type: Number, required: false }) minStep!: number
+const props = withDefaults(
+  defineProps<{
+    value: number
+    label: string
+    placeholder?: string
+    expanded?: boolean
+    message?: string
+    max?: number
+    min?: number
+    step?: number
+    minStep?: number
+  }>(),
+  {
+    expanded: false,
+    min: 1,
+    step: 1,
+  }
+)
+const emit = defineEmits(['input'])
 
-  public hasFocus = false
-}
+const vValue = computed({
+  get: () => props.value,
+  set: (value: number) => emit('input', value),
+})
+
+const hasFocus = ref(false)
 </script>
 
 <style scoped>

--- a/components/shared/form/BasicNumberInput.vue
+++ b/components/shared/form/BasicNumberInput.vue
@@ -44,10 +44,7 @@ const props = withDefaults(
 )
 const emit = defineEmits(['input'])
 
-const vValue = computed({
-  get: () => props.value,
-  set: (value: number) => emit('input', value),
-})
+const vValue = useVModel(props, 'value', emit, { eventName: 'input' })
 
 const hasFocus = ref(false)
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Related wtih #4750 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=12RA5J7wGg6bDWPTZG359Pn5bCzXSJRfsifo3UktqVAjhJ9k&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c3cecd</samp>

Refactored `BasicNumberInput.vue` to use Vue 3 Composition API. Removed VModel and Prop decorators and replaced them with defineProps, defineEmits, and computed helpers. Improved code readability and TypeScript support.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8c3cecd</samp>

> _`BasicNumberInput`_
> _Composed with new Vue syntax_
> _Spring of refactoring_