### PR TITLE
mimetype from static

### DIFF
--- a/composables/massmint/useZipValidator.ts
+++ b/composables/massmint/useZipValidator.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { ZipEntry, unzip } from 'unzipit'
 import { MAX_UPLOADED_FILE_SIZE } from '@/utils/constants'
+import { mimeTypes } from '@kodadot1/static'
 export interface FileObject {
   imageUrl: string
   file: File
@@ -37,26 +38,6 @@ export const validFormats = [
   'mp3',
   'json',
 ]
-export const mimeTypes: { [key: string]: string } = {
-  bmp: 'image/bmp',
-  gif: 'image/gif',
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  png: 'image/png',
-  svg: 'image/svg+xml',
-  tiff: 'image/tiff',
-  webp: 'image/webp',
-  mp4: 'video/mp4',
-  ogv: 'video/ogg',
-  mov: 'video/quicktime',
-  qt: 'video/quicktime',
-  webm: 'video/webm',
-  glb: 'model/gltf-binary',
-  gltf: 'model/gltf+json',
-  flac: 'audio/flac',
-  mp3: 'audio/mpeg',
-  json: 'application/json',
-}
 
 const toMegaBytes = (bytes: number) => bytes / Math.pow(1024, 2)
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Related #6782

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fad24a</samp>

Improved modularity and readability of `useZipValidator.ts` by extracting `mimeTypes` to a separate module.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4fad24a</samp>

> _We'll haul away the zip validator_
> _And import `mimeTypes` from afar_
> _It makes the code more neat and clear_
> _So heave away, me hearties, heave away_
