### PR TITLE
feat: support for downloading original images

### DIFF
--- a/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
+++ b/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
@@ -29,7 +29,7 @@
 import { NeoButton, NeoDropdown, NeoDropdownItem } from '@kodadot1/brick'
 import { Interaction } from '@kodadot1/minimark/v1'
 import { downloadImage } from '@/utils/download'
-import { ipfsToCf } from '@/utils/ipfs'
+import { toOriginalContentUrl } from '@/utils/ipfs'
 
 const { $route, $i18n } = useNuxtApp()
 const { accountId } = useAuth()
@@ -45,7 +45,8 @@ const props = defineProps<{
 }>()
 
 const downloadMedia = () => {
-  props.ipfsImage && downloadImage(ipfsToCf(props.ipfsImage), props.name)
+  props.ipfsImage &&
+    downloadImage(toOriginalContentUrl(props.ipfsImage), props.name)
 }
 
 const burn = () => {

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -182,3 +182,10 @@ export function toCloudflareIpfsUrl(baseurl) {
   const url = new URL(baseurl)
   return `https://cloudflare-ipfs.com/${url.pathname}`
 }
+
+export function toOriginalContentUrl(baseurl: string) {
+  const hasQueryString = baseurl.includes('?')
+  const separator = hasQueryString ? '&' : '?'
+  const originalContentSuffix = `${separator}original=true`
+  return `${baseurl}${originalContentSuffix}`
+}

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -184,8 +184,7 @@ export function toCloudflareIpfsUrl(baseurl) {
 }
 
 export function toOriginalContentUrl(baseurl: string) {
-  const hasQueryString = baseurl.includes('?')
-  const separator = hasQueryString ? '&' : '?'
-  const originalContentSuffix = `${separator}original=true`
-  return `${baseurl}${originalContentSuffix}`
+  const url = new URL(baseurl)
+  url.searchParams.append('original', 'true')
+  return url.toString()
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #6120 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at [/ksm/gallery/13902891-008963f0b21767d825-BULL-RMRK_BULL_144-00000144](https://deploy-preview-6958--koda-canary.netlify.app/ksm/gallery/13902891-008963f0b21767d825-BULL-RMRK_BULL_144-00000144), and got the original image (995KB)
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85e1079</samp>

Added a feature to download the original image from IPFS in the gallery item menu. Implemented a new function `toOriginalContentUrl` in `utils/ipfs.ts` and used it in `GalleryItemMoreActionBtn.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 85e1079</samp>

> _`toOriginalContentUrl`_
> _Adds a query string_
> _For IPFS downloads_
