### PR TITLE
fix(loader): Loader won't close when you click outside modal on BSX

### DIFF
--- a/components/bsx/Create/CreateToken.vue
+++ b/components/bsx/Create/CreateToken.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <Loader v-model="isLoading" :status="status" :can-cancel="false" />
+    <Loader v-model="isLoading" :status="status" can-cancel />
     <BaseTokenForm
       ref="baseTokenForm"
       :show-explainer-text="showExplainerText"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6827
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
copilot:summary

copilot:poem


