### PR TITLE
fix: remove prevent default event from function

### DIFF
--- a/components/landing/SearchLanding.vue
+++ b/components/landing/SearchLanding.vue
@@ -75,8 +75,7 @@ const landingImage = computed(() => {
   }
 })
 
-const switchChain = (value, event) => {
-  event.preventDefault()
+const switchChain = (value) => {
   if (value !== urlPrefix.value) {
     setUrlPrefix(value)
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6890
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

## Comments
Suggestion was committed in #6844 but also required an update to the switchChain function.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29909f8</samp>

Refactored the `switchChain` function in `SearchLanding.vue` to use a `v-model` binding instead of a `click` event. This simplifies the code and avoids unnecessary calls to `event.preventDefault()`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 29909f8</samp>

> _`switchChain` function_
> _No longer needs `event`_
> _`v-model` binds it_