### PR TITLE
fix: update accessibility issues - lighthouse #6838

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -135,7 +135,7 @@
                   <path
                     fill-rule="evenodd"
                     clip-rule="evenodd"
-                    d="M0 0h248V62.804H0V0ZM0 229.083h248V511.471L223.954 385.808L0 511.471V229.083ZM0 114.541h248V177.345H0V114.541Z"
+                    d="M0 0H448V62.804H0V0ZM0 229.083H448V511.471L223.954 385.808L0 511.471V229.083ZM0 114.541H448V177.345H0V114.541Z"
                     fill="currentColor" />
                 </g>
                 <defs>

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -2,10 +2,10 @@
   <footer class="footer-container section">
     <div
       class="footer-container-inner is-flex is-align-items-start is-justify-content-space-between">
-      <div class="footer-container-subs is-flex is-flex-direction-column">
-        <h4 class="subtitle is-5">
+      <section class="footer-container-subs is-flex is-flex-direction-column">
+        <h2 class="subtitle is-5">
           {{ $t('footer.subscribe') }}
-        </h4>
+        </h2>
         <div class="is-flex is-align-items-center footer-container-subs-items">
           <div id="custom-substack-embed"></div>
 
@@ -24,9 +24,9 @@
           </script>
           <script src="https://substackapi.com/widget.js" async></script>
         </div>
-      </div>
-      <div class="footer-container-info is-flex is-flex-direction-column">
-        <h4 class="subtitle is-5">Incentives</h4>
+      </section>
+      <section class="footer-container-info is-flex is-flex-direction-column">
+        <h2 class="subtitle is-5">Incentives</h2>
         <div>
           <ul class="footer-container-list">
             <li
@@ -51,9 +51,9 @@
             </li>
           </ul>
         </div>
-      </div>
-      <div class="footer-container-info is-flex is-flex-direction-column">
-        <h4 class="subtitle is-5">Marketplace</h4>
+      </section>
+      <section class="footer-container-info is-flex is-flex-direction-column">
+        <h2 class="subtitle is-5">Marketplace</h2>
         <div>
           <ul class="footer-container-list">
             <li
@@ -78,9 +78,9 @@
             </li>
           </ul>
         </div>
-      </div>
-      <div class="footer-container-info is-flex is-flex-direction-column">
-        <h4 class="subtitle is-5">KodaDot</h4>
+      </section>
+      <section class="footer-container-info is-flex is-flex-direction-column">
+        <h2 class="subtitle is-5">KodaDot</h2>
         <div>
           <ul class="footer-container-list">
             <li
@@ -105,12 +105,13 @@
             </li>
           </ul>
         </div>
-      </div>
+      </section>
 
-      <div class="footer-container-socials is-flex is-flex-direction-column">
-        <h4 class="subtitle is-5">
+      <section
+        class="footer-container-socials is-flex is-flex-direction-column">
+        <h2 class="subtitle is-5">
           {{ $t('footer.join') }}
-        </h4>
+        </h2>
         <ul class="footer-container-socials-list is-flex">
           <li
             v-for="item in socials"
@@ -120,6 +121,7 @@
             <a
               class="is-flex icon"
               rel="nofollow noopener noreferrer"
+              role="link"
               :aria-label="item.name">
               <!-- substack doesnt have a font awesome icon -->
               <svg
@@ -133,7 +135,7 @@
                   <path
                     fill-rule="evenodd"
                     clip-rule="evenodd"
-                    d="M0 0H448V62.804H0V0ZM0 229.083H448V511.471L223.954 385.808L0 511.471V229.083ZM0 114.541H448V177.345H0V114.541Z"
+                    d="M0 0h248V62.804H0V0ZM0 229.083h248V511.471L223.954 385.808L0 511.471V229.083ZM0 114.541h248V177.345H0V114.541Z"
                     fill="currentColor" />
                 </g>
                 <defs>
@@ -150,7 +152,7 @@
             </a>
           </li>
         </ul>
-      </div>
+      </section>
     </div>
     <img src="/blurred-landing-footer.png" class="left-blurred-image" alt="" />
   </footer>

--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -7,7 +7,7 @@
           :key="`${item.id}-${index}`"
           class="keen-slider__slide carousel-item">
           <div class="h-full is-flex is-flex-direction-column">
-            <CarouselMedia :item="item" />
+            <CarouselMedia :item="item" :index="index" :length="nfts.length" />
             <CarouselInfo :item="item" />
           </div>
         </div>

--- a/components/carousel/module/CarouselMedia.vue
+++ b/components/carousel/module/CarouselMedia.vue
@@ -4,6 +4,7 @@
     :class="{ 'carousel-media-collection': isCollection }">
     <nuxt-link
       :to="urlOf({ id: item.id, url, chain: item.chain })"
+      :aria-label="`slide ${index + 1} of ${length}`"
       rel="nofollow">
       <MediaItem
         class="carousel-media-wrapper"
@@ -24,6 +25,8 @@ import { useCarouselUrl } from '../utils/useCarousel'
 
 const props = defineProps<{
   item: CarouselNFT & NFTWithMetadata
+  index: number
+  length: number
 }>()
 
 const { urlOf } = useCarouselUrl()

--- a/components/navbar/ProfileDropdown.vue
+++ b/components/navbar/ProfileDropdown.vue
@@ -4,6 +4,7 @@
       v-if="account"
       class="navbar-item"
       role="button"
+      aria-label="open profile menu"
       @click="toggleWalletConnectModal">
       <Avatar :value="account" class="navbar__avatar-icon" :size="27" />
     </a>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6838 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

### Solutions
[aria-*] attributes do not match their roles

Added roles that are missing to the areas which been flagged by lighthouse.

Links do not have a discernible name

Added "slide n of n" as a aria-label to carousel media links. (Researched and found to be a good way)

Heading elements are not in a sequentially-descending order
Added semantic updates "section" and "h2" to sections & headings in footer.

### Lighthouse
New:
| Desktop | Mobile |
| --------- | -------- |
| ![image](https://github.com/kodadot/nft-gallery/assets/22052693/426ec7f3-cb10-451a-8109-c880df9e84ab) | ![image](https://github.com/kodadot/nft-gallery/assets/22052693/5d9df945-2c9a-408f-9a24-b0dbb9cc0fc2) |

Previous:
| Desktop | Mobile |
| --------- | -------- |
| ![image](https://github.com/kodadot/nft-gallery/assets/22052693/3a971086-00a5-4014-a1e2-473a7ca31dc3) | ![image](https://github.com/kodadot/nft-gallery/assets/22052693/8456e0a3-aea4-4d34-b625-9b6b015905d7) |

### Other
- For desktop there is a low contrast issue which is preventing 100% accessibility. Might need design intervention if we want to tackle this in future.
![image](https://github.com/kodadot/nft-gallery/assets/22052693/1badea37-7334-4347-81af-7f5f5c94d02b)

- I noticed on a few components the usage of "aria-role" attribute instead of just "role". I think this may have been a mistake and should be updated to "role"...

### Suggestion
Investigate ways to manage the score whilst developing new components so that it does not continuously creep down.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 709a249</samp>

Improved the accessibility of the carousel and the footer components by adding `aria-label` attributes, `role` attributes, and semantic HTML elements. Added props to the `<CarouselMedia>` component to display the current slide index and the total number of slides.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 709a249</samp>

> _We're making the web more accessible_
> _For every user and device_
> _We add `aria-label` and `role` attributes_
> _And we check our props and tags twice_














