### PR TITLE
refactor: deprecated ohmyfetch

### DIFF
--- a/components/gallery/GalleryItemDescription.vue
+++ b/components/gallery/GalleryItemDescription.vue
@@ -150,7 +150,6 @@
 </template>
 
 <script setup lang="ts">
-import { obtainMimeType } from '@kodadot1/minipfs'
 import {
   MediaItem,
   NeoTabItem,
@@ -165,7 +164,7 @@ import { sanitizeIpfsUrl, toCloudflareIpfsUrl } from '@/utils/ipfs'
 import { GalleryItem, useGalleryItem } from './useGalleryItem'
 
 import { MediaType } from '@/components/rmrk/types'
-import { resolveMedia } from '@/utils/gallery/media'
+import { getMimeType, resolveMedia } from '@/utils/gallery/media'
 
 import { replaceSingularCollectionUrlByText } from '@/utils/url'
 
@@ -250,7 +249,7 @@ watchEffect(async () => {
   }
 
   if (nftAnimation.value) {
-    animationMediaMimeType.value = await obtainMimeType(nftAnimation.value)
+    animationMediaMimeType.value = await getMimeType(nftAnimation.value)
   }
 })
 

--- a/components/generative/promptBuilder.ts
+++ b/components/generative/promptBuilder.ts
@@ -1,4 +1,4 @@
-import { $fetch } from 'ohmyfetch'
+import { $fetch } from 'ofetch'
 import { PredictionStatus } from '@/services/replicate'
 import { pinImageSafe } from '@/utils/safePin'
 import { createMetadata, unSanitizeIpfsUrl } from '@kodadot1/minimark/utils'

--- a/components/media/type/JsonMedia.vue
+++ b/components/media/type/JsonMedia.vue
@@ -20,7 +20,7 @@ const data = ref<{ key: string; value: string }[]>([])
 
 onMounted(async () => {
   if (props.src) {
-    const { data } = await api.get(props.src)
+    const data = await api(props.src)
     $consola.log('data', data)
     data.forEach(([key, value]) => {
       data.push({

--- a/components/search/utils/collectionSearch.ts
+++ b/components/search/utils/collectionSearch.ts
@@ -1,15 +1,15 @@
-import Axios from 'axios'
+import { $fetch } from 'ofetch'
 import { URLS } from '~/utils/constants'
 import consola from 'consola'
 
 const BASE_URL = URLS.koda.search
 
-const api = Axios.create({
+const api = $fetch.create({
   baseURL: BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: false,
+  credentials: 'omit',
 })
 export async function fetchCollectionSuggestion(key: string, limit?: number) {
   const object = {
@@ -19,9 +19,12 @@ export async function fetchCollectionSuggestion(key: string, limit?: number) {
   }
 
   try {
-    const res = await api.post('/search', object)
-    if (res?.data && Array.isArray(res?.data)) {
-      return res.data
+    const data = await api('/search', {
+      method: 'POST',
+      body: object,
+    })
+    if (data && Array.isArray(data)) {
+      return data
     }
     return []
   } catch (e) {

--- a/libs/ui/src/components/MediaItem/type/JsonMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/JsonMedia.vue
@@ -20,7 +20,7 @@ const items = ref<{ key: string; value: string }[]>([])
 
 onMounted(async () => {
   if (props.src) {
-    const { data } = await api.get(props.src)
+    const data = await api(props.src)
 
     items.value = Object.entries(data).map(([key, value]) => ({
       key,

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@kodadot1/sub-api": "^0.1.2",
     "@nuxtjs/apollo": "^4.0.1-rc.5",
     "@nuxtjs/i18n": "^7.3.1",
-    "@nuxtjs/sitemap": "thisismydesign/sitemap-module#cd4dc22293b9b67e8ebb5b3c49840e67c108e312",
+    "@nuxtjs/sitemap": "https://github.com/thisismydesign/sitemap-module#cd4dc22293b9b67e8ebb5b3c49840e67c108e312",
     "@paraspell/sdk": "^2.0.5",
     "@pinia/nuxt": "^0.4.11",
     "@polkadot/api": "^10.6.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mingo": "^5.1.0",
     "nuxt-edge": "2.17.2-28202417.20abbc1",
     "nuxt-property-decorator": "^2.9.1",
-    "ohmyfetch": "^0.4.21",
+    "ofetch": "^1.3.2",
     "pinia-plugin-persistedstate": "^3.2.0",
     "setimmediate": "^1.0.5",
     "slugify": "^1.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 7.3.1(vue@2.7.14)
       '@nuxtjs/sitemap':
         specifier: thisismydesign/sitemap-module#cd4dc22293b9b67e8ebb5b3c49840e67c108e312
-        version: github.com/thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312
+        version: git@github.com+thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312
       '@paraspell/sdk':
         specifier: ^2.0.5
         version: 2.0.5(@polkadot/api-base@10.6.1)(@polkadot/api@10.6.1)(@polkadot/apps-config@0.130.1)(@polkadot/types@10.6.1)
@@ -149,9 +149,9 @@ importers:
       nuxt-property-decorator:
         specifier: ^2.9.1
         version: 2.9.1(vue@2.7.14)
-      ohmyfetch:
-        specifier: ^0.4.21
-        version: 0.4.21
+      ofetch:
+        specifier: ^1.3.2
+        version: 1.3.2
       pinia-plugin-persistedstate:
         specifier: ^3.2.0
         version: 3.2.0
@@ -396,7 +396,7 @@ importers:
         version: 0.16.4(sass@1.65.1)(vite@3.2.7)
       vite:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@20.2.5)(sass@1.65.1)
+        version: 3.2.7(sass@1.65.1)(terser@5.17.7)
       vue:
         specifier: 2.7.14
         version: 2.7.14
@@ -4269,7 +4269,7 @@ packages:
       chokidar: 3.5.3
       pathe: 0.2.0
       picocolors: 1.0.0
-      vite: 3.2.7(@types/node@20.2.5)(sass@1.65.1)
+      vite: 3.2.7(sass@1.65.1)(terser@5.17.7)
     dev: true
 
   /@histoire/vendors@0.16.0:
@@ -4411,7 +4411,7 @@ packages:
   /@kodadot1/minipfs@0.4.0-rc.0:
     resolution: {integrity: sha512-XLwrSIBFwnlPLeuk2G6USjg8eKJPoY4+yALE39gGtRxpQcxTz0kfpwKCIzcbKdgU+iutRIAL4JoVtiYfkPWjeg==}
     dependencies:
-      ofetch: 1.1.1
+      ofetch: 1.3.2
     dev: false
 
   /@kodadot1/sub-api@0.1.2:
@@ -4637,7 +4637,7 @@ packages:
       nitropack: 1.0.0
       node-fetch: 3.3.1
       nuxi: 3.0.0
-      ofetch: 1.1.1
+      ofetch: 1.3.2
       ohash: 1.1.2
       pathe: 1.1.1
       perfect-debounce: 0.1.3
@@ -9156,7 +9156,7 @@ packages:
       vite: ^3.0.0 || ^4.0.0
       vue: ^2.7.0-0
     dependencies:
-      vite: 3.2.7(@types/node@20.2.5)(sass@1.65.1)
+      vite: 3.2.7(sass@1.65.1)(terser@5.17.7)
       vue: 2.7.14
     dev: true
 
@@ -11244,13 +11244,6 @@ packages:
     engines: {node: '>=4.5.0'}
     dependencies:
       dicer: 0.3.0
-    dev: false
-
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
     dev: false
 
   /byline@5.0.0:
@@ -15725,7 +15718,7 @@ packages:
       sade: 1.8.1
       shiki-es: 0.2.0
       sirv: 2.0.3
-      vite: 3.2.7(@types/node@20.2.5)(sass@1.65.1)
+      vite: 3.2.7(sass@1.65.1)(terser@5.17.7)
       vite-node: 0.28.4(sass@1.65.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -17872,8 +17865,8 @@ packages:
       mime: 3.0.0
       mlly: 1.4.0
       mri: 1.2.0
-      node-fetch-native: 1.2.0
-      ofetch: 1.1.1
+      node-fetch-native: 1.4.0
+      ofetch: 1.3.2
       ohash: 1.1.2
       pathe: 1.1.1
       perfect-debounce: 0.1.3
@@ -17947,12 +17940,11 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
 
-  /node-fetch-native@0.1.8:
-    resolution: {integrity: sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q==}
-    dev: false
-
   /node-fetch-native@1.2.0:
     resolution: {integrity: sha512-5IAMBTl9p6PaAjYCnMv5FmqIF6GcZnawAVnzaCG0rX2aYZJ4CxEkZNtVPuTRug7fL7wyM5BQYTlAzcyMPi6oTQ==}
+
+  /node-fetch-native@1.4.0:
+    resolution: {integrity: sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==}
 
   /node-fetch@2.6.1:
     resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
@@ -18360,18 +18352,17 @@ packages:
       destr: 2.0.1
       node-fetch-native: 1.2.0
       ufo: 1.2.0
+    dev: true
+
+  /ofetch@1.3.2:
+    resolution: {integrity: sha512-XphiqMCUugscBfS7EjEfe8s3Hb5kfrTqdk9QAYl9z/wvhI3g97EpQdldqd0zAWqQXInHEqkRBQ08reMFHQwjDA==}
+    dependencies:
+      destr: 2.0.1
+      node-fetch-native: 1.4.0
+      ufo: 1.2.0
 
   /ohash@1.1.2:
     resolution: {integrity: sha512-9CIOSq5945rI045GFtcO3uudyOkYVY1nyfFxVQp+9BRgslr8jPNiSSrsFGg/BNTUFOLqx0P5tng6G32brIPw0w==}
-
-  /ohmyfetch@0.4.21:
-    resolution: {integrity: sha512-VG7f/JRvqvBOYvL0tHyEIEG7XHWm7OqIfAs6/HqwWwDfjiJ1g0huIpe5sFEmyb+7hpFa1EGNH2aERWR72tlClw==}
-    dependencies:
-      destr: 1.2.2
-      node-fetch-native: 0.1.8
-      ufo: 0.8.6
-      undici: 5.22.1
-    dev: false
 
   /on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -21676,11 +21667,6 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-    dev: false
-
   /strict-uri-encode@1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
     engines: {node: '>=0.10.0'}
@@ -22597,20 +22583,13 @@ packages:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: false
 
-  /undici@5.22.1:
-    resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      busboy: 1.6.0
-    dev: false
-
   /unenv@1.5.1:
     resolution: {integrity: sha512-tQHlmQUPyIoyGc2bF8phugmQd6wVatkVe5FqxxhM1vHfmPKWTiogSVTHA0mO8gNztDKZLpBEJx3M3CJrTZyExg==}
     dependencies:
       consola: 3.2.3
       defu: 6.1.2
       mime: 3.0.0
-      node-fetch-native: 1.2.0
+      node-fetch-native: 1.4.0
       pathe: 1.1.1
     dev: true
 
@@ -22778,8 +22757,8 @@ packages:
       listhen: 1.0.4
       lru-cache: 9.1.2
       mri: 1.2.0
-      node-fetch-native: 1.2.0
-      ofetch: 1.1.1
+      node-fetch-native: 1.4.0
+      ofetch: 1.3.2
       ufo: 1.2.0
     transitivePeerDependencies:
       - supports-color
@@ -23019,7 +22998,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 3.2.7(@types/node@20.2.5)(sass@1.65.1)
+      vite: 3.2.7(sass@1.65.1)(terser@5.17.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -24308,8 +24287,8 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
-  github.com/thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312:
-    resolution: {tarball: https://codeload.github.com/thisismydesign/sitemap-module/tar.gz/cd4dc22293b9b67e8ebb5b3c49840e67c108e312}
+  git@github.com+thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312:
+    resolution: {commit: cd4dc22293b9b67e8ebb5b3c49840e67c108e312, repo: git@github.com:thisismydesign/sitemap-module.git, type: git}
     name: '@nuxtjs/sitemap'
     version: 2.4.0
     engines: {node: '>=8.9.0', npm: '>=5.0.0'}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(vue@2.7.14)
       '@nuxtjs/sitemap':
-        specifier: thisismydesign/sitemap-module#cd4dc22293b9b67e8ebb5b3c49840e67c108e312
-        version: git@github.com+thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312
+        specifier: https://github.com/thisismydesign/sitemap-module#cd4dc22293b9b67e8ebb5b3c49840e67c108e312
+        version: github.com/thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312
       '@paraspell/sdk':
         specifier: ^2.0.5
         version: 2.0.5(@polkadot/api-base@10.6.1)(@polkadot/api@10.6.1)(@polkadot/apps-config@0.130.1)(@polkadot/types@10.6.1)
@@ -24287,8 +24287,8 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
-  git@github.com+thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312:
-    resolution: {commit: cd4dc22293b9b67e8ebb5b3c49840e67c108e312, repo: git@github.com:thisismydesign/sitemap-module.git, type: git}
+  github.com/thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312:
+    resolution: {tarball: https://codeload.github.com/thisismydesign/sitemap-module/tar.gz/cd4dc22293b9b67e8ebb5b3c49840e67c108e312}
     name: '@nuxtjs/sitemap'
     version: 2.4.0
     engines: {node: '>=8.9.0', npm: '>=5.0.0'}

--- a/services/keywise.ts
+++ b/services/keywise.ts
@@ -1,4 +1,4 @@
-import { $fetch, FetchError } from 'ohmyfetch'
+import { $fetch, FetchError } from 'ofetch'
 import consola from 'consola'
 import { URLS } from '../utils/constants'
 
@@ -24,9 +24,9 @@ export const getValue = async (
 
   const { url } = await keywiseApi<KeyValue>(
     `resolve/${prefix}-${nftId}`
-  ).catch((error: FetchError) => {
+  ).catch((error: FetchError<{ message: string }>) => {
     consola.error(
-      `[WORKER::KEYWISE] Unable to GET KEY for reasons ${error.data}`
+      `[WORKER::KEYWISE] Unable to GET KEY for reasons ${error?.data?.message}`
     )
     return { url: '' }
   })

--- a/services/nftStorage.ts
+++ b/services/nftStorage.ts
@@ -1,4 +1,4 @@
-import { $fetch, FetchError } from 'ohmyfetch'
+import { $fetch, FetchError } from 'ofetch'
 import { URLS } from '../utils/constants'
 import consola from 'consola'
 import { Metadata } from '@kodadot1/minimark/common'

--- a/services/replicate.ts
+++ b/services/replicate.ts
@@ -1,4 +1,4 @@
-import { $fetch, FetchError } from 'ohmyfetch'
+import { $fetch, FetchError } from 'ofetch'
 import { URLS } from '../utils/constants'
 // import consola from 'consola'
 

--- a/services/supabase.ts
+++ b/services/supabase.ts
@@ -1,4 +1,4 @@
-import { $fetch, FetchError } from 'ohmyfetch'
+import { $fetch, FetchError } from 'ofetch'
 // import consola from 'consola'
 
 const BASE_URL = 'https://mtwfjfuiknglhfozmotu.functions.supabase.co/'

--- a/services/waifu.ts
+++ b/services/waifu.ts
@@ -1,4 +1,4 @@
-import { $fetch, FetchError } from 'ohmyfetch'
+import { $fetch, FetchError } from 'ofetch'
 
 const BASE_URL = 'https://waifu-me.kodadot.workers.dev'
 

--- a/utils/coingecko.ts
+++ b/utils/coingecko.ts
@@ -60,7 +60,7 @@ export const getApproximatePriceOf = async (
 export const getKSMUSD = async (): Promise<number> => {
   const coinId = 'kusama'
   try {
-    const { data } = await api('/simple/price', {
+    const data = await api('/simple/price', {
       params: {
         ids: coinId,
         vs_currencies: 'usd',

--- a/utils/coingecko.ts
+++ b/utils/coingecko.ts
@@ -1,19 +1,19 @@
-import Axios from 'axios'
+import { $fetch } from 'ofetch'
 import { URLS } from './constants'
 
 export const BASE_URL = URLS.providers.coingecko
 
-const api = Axios.create({
+const api = $fetch.create({
   baseURL: BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: false,
+  credentials: 'omit',
 })
 
 export const getPrice = async (id: string): Promise<any> => {
   try {
-    const { data } = await api.get('/simple/price', {
+    const data = await api('/simple/price', {
       params: {
         ids: id,
         vs_currencies: 'usd',
@@ -60,7 +60,7 @@ export const getApproximatePriceOf = async (
 export const getKSMUSD = async (): Promise<number> => {
   const coinId = 'kusama'
   try {
-    const { data } = await api.get('/simple/price', {
+    const { data } = await api('/simple/price', {
       params: {
         ids: coinId,
         vs_currencies: 'usd',

--- a/utils/directUpload.ts
+++ b/utils/directUpload.ts
@@ -1,4 +1,4 @@
-import Axios from 'axios'
+import { $fetch } from 'ofetch'
 import consola from 'consola'
 
 import { secondaryFileVisible } from '@/utils/mintUtils'
@@ -7,7 +7,7 @@ import { URLS } from './constants'
 
 export const BASE_URL = URLS.koda.directUpload
 
-const api = Axios.create({
+const api = $fetch.create({
   baseURL: BASE_URL,
 })
 
@@ -34,13 +34,13 @@ type CdnUploadResponse = {
 
 export const getKey = async (
   validationKey: string
-): Promise<DirectUploadResult> => {
+): Promise<DirectUploadResult | undefined> => {
   try {
-    const { status, data } = await api.get<DirectUploadApiResponse>(
+    const { _data, status } = await api.raw<DirectUploadApiResponse>(
       `getKey/${validationKey}`
     )
     consola.log('[PINNING] Obtain', status)
-    return data.result
+    return _data?.result
   } catch (e) {
     consola.warn(e)
     throw e
@@ -51,19 +51,21 @@ export const upload = async (
   file: File,
   url: string,
   id?: string
-): Promise<CdnUploadResponse> => {
+): Promise<CdnUploadResponse | undefined> => {
   const formData = new FormData()
   formData.append('file', file)
   if (id) {
     formData.append('id', id)
   }
-  const { status, data } = await Axios.post<CdnUploadResponse>(url, formData, {
+  const { status, _data } = await $fetch.raw<CdnUploadResponse>(url, {
+    method: 'POST',
     headers: {
       'Content-Type': 'multipart/form-data;',
     },
+    body: formData,
   })
   consola.log('[DIRECT UPLOAD] OK?', status)
-  return data
+  return _data
 }
 
 export const uploadDirect = async (
@@ -72,8 +74,10 @@ export const uploadDirect = async (
 ): Promise<void> => {
   try {
     const token = await getKey(ipfsHash)
-    const { result } = await upload(file, token.uploadURL, ipfsHash)
-    consola.log('[DIRECT UPLOAD] OK!', result.filename)
+    if (token) {
+      const res = await upload(file, token.uploadURL, ipfsHash)
+      consola.log('[DIRECT UPLOAD] OK!', res?.result.filename)
+    }
   } catch (e) {
     consola.warn('[DIRECT UPLOAD] ERR!', (e as Error).message)
   }

--- a/utils/directUpload.ts
+++ b/utils/directUpload.ts
@@ -57,11 +57,10 @@ export const upload = async (
   if (id) {
     formData.append('id', id)
   }
+
+  //FormData support: https://github.com/unjs/ofetch/issues/37
   const { status, _data } = await $fetch.raw<CdnUploadResponse>(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'multipart/form-data;',
-    },
     body: formData,
   })
   consola.log('[DIRECT UPLOAD] OK?', status)

--- a/utils/fetch.ts
+++ b/utils/fetch.ts
@@ -1,15 +1,16 @@
-import Axios from 'axios'
+import { $fetch } from 'ofetch'
 import { sanitizeIpfsUrl } from '@/utils/ipfs'
 import { logError } from '@/utils/mappers'
+import { getMimeType } from '@/utils/gallery/media'
 
 export const BASE_URL = 'https://ipfs.io/'
 
-const api = Axios.create({
+const api = $fetch.create({
   baseURL: BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: false,
+  credentials: 'omit',
 })
 
 export const fetchMimeType = async (
@@ -22,8 +23,7 @@ export const fetchMimeType = async (
   const assetUrl = sanitizeIpfsUrl(ipfsLink, 'image')
 
   try {
-    const { headers } = await api.head(assetUrl)
-    return headers['content-type']
+    return await getMimeType(assetUrl)
   } catch (e: any) {
     logError(e, (msg) => {
       console.warn(

--- a/utils/gallery/media.ts
+++ b/utils/gallery/media.ts
@@ -1,4 +1,4 @@
-import { $fetch } from 'ohmyfetch'
+import { $fetch } from 'ofetch'
 
 import { MediaType } from '~/components/rmrk/types'
 
@@ -15,8 +15,8 @@ export function isImageVisible(type: MediaType) {
 }
 
 export async function getMimeType(mediaUrl: string) {
-  const { type } = await $fetch(mediaUrl, { method: 'HEAD' })
-  return type
+  const { headers } = await $fetch.raw(mediaUrl, { method: 'HEAD' })
+  return headers.get('content-type') || ''
 }
 
 export async function processMedia(mediaUrl: string) {

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -119,9 +119,9 @@ export const fetchMetadata = async <T>(
       return emptyObject<T>()
     }
 
-    const { status, data } = await api.get(sanitizer(rmrk.metadata))
+    const { status, _data } = await api.raw(sanitizer(rmrk.metadata))
     if (status < 400) {
-      return data as T
+      return _data as T
     }
   } catch (e) {
     console.warn('IPFS Err', e)
@@ -143,8 +143,7 @@ export const fetchCollectionMetadata = (
 export const preheatFileFromIPFS = (ipfsUrl: string) => {
   const url = sanitizeIpfsUrl(ipfsUrl, 'image')
   const hash = fastExtract(url)
-  api
-    .get(url)
+  api(url)
     .then(() => consola.log(`[PREHEAT] ${hash}`))
     .catch((err) => consola.warn(`[PREHEAT] ${hash} ${err.message}`))
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  - [x] Refactoring

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #6913

  - replace `ohmyfetch` with `ofetch` as the only one network fetch package
  - refactor fetch from `axios`
  - probably remove `axios` ?


  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a90d86d</samp>

This pull request replaces the HTTP client library `Axios` and its wrapper `ohmyfetch` with a more lightweight and native fetch library `ofetch` in various files and components of the nft-gallery project. This is to improve performance, compatibility, and code quality. It also updates some dependencies and removes some unused ones in `pnpm-lock.yaml` and `package.json`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a90d86d</samp>

> _Oh we're the crew of the nft-gallery_
> _And we're sailing on the web so free_
> _We're switching to `ofetch` for our fetching needs_
> _So heave away and pull with me_
  