### PR TITLE
fix: Footer shows i18n object instead of translated string

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -643,11 +643,6 @@
     "totalSoldItems": "Σ verkaufter Artikel",
     "totalHoldingsBoughtValues": "Ausgegebene KSM für die NFTs im Konto"
   },
-  "tutorial": {
-    "create": "1. Erstelle ein polkadot.js Konto",
-    "ksm": "2. Besorge KSM",
-    "mint": "3. Minten"
-  },
   "general": {
     "apply": "Anwenden",
     "using": "benutzen",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  - [ ] Refactoring

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #6733
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI
  
German language

<img width="866" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/9b9b3a08-1e06-42b4-81b1-589fa7c799df">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  