### PR TITLE
fix: Missing USD value on gallery item

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -100,8 +100,9 @@ import {
   NeoTooltip,
 } from '@kodadot1/brick'
 import { formatToNow } from '@/utils/format/time'
-import formatBalance from '@/utils/format/balance'
+import formatBalance, { withoutDigitSeparator } from '@/utils/format/balance'
 import { parseDate } from '@/utils/datetime'
+import { getApproximatePriceOf } from '@/utils/coingecko'
 
 import type { Interaction } from '@/components/rmrk/service/scheme'
 import useSubscriptionGraphql from '@/composables/useSubscriptionGraphql'
@@ -113,6 +114,11 @@ const dprops = defineProps<{
 
 const { decimals, chainSymbol } = useChain()
 const { urlPrefix } = usePrefix()
+const tokenPrice = ref(0)
+
+onMounted(async () => {
+  tokenPrice.value = await getApproximatePriceOf(chainSymbol.value)
+})
 
 const interaction =
   urlPrefix.value === 'ksm'
@@ -159,7 +165,12 @@ watchEffect(() => {
 })
 
 const formatPrice = (price) => {
-  return formatBalance(price, decimals.value, false)
+  const tokenAmount = formatBalance(price, decimals.value, false)
+  const flatPrice = `${Math.round(
+    Number(withoutDigitSeparator(tokenAmount)) * tokenPrice.value
+  )}`
+
+  return `${tokenAmount}($${flatPrice})`
 }
 </script>
 <style lang="scss" scoped>

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -21,7 +21,10 @@
         field="meta"
         :label="`${$t(`tabs.tabActivity.price`)} (${chainSymbol})`">
         <p v-if="Number(props.row.meta)">
-          {{ formatPrice(props.row.meta) }}
+          {{ formatPrice(props.row.meta)[0] }}
+          <span class="has-text-grey">
+            (${{ formatPrice(props.row.meta)[1] }})</span
+          >
         </p>
       </NeoTableColumn>
 
@@ -169,8 +172,7 @@ const formatPrice = (price) => {
   const flatPrice = `${Math.round(
     Number(withoutDigitSeparator(tokenAmount)) * tokenPrice.value
   )}`
-
-  return `${tokenAmount}($${flatPrice})`
+  return [tokenAmount, flatPrice]
 }
 </script>
 <style lang="scss" scoped>

--- a/utils/coingecko.ts
+++ b/utils/coingecko.ts
@@ -34,9 +34,7 @@ const tokenMap = {
   BSX: 'basilisk',
 }
 
-export const getApproximatePriceOf = async (
-  id: 'KSM' | 'DOT' | 'BSX'
-): Promise<number> => {
+export const getApproximatePriceOf = async (id: string): Promise<number> => {
   const coinId = tokenMap[id]
   const stored = localStorage.getItem(id)
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #6954
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="818" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/9863ceff-ccae-4eaf-963e-624ae10f26b8">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8208fa</samp>

Added USD prices to NFT activity table and made coingecko utility function more generic. This improves the user experience and the code maintainability.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f8208fa</samp>

> _Sing, O Muse, of the skillful coder who modified the function_
> _That `getApproximatePriceOf` was called, to take a string as input_
> _And not a fixed union of tokens, as before, that limited its use_
> _But now with `tokenMap` he made it work for any coin of value._
  