### PR TITLE
 fix: wrong usd price of dot coin in purchase cart

### DIFF
--- a/components/common/shoppingCart/utils.ts
+++ b/components/common/shoppingCart/utils.ts
@@ -3,6 +3,7 @@ import { ShoppingCartItem } from './types'
 import { useFiatStore } from '@/stores/fiat'
 import { sum } from '@/utils/math'
 import { NFT } from '@/components/rmrk/service/scheme'
+import { chainPropListOf } from '@/utils/config/chain.config'
 
 export const prefixToToken = {
   ksm: 'KSM',
@@ -14,12 +15,18 @@ export const prefixToToken = {
   dot: 'DOT',
 }
 
+const getTokenDecimal = (item: ShoppingCartItem) => {
+  const token = prefixToToken[item.urlPrefix]
+  const tokenDecimal = chainPropListOf(token.toLowerCase()).tokenDecimals
+  return tokenDecimal
+}
+
 export const totalPriceUsd = (items: ShoppingCartItem[]) => {
   const fiatStore = useFiatStore()
 
   const nftSPrice = items.map((item) =>
     calculateExactUsdFromToken(
-      Number(item.price) * Math.pow(10, -12),
+      Number(item.price) * Math.pow(10, -getTokenDecimal(item)),
       Number(fiatStore.getCurrentTokenValue(prefixToToken[item.urlPrefix]))
     )
   )
@@ -27,7 +34,7 @@ export const totalPriceUsd = (items: ShoppingCartItem[]) => {
   const royalties = items.map((item) =>
     item.royalty
       ? calculateExactUsdFromToken(
-          Number(item.royalty.amount) * Math.pow(10, -12),
+          Number(item.royalty.amount) * Math.pow(10, -getTokenDecimal(item)),
           Number(fiatStore.getCurrentTokenValue(prefixToToken[item.urlPrefix]))
         )
       : 0

--- a/components/common/shoppingCart/utils.ts
+++ b/components/common/shoppingCart/utils.ts
@@ -17,8 +17,7 @@ export const prefixToToken = {
 
 const getTokenDecimal = (item: ShoppingCartItem) => {
   const token = prefixToToken[item.urlPrefix]
-  const tokenDecimal = chainPropListOf(token.toLowerCase()).tokenDecimals
-  return tokenDecimal
+return chainPropListOf(token.toLowerCase()).tokenDecimals
 }
 
 export const totalPriceUsd = (items: ShoppingCartItem[]) => {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6961 
- [x] Closes #6943 


#### Optional


#### Did your issue had any of the "$" label on it?
My DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=12jXHf7yYF4wTRjDPbwFB24V1nVRPRkuU2S8Ke5ZWTfvyBGW&usdamount=8.82&donation=true)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

<img width="401" alt="shot" src="https://github.com/kodadot/nft-gallery/assets/22696500/f6503e5f-51bd-4694-9da2-0656149b3d77">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf06fe5</samp>

Improved token decimal handling in `shoppingCart` component. Used `getChainProperties` function to convert token prices and royalties to USD in `components/common/shoppingCart/utils.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cf06fe5</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the shopping cart component with a clever mind._
> _He imported a function to get the chain properties_
> _of tokens, and converted their prices and royalties._
