### PR TITLE
fix: export const name issue

### DIFF
--- a/composables/transaction/mintToken/transactionMintBasilisk.ts
+++ b/composables/transaction/mintToken/transactionMintBasilisk.ts
@@ -56,4 +56,4 @@ const getArgs = async (item: ActionMintToken, api) => {
   return [arg]
 }
 
-export const execMintStatemine = transactionFactory(getArgs)
+export const execMintBasilisk = transactionFactory(getArgs)


### PR DESCRIPTION
sry my bad error in export constant naming. just a quick small pr to fix this one so i do not use the common pr template.

@yangwao @vikiival  @Jarsen136 

> <img width="456" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/c10b8a2d-a754-4f03-8cc6-d8a42e971983">
> 
> @floyd-li Hey, there is something broken here.

_Originally posted by @Jarsen136 in https://github.com/kodadot/nft-gallery/issues/6928#issuecomment-1694393635_
            