### PR TITLE
fix: update sidebar title padding and icon

### DIFF
--- a/components/common/ConnectWallet/ConnectWalletModal.vue
+++ b/components/common/ConnectWallet/ConnectWalletModal.vue
@@ -9,7 +9,7 @@
         }}
       </span>
       <a class="is-flex is-align-items-center" @click="emit('close')">
-        <NeoIcon icon="close" />
+        <NeoIcon icon="xmark" pack="fa-sharp" size="medium" />
       </a>
     </header>
     <section v-if="showAccount">

--- a/components/common/NotificationBox/NotificationBoxModal.vue
+++ b/components/common/NotificationBox/NotificationBoxModal.vue
@@ -3,12 +3,12 @@
     v-if="isOpen"
     class="notification-modal-container theme-background-color border-left is-flex is-flex-direction-column">
     <header
-      class="py-4 px-6 is-flex is-justify-content-space-between border-bottom mb-4">
+      class="py-5 px-6 is-flex is-justify-content-space-between border-bottom mb-4">
       <span class="modal-card-title is-size-6 has-text-weight-bold">
         {{ $t('notification.notifications') }}
       </span>
       <a class="is-flex is-align-items-center" @click="closeModal">
-        <NeoIcon icon="close" />
+        <NeoIcon icon="xmark" pack="fa-sharp" size="medium" />
       </a>
     </header>
     <div class="px-0 pt-0 pb-3 theme-background-color">

--- a/components/common/shoppingCart/ShoppingCartModal.vue
+++ b/components/common/shoppingCart/ShoppingCartModal.vue
@@ -3,14 +3,16 @@
     <div
       class="shopping-cart-modal-container theme-background-color border-left is-flex is-flex-direction-column">
       <header
-        class="py-4 px-6 is-flex is-justify-content-space-between border-bottom">
+        class="py-5 px-6 is-flex is-justify-content-space-between border-bottom">
         <span class="modal-card-title is-size-6 has-text-weight-bold">
           {{ $t('shoppingCart.title') }}
         </span>
         <NeoButton
           variant="text"
           no-shadow
-          icon="close"
+          icon="xmark"
+          icon-pack="fa-sharp"
+          size="medium"
           @click.native="closeShoppingCart" />
       </header>
       <div

--- a/styles/components/_connect-wallet.scss
+++ b/styles/components/_connect-wallet.scss
@@ -51,7 +51,7 @@
 
     .modal-card-head {
       background: unset;
-      padding: 1rem 2rem;
+      padding: 1.5rem 2rem;
       @include ktheme() {
         border-bottom: 1px solid theme('border-color');
       }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6535
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=129QwMHtmhf7qGF5EoMxVT7dosyb9SYZTkJTfQHYQ3kUQap4&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
 - sidebars'(notif, connect wallet, profile, cart) padding's vertical to 24px
 
  ![CleanShot 2023-08-22 at 16 38 06](https://github.com/kodadot/nft-gallery/assets/17610879/9eaab61b-3140-4455-9ca6-cf84e56f0ca1)

 - use this xmark - regular, sharp and make it 20px
   
  ![CleanShot 2023-08-22 at 16 30 52@2x](https://github.com/kodadot/nft-gallery/assets/17610879/ad726ace-5834-42ee-b840-2c415a665716)


## Copilot Summary
copilot:summary

copilot:poem
