### PR TITLE
fix: profile items not showing, loading skeleton not working after clicking 'Buy now'

### DIFF
--- a/components/items/ItemsGrid/ItemsGrid.vue
+++ b/components/items/ItemsGrid/ItemsGrid.vue
@@ -68,7 +68,11 @@ const gotoPage = (page: number) => {
   fetchSearch({ page, search: parseSearch(props.search) })
 }
 const fetchPageData = async (page: number, loadDirection) => {
-  return await fetchSearch({ page, loadDirection })
+  return await fetchSearch({
+    page,
+    loadDirection,
+    search: parseSearch(props.search),
+  })
 }
 const {
   first,
@@ -121,6 +125,7 @@ watch(
       return
     }
     if (!isEqual(newSearch, oldSearch)) {
+      isLoading.value = true
       refetch(parseSearch(props.search))
     }
   },

--- a/components/profile/FilterButton.vue
+++ b/components/profile/FilterButton.vue
@@ -3,7 +3,7 @@
     :active="model"
     no-shadow
     rounded
-    :label="urlParam ?? label"
+    :label="label"
     @click.native="model = !model" />
 </template>
 

--- a/components/profile/activityTab/Activity.vue
+++ b/components/profile/activityTab/Activity.vue
@@ -10,10 +10,11 @@
           variant="text"
           @click.native="activateAllFilter" />
         <FilterButton
-          v-for="urlParam in filters"
-          :key="urlParam"
+          v-for="param in filters"
+          :key="param"
+          :label="param"
           class="is-capitalized"
-          :url-param="urlParam" />
+          :url-param="param" />
       </div>
     </div>
     <hr class="my-0" />


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6927
- [ ] Requires deployment <snek/rubick/worker>

I'd like to describe why I fixed the 'Buy now' display bug like this (see commit: 6763716).

Before the fix, the `FilterButton` component was using `urlParam` as the button label(`:label="urlParam ?? label"`). It worked well on the FilterButtons in `Activity.vue` because all the `label` names are in a single word so they're coincidentally equal to the `urlParam`. But when it came to the 'Buy now' `FilterButton` on which `urlParam` was `buy_now`, it occured error.

I prefer to use param `label` for FilterButton's label and `urlParam` for the query param, that'll be clearer and more precise. So I've edited the `FilterButton.vue `component and the FilterButtons on `Activity.vue` to fix this bug.

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=129QwMHtmhf7qGF5EoMxVT7dosyb9SYZTkJTfQHYQ3kUQap4&usdamount=0&donation=true)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

-  FilterButton showing text from 'buy_now' to 'Buy now'
![CleanShot 2023-08-25 at 14 00 59@2x](https://github.com/kodadot/nft-gallery/assets/17610879/44fa1f52-65ae-4692-ab2a-8aa60e5d9cdb)
- 'skeleton like on explore' now aslo works on the refetch action after clicking 'Buy now' button
https://github.com/kodadot/nft-gallery/assets/17610879/0557098d-6a08-486a-9161-31cc2e049f80
@exezbcz Please have a check~


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0dacc94</samp>

Improved the search and loading features for the items grid and refactored the `FilterButton` component. Moved the `FilterButton` component to the `items` folder and changed its props to be more descriptive and consistent.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0dacc94</samp>

> _We're changing the props of the FilterButton_
> _To make it more clear and consistent_
> _We're searching and loading the items grid_
> _With doom and despair we're persistent_
