### PR TITLE
🔧 BalanceInput height

### DIFF
--- a/components/shared/BalanceInput.vue
+++ b/components/shared/BalanceInput.vue
@@ -19,6 +19,7 @@
             @input="handleInput" />
           <p class="control balance">
             <NeoSelect
+              class="h-full"
               :value="selectedUnit"
               :disabled="!calculate"
               data-testid="balance-input-select"
@@ -145,3 +146,11 @@ defineExpose({
   checkValidity,
 })
 </script>
+
+<style scoped lang="scss">
+:deep .h-full {
+  * {
+    height: 100%;
+  }
+}
+</style>

--- a/components/shared/BalanceInput.vue
+++ b/components/shared/BalanceInput.vue
@@ -19,7 +19,6 @@
             @input="handleInput" />
           <p class="control balance">
             <NeoSelect
-              class="h-full"
               :value="selectedUnit"
               :disabled="!calculate"
               data-testid="balance-input-select"
@@ -146,11 +145,3 @@ defineExpose({
   checkValidity,
 })
 </script>
-
-<style scoped lang="scss">
-:deep .h-full {
-  * {
-    height: 100%;
-  }
-}
-</style>

--- a/libs/ui/src/components/NeoSelect/NeoSelect.scss
+++ b/libs/ui/src/components/NeoSelect/NeoSelect.scss
@@ -5,7 +5,7 @@
 @import '../../scss/variable.scss';
 
 $select-padding: 0.5rem;
-$select-height: 3.25em;
+$select-height: 3rem;
 $select-border-radius: 0;
 
 @import '@oruga-ui/oruga/src/scss/components/select.scss';


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [] Closes #6871
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI
![image](https://github.com/kodadot/nft-gallery/assets/22791238/e15ea0f0-ba09-435a-828c-a8e17821e554)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb0ef29</samp>

Improved the UI of the balance input component by adding a custom CSS class. This affects the file `components/shared/BalanceInput.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb0ef29</samp>

> _To make the balance input look nice_
> _We added a custom CSS class_
> _It's called `.h-full`_
> _And it makes the element tall_
> _So it fills the parent's height with sass_
