### PR TITLE
fix: tooltip inside modal style

### DIFF
--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -80,7 +80,7 @@
               <NeoTooltip
                 :label="targetAddresses[0].address"
                 append-to-body
-                :content-class="`transfer-tooltip ${isMobile ? 'mobile' : ''}`">
+                content-class="transfer-tooltip">
                 <NeoIcon icon="circle-info" class="is-size-6" pack="far" />
               </NeoTooltip>
             </div>

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -80,7 +80,7 @@
               <NeoTooltip
                 :label="targetAddresses[0].address"
                 append-to-body
-                root-class="parent-z-index-auto">
+                :root-class="`parent-z-index-auto ${isMobile ? 'mobile' : ''}`">
                 <NeoIcon icon="circle-info" class="is-size-6" pack="far" />
               </NeoTooltip>
             </div>
@@ -117,7 +117,9 @@
                     <NeoTooltip
                       :label="address.address"
                       append-to-body
-                      root-class="parent-z-index-auto">
+                      :root-class="`parent-z-index-auto ${
+                        isMobile ? 'mobile' : ''
+                      }`">
                       <NeoIcon
                         icon="circle-info"
                         class="is-size-6"
@@ -270,9 +272,18 @@ const isExpandList = ref(false)
   }
 }
 </style>
-<style>
+<style lang="scss">
 /* trick to implement 'parent-selector' */
 div:has(> .parent-z-index-auto) {
   z-index: auto !important;
+}
+
+div:has(> .parent-z-index-auto.mobile) {
+  .o-tip__content {
+    transform: translateX(calc(-100vw + 2rem));
+  }
+  .o-tip__arrow {
+    transform: translateX(calc(50vw - 2rem));
+  }
 }
 </style>

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -77,11 +77,12 @@
                   :address="targetAddresses[0].address"
                   hide-identity-popover />
               </span>
-              <NeoIcon
-                icon="circle-info"
-                class="is-size-6"
-                pack="far"
-                :title="targetAddresses[0].address" />
+              <NeoTooltip
+                :label="targetAddresses[0].address"
+                append-to-body
+                root-class="parent-z-index-auto">
+                <NeoIcon icon="circle-info" class="is-size-6" pack="far" />
+              </NeoTooltip>
             </div>
             <div
               v-else
@@ -113,11 +114,15 @@
                         :address="address.address"
                         hide-identity-popover />
                     </span>
-                    <NeoIcon
-                      icon="circle-info"
-                      class="is-size-6"
-                      pack="far"
-                      :title="address.address" />
+                    <NeoTooltip
+                      :label="address.address"
+                      append-to-body
+                      root-class="parent-z-index-auto">
+                      <NeoIcon
+                        icon="circle-info"
+                        class="is-size-6"
+                        pack="far" />
+                    </NeoTooltip>
                   </div>
                 </div>
                 <div
@@ -171,7 +176,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon, NeoModal } from '@kodadot1/brick'
+import { NeoButton, NeoIcon, NeoModal, NeoTooltip } from '@kodadot1/brick'
 import { NAMES } from '@/libs/static/src/names'
 import Avatar from '@/components/shared/Avatar.vue'
 import Identity from '@/components/identity/IdentityIndex.vue'
@@ -263,5 +268,11 @@ const isExpandList = ref(false)
       border-top: 1px solid theme('k-shade');
     }
   }
+}
+</style>
+<style>
+/* trick to implement 'parent-selector' */
+div:has(> .parent-z-index-auto) {
+  z-index: auto !important;
 }
 </style>

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -80,7 +80,7 @@
               <NeoTooltip
                 :label="targetAddresses[0].address"
                 append-to-body
-                :root-class="`parent-z-index-auto ${isMobile ? 'mobile' : ''}`">
+                :content-class="`transfer-tooltip ${isMobile ? 'mobile' : ''}`">
                 <NeoIcon icon="circle-info" class="is-size-6" pack="far" />
               </NeoTooltip>
             </div>
@@ -117,7 +117,7 @@
                     <NeoTooltip
                       :label="address.address"
                       append-to-body
-                      :root-class="`parent-z-index-auto ${
+                      :content-class="`transfer-tooltip ${
                         isMobile ? 'mobile' : ''
                       }`">
                       <NeoIcon
@@ -273,17 +273,11 @@ const isExpandList = ref(false)
 }
 </style>
 <style lang="scss">
-/* trick to implement 'parent-selector' */
-div:has(> .parent-z-index-auto) {
-  z-index: auto !important;
-}
-
-div:has(> .parent-z-index-auto.mobile) {
-  .o-tip__content {
-    transform: translateX(calc(-100vw + 2rem));
-  }
+// manually calculated number, based on address length and container padding, not the best solution but it works :)
+.o-tip__content.transfer-tooltip {
+  transform: translateX(-22rem);
   .o-tip__arrow {
-    transform: translateX(calc(50vw - 2rem));
+    transform: translateX(10rem);
   }
 }
 </style>

--- a/components/transfer/TransferConfirmModal.vue
+++ b/components/transfer/TransferConfirmModal.vue
@@ -117,9 +117,7 @@
                     <NeoTooltip
                       :label="address.address"
                       append-to-body
-                      :content-class="`transfer-tooltip ${
-                        isMobile ? 'mobile' : ''
-                      }`">
+                      content-class="transfer-tooltip">
                       <NeoIcon
                         icon="circle-info"
                         class="is-size-6"

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
@@ -62,8 +62,3 @@ $tooltip-arrow-margin: 1rem;
     height: inherit !important;
   }
 }
-
-/* trick to implement 'parent-selector' */
-div:has(> .neo-tooltip.append-to-body) {
-  z-index: auto !important;
-}

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
@@ -62,3 +62,8 @@ $tooltip-arrow-margin: 1rem;
     height: inherit !important;
   }
 }
+
+/* trick to implement 'parent-selector' */
+div:has(> .neo-tooltip.append-to-body) {
+  z-index: auto !important;
+}

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -1,6 +1,7 @@
 <template>
   <o-tooltip
     v-if="active"
+    ref="tooltipRef"
     :append-to-body="appendToBody"
     :auto-close="autoClose"
     :multiline="multiline"
@@ -15,6 +16,7 @@
     :position="position"
     :label="label"
     :delay="delay"
+    @open="handleOpen"
     @click.native="handleClick">
     <template #content>
       <slot name="content"></slot>
@@ -86,6 +88,16 @@ const multilineWidth = computed(() => {
   }
   return props.multilineWidth
 })
+
+const tooltipRef = ref<InstanceType<typeof OTooltip>>(null)
+const handleOpen = async () => {
+  // wrapper element of tooltip generated dynamic
+  // so we must manually set style when it opened
+  if (props.appendToBody) {
+    await nextTick()
+    tooltipRef.value.bodyEl.style.zIndex = 'auto'
+  }
+}
 
 const handleClick = (event: MouseEvent) => {
   if (props.stopEvents) {

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -6,6 +6,7 @@
     :multiline="multiline"
     class="neo-tooltip"
     :content-class="contentClass"
+    :root-class="rootClass"
     :style="{
       '--font-size': fontSize,
       '--multiline-width': multilineWidth,
@@ -46,6 +47,7 @@ export interface Props {
   stopEvents?: boolean
   autoClose?: string[] | boolean
   contentClass?: string
+  rootClass?: string
 }
 const props = withDefaults(defineProps<Props>(), {
   label: '',
@@ -60,6 +62,7 @@ const props = withDefaults(defineProps<Props>(), {
   stopEvents: false,
   autoClose: true,
   contentClass: '',
+  rootClass: '',
 })
 
 const fontSize = computed(() => {

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -65,6 +65,14 @@ const props = withDefaults(defineProps<Props>(), {
   rootClass: '',
 })
 
+const rootClass = computed(() => {
+  let classStr = props.rootClass
+  if (props.appendToBody) {
+    classStr += ' append-to-body'
+  }
+  return classStr
+})
+
 const fontSize = computed(() => {
   if (typeof props.fontSize === 'number') {
     return `${props.fontSize}px`


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6837
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="759" alt="iShot_2023-08-21_09 52 08" src="https://github.com/kodadot/nft-gallery/assets/16473062/786203a8-805e-4cc5-aad2-d385a4986bbe">

<img width="732" alt="iShot_2023-08-21_09 52 54" src="https://github.com/kodadot/nft-gallery/assets/16473062/eec724a3-3e06-44b9-83eb-1e0cef1d9dee">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b18b253</samp>

Enhanced the user interface of the NFT transfer feature by using a custom tooltip component and fixing a styling bug. Modified the `NeoTooltip` component to accept a `rootClass` prop and updated the `TransferConfirmModal` component to use it.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b18b253</samp>

> _`NeoTooltip` shines_
> _Customizing its root class_
> _Winter bug is fixed_

