### PR TITLE
fix: remove anchor tags from cookie banner affecting lighthouse score

### DIFF
--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -54,6 +54,12 @@ const declineCookies = () => {
     height: 2.188rem;
     max-width: 720px;
 
+    .action {
+      span {
+        cursor: pointer;
+      }
+    }
+
     @media screen and (max-width: 768px) {
       height: auto;
       width: 11.875rem;

--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -14,12 +14,12 @@
           </div>
           <div class="bar ml-4 mr-4" />
           <div class="action is-success">
-            <a @click="declineCookies">
+            <span @click="declineCookies">
               {{ $t('cookies.decline') }}
-            </a>
-            <a class="has-text-weight-bold ml-3" @click="acceptCookies">
+            </span>
+            <span class="has-text-weight-bold ml-3" @click="acceptCookies">
               {{ $t('cookies.accept') }}
-            </a>
+            </span>
           </div>
         </div>
       </div>

--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -48,6 +48,8 @@ const declineCookies = () => {
 </script>
 
 <style lang="scss">
+@import '@/styles/abstracts/variables';
+
 .cookie-banner {
   .snackbar {
     align-self: flex-start;
@@ -57,6 +59,14 @@ const declineCookies = () => {
     .action {
       span {
         cursor: pointer;
+        @include ktheme() {
+          color: theme('text-color');
+        }
+        &:hover {
+          @include ktheme() {
+            color: theme('link-hover');
+          }
+        }
       }
     }
 

--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -14,12 +14,16 @@
           </div>
           <div class="bar ml-4 mr-4" />
           <div class="action is-success">
-            <span @click="declineCookies">
+            <NeoButton variant="text" no-shadow @click.native="declineCookies">
               {{ $t('cookies.decline') }}
-            </span>
-            <span class="has-text-weight-bold ml-3" @click="acceptCookies">
+            </NeoButton>
+            <NeoButton
+              variant="text"
+              no-shadow
+              class="has-text-weight-bold ml-3"
+              @click.native="acceptCookies">
               {{ $t('cookies.accept') }}
-            </span>
+            </NeoButton>
           </div>
         </div>
       </div>
@@ -28,6 +32,7 @@
 </template>
 
 <script lang="ts" setup>
+import { NeoButton } from '@kodadot1/brick'
 // import { useState } from 'vue-gtag-next'
 
 // const { isEnabled } = useState()
@@ -55,20 +60,6 @@ const declineCookies = () => {
     align-self: flex-start;
     height: 2.188rem;
     max-width: 720px;
-
-    .action {
-      span {
-        cursor: pointer;
-        @include ktheme() {
-          color: theme('text-color');
-        }
-        &:hover {
-          @include ktheme() {
-            color: theme('link-hover');
-          }
-        }
-      }
-    }
 
     @media screen and (max-width: 768px) {
       height: auto;

--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -53,8 +53,6 @@ const declineCookies = () => {
 </script>
 
 <style lang="scss">
-@import '@/styles/abstracts/variables';
-
 .cookie-banner {
   .snackbar {
     align-self: flex-start;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6882 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

## Comments
Cookie banner pops up during lighthouse testing causing non crawlable links error. Since I had it saved my tests on #6844 did not take it into account.

Lets pretend this was part of  #6844 for my own sanity 🤣 🤣 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4db31c1</samp>

Improved cookie banner component by using `<span>` tags instead of `<a>` tags in `components/CookieBanner.vue`. This prevents unwanted page navigation and enhances accessibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4db31c1</samp>

> _`<a>` tags are gone_
> _`<span>` tags improve the banner_
> _Autumn leaves don't fall_