### PR TITLE
fix: rmrk2 fallback images

### DIFF
--- a/components/gallery/useGalleryItem.ts
+++ b/components/gallery/useGalleryItem.ts
@@ -96,9 +96,15 @@ export const useGalleryItem = (nftId?: string): GalleryItem => {
     nft.value = nftEntity
 
     const resources = nftEntity.resources?.map((resource) => {
+      const imageSrc =
+        resource.meta?.animationUrl ||
+        resource.src ||
+        resource.meta?.image ||
+        resource.thumb
+
       return {
         ...resource,
-        src: sanitizeIpfsUrl(resource.meta?.animationUrl || resource.src),
+        src: sanitizeIpfsUrl(imageSrc),
         thumb: sanitizeIpfsUrl(resource.thumb || resource.meta?.image),
         animation: sanitizeIpfsUrl(resource.meta?.animationUrl),
       }

--- a/components/rmrk/Gallery/GalleryCard.vue
+++ b/components/rmrk/Gallery/GalleryCard.vue
@@ -84,7 +84,7 @@ const animatedUrl = ref('')
 const mimeType = ref('')
 const preferencesStore = usePreferencesStore()
 
-useLazyAsyncData(`gallery-card-metadata-${props.id}`, async () => {
+watchEffect(async () => {
   if (props.metadata) {
     const meta = await processSingleMetadata<NFTMetadata>(props.metadata)
 

--- a/components/rmrk/Gallery/GalleryCard.vue
+++ b/components/rmrk/Gallery/GalleryCard.vue
@@ -45,7 +45,7 @@
 <script lang="ts" setup>
 import { processSingleMetadata } from '@/utils/cachingStrategy'
 import { getMimeType } from '@/utils/gallery/media'
-import { getSanitizer, sanitizeIpfsUrl } from '@/utils/ipfs'
+import { sanitizeIpfsUrl } from '@/utils/ipfs'
 
 import { NFTMetadata } from '@/components/rmrk/service/scheme'
 import { usePreferencesStore } from '@/stores/preferences'
@@ -60,18 +60,21 @@ const props = withDefaults(
     route?: string
     link?: string
     id: string
-    name: string
-    emoteCount: string | number
-    imageType: string
-    price: string
+    name?: string
+    emoteCount?: string | number
+    price?: string
     metadata: string
     currentOwner: string
-    listed: boolean
+    listed?: boolean
     hideName: boolean
   }>(),
   {
     route: '/rmrk/gallery',
     link: 'rmrk/gallery',
+    name: '',
+    emoteCount: '',
+    listed: true,
+    price: '0',
   }
 )
 
@@ -81,11 +84,11 @@ const animatedUrl = ref('')
 const mimeType = ref('')
 const preferencesStore = usePreferencesStore()
 
-useLazyAsyncData('metadata', async () => {
+useLazyAsyncData(`gallery-card-metadata-${props.id}`, async () => {
   if (props.metadata) {
     const meta = await processSingleMetadata<NFTMetadata>(props.metadata)
 
-    image.value = getSanitizer(meta.image || '', 'image')(meta.image || '')
+    image.value = sanitizeIpfsUrl(meta.image || meta.thumbnailUri)
     title.value = meta.name
     animatedUrl.value = sanitizeIpfsUrl(
       meta.animation_url || meta.mediaUri || '',

--- a/composables/useNft.ts
+++ b/composables/useNft.ts
@@ -9,6 +9,11 @@ export type NftResources = {
   thumb?: string
   mimeType?: string
   animation?: string
+  meta?: {
+    id: string
+    image?: string
+    animationUrl?: string
+  }
 }
 
 export type ItemResources = {

--- a/utils/carousel.ts
+++ b/utils/carousel.ts
@@ -18,7 +18,7 @@ export const formatNFT = (nfts, chain?: string): CarouselNFT[] => {
   return data.map((nft) => {
     const timestamp = nft.updatedAt || nft.timestamp
     const metaImage =
-      nft.meta.image || nft.resources[0].thumb || nft.resources[0].src
+      nft.meta.image || nft.resources?.[0].thumb || nft.resources?.[0].src
     const metaAnimationUrl = nft.meta.animationUrl
     const name = nft.name || nft.meta.name
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Fix rmrk2 images on gallery item
- [x] Fix popover images
- [x] Fix rmrk2 images on carousel

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Screenshot 📸

- [x] My fix has changed UI

![Screenshot 2023-08-23 at 16-24-29 Andesaurus God #0004 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/734428/acdcb65c-b774-45ce-83b8-17678f4d537a)
![Screenshot 2023-08-23 at 16-23-37 Andesaurus God #0004 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/734428/25502c19-6437-4bbb-9e5b-6a29beb8e54b)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aae7f9b</samp>

This pull request improves the functionality and performance of the GalleryCard component and the useGalleryItem composable, by refactoring the code, fixing bugs, and adding a new meta property to the NftResources type. It also removes unused code and enhances the lazy loading of image data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aae7f9b</samp>

> _We'll fix the bugs and refactor the code, me hearties, yo ho!_
> _We'll use the `meta` and the `imageSrc`, me hearties, yo ho!_
> _We'll heave away on the count of three, and make the gallery shine_
> _We'll use the `sanitizeIpfsUrl` and save some loading time_
