### PR TITLE
Refactor: CreateCollection

### DIFF
--- a/components/bsx/Create/CreateCollection.vue
+++ b/components/bsx/Create/CreateCollection.vue
@@ -50,6 +50,12 @@ import { BaseCollectionType } from '@/composables/transaction/types'
 import shouldUpdate from '@/utils/shouldUpdate'
 import { Token, getBalance, getDeposit, getFeesToken } from './utils'
 import { NeoField } from '@kodadot1/brick'
+import Loader from '@/components/shared/Loader.vue'
+import BaseCollectionForm from '@/components/base/BaseCollectionForm.vue'
+import SubmitButton from '@/components/base/SubmitButton.vue'
+import Money from '@/components/bsx/format/TokenMoney.vue'
+import AccountBalance from '@/components/shared/AccountBalance.vue'
+import MultiPaymentFeeButton from '@/components/bsx/specific/MultiPaymentFeeButton.vue'
 
 const emit = defineEmits(['created'])
 
@@ -59,15 +65,6 @@ const { apiUrl } = useApi()
 const { urlPrefix, tokenId } = usePrefix()
 const { status: transactionStatus, isLoading: isTransactionLoading } =
   useTransactionStatus()
-
-const Loader = () => import('@/components/shared/Loader.vue')
-const BaseCollectionForm = () =>
-  import('@/components/base/BaseCollectionForm.vue')
-const SubmitButton = () => import('@/components/base/SubmitButton.vue')
-const Money = () => import('@/components/bsx/format/TokenMoney.vue')
-const AccountBalance = () => import('@/components/shared/AccountBalance.vue')
-const MultiPaymentFeeButton = () =>
-  import('@/components/bsx/specific/MultiPaymentFeeButton.vue')
 
 const base = ref<BaseCollectionType>({
   name: '',

--- a/components/bsx/Create/CreateCollection.vue
+++ b/components/bsx/Create/CreateCollection.vue
@@ -99,6 +99,19 @@ const depositOfToken = computed(() =>
   getDeposit(feesToken.value, parseFloat(collectionDeposit.value))
 )
 
+const { transaction, status, isLoading, blockNumber } = useTransaction()
+watch([isLoading, status], () => {
+  isTransactionLoading.value = isLoading.value
+  if (Boolean(status.value)) {
+    transactionStatus.value = status.value
+  }
+})
+watch(blockNumber, (block) => {
+  if (block) {
+    emit('created')
+  }
+})
+
 async function submit(): Promise<void> {
   // check fields
   if (!checkValidity()) {
@@ -114,19 +127,6 @@ async function submit(): Promise<void> {
   }
   isTransactionLoading.value = true
   transactionStatus.value = 'loader.checkBalance'
-
-  const { transaction, status, isLoading, blockNumber } = useTransaction()
-  watch([isLoading, status], () => {
-    isTransactionLoading.value = isLoading.value
-    if (Boolean(status.value)) {
-      transactionStatus.value = status.value
-    }
-  })
-  watch(blockNumber, (block) => {
-    if (block) {
-      emit('created')
-    }
-  })
 
   try {
     showNotification(


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

1st issue is the component registration, while dynamic import (lazy-loading) component registration in this syntax works on nuxt-bridge, it doesn't work on nuxt 3.

2nd issue is the unnecessary re-registration of watcher inside a submit function. This may cause bugs or may affect performance. Everytime the function is run, another watcher watching the same reactive reference & doing the same logic is created.

This issue is also present in 
- bsx/Create/CreateToken.vue
- collection/drop/DropContainer.vue
- rmrk/Create/CreateCollection.vue
- rmrk/Create/CreateToken.vue
- stmn/Create/CreateCollection.vue

Do we want to this changes and change all the above files as well?


## PR Type

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #6959
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16UcV9V6nVvPYdHz98ymUKmNLkzjCEU5sbKJMi7hxYyTHjzR&usdamount=100&donation=true)

#### Community participation

- [ ] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5621f42</samp>

Refactored component imports and added feedback for collection creation in `CreateCollection.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5621f42</samp>

> _To make the code more compact_
> _Some components are imported direct_
> _And when you create_
> _A collection, you'll see_
> _A feedback message that's perfect_