### PR TITLE
Search to composition API

### DIFF
--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -64,9 +64,11 @@ const emit = defineEmits<{
   (e: 'update:priceMax', value?: number): void
 }>()
 
-const { $route, $router, $consola } = useNuxtApp()
+const { $consola } = useNuxtApp()
 const { urlPrefix } = usePrefix()
 const { decimals } = useChain()
+const route = useRoute()
+const router = useRouter()
 
 const searchRef = ref(null)
 const isVisible = ref(false)
@@ -77,13 +79,13 @@ const priceRange = ref<
 const priceRangeDirty = ref(false)
 
 const query = reactive<SearchQuery>({
-  search: $route.query?.search?.toString() ?? '',
-  type: $route.query?.type?.toString() ?? '',
+  search: route.query?.search?.toString() ?? '',
+  type: route.query?.type?.toString() ?? '',
   sortByMultiple: props.sortByMultiple ?? [],
-  listed: $route.query?.listed?.toString() === 'true',
+  listed: route.query?.listed?.toString() === 'true',
 })
 
-const urlSearchQuery = computed(() => $route.query.search)
+const urlSearchQuery = computed(() => route.query.search)
 const routePathList = computed(() =>
   searchPageRoutePathList.map((route) => `/${urlPrefix.value}/explore/${route}`)
 )
@@ -95,7 +97,7 @@ const searchQuery = computed({
     updateSearch(value)
   },
 })
-const isExplorePage = computed(() => routePathList.value.includes($route.path))
+const isExplorePage = computed(() => routePathList.value.includes(route.path))
 
 type Listed = boolean | { listed: boolean; min?: string; max?: string }
 const vListed = computed({
@@ -132,17 +134,16 @@ const updateListed = useDebounceFn((value: string | Listed): boolean => {
 
 const replaceUrl = useDebounceFn(
   (queryCondition: Record<string, any>, pathName?: string) => {
-    if (pathName && pathName !== $route.path) {
+    if (pathName && pathName !== route.path) {
       return
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { page, ...restQuery } = $route.query
-    $router
+    const { page, ...restQuery } = route.query
+    router
       .replace({
-        path: $route.path,
         query: {
           ...restQuery,
-          search: searchQuery.value || $route.query.search || undefined,
+          search: searchQuery.value || route.query.search || undefined,
           ...queryCondition,
         },
       })
@@ -171,13 +172,13 @@ const updateSortBy = useDebounceFn((value: string[] | string) => {
   return final
 }, 400)
 
-const updateSearch = useDebounceFn((value: string): string => {
-  if (value !== $route.query.search && value !== searchQuery.value) {
-    replaceUrl({ search: value ? value : undefined }, $route.path)
+const updateSearch = (value: string): string => {
+  if (value !== route.query.search && value !== searchQuery.value) {
+    replaceUrl({ search: value ? value : undefined }, route.path)
   }
   emit('update:search', value)
   return value
-}, 50)
+}
 
 function bindFilterEvents(event: KeyboardEvent) {
   switch (event.key) {
@@ -223,10 +224,10 @@ function nativeSearch() {
 function redirectToGalleryPageIfNeed(params?: Record<string, string>) {
   const { isCollectionSearchMode } = useCollectionSearch()
   if (!isExplorePage.value && !isCollectionSearchMode.value) {
-    $router.push({
+    router.push({
       path: `/${urlPrefix.value}/explore/items`,
       query: {
-        ...$route.query,
+        ...route.query,
         ...params,
       },
     })
@@ -259,14 +260,14 @@ watch(urlSearchQuery, (urlSearchQuery) => {
 useKeyboardEvents({ f: bindFilterEvents })
 
 onMounted(() => {
-  if (!name.value && $route.query.search) {
-    name.value = Array.isArray($route.query.search) ? '' : $route.query.search
+  if (!name.value && route.query.search) {
+    name.value = Array.isArray(route.query.search) ? '' : route.query.search
   }
 
-  exist($route.query.search, updateSearch)
-  exist($route.query.min, (v) => updatePriceRangeByQuery(v))
-  exist($route.query.max, (v) => updatePriceRangeByQuery(undefined, v))
-  existArray($route.query.sort as string[], updateSortBy)
-  exist($route.query.listed, updateListed)
+  exist(route.query.search, updateSearch)
+  exist(route.query.min, (v) => updatePriceRangeByQuery(v))
+  exist(route.query.max, (v) => updatePriceRangeByQuery(undefined, v))
+  existArray(route.query.sort as string[], updateSortBy)
+  exist(route.query.listed, updateListed)
 })
 </script>

--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -216,7 +216,6 @@ function updatePriceRangeByQuery(minValue?: string, maxValue?: string) {
 }
 
 function nativeSearch() {
-  redirectToGalleryPageIfNeed()
   searchQuery.value = name.value
 }
 

--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -216,6 +216,7 @@ function updatePriceRangeByQuery(minValue?: string, maxValue?: string) {
 }
 
 function nativeSearch() {
+  redirectToGalleryPageIfNeed({ search: name.value })
   searchQuery.value = name.value
 }
 

--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -218,7 +218,6 @@ function updatePriceRangeByQuery(minValue?: string, maxValue?: string) {
 function nativeSearch() {
   redirectToGalleryPageIfNeed()
   searchQuery.value = name.value
-  updateSearch(name.value)
 }
 
 function redirectToGalleryPageIfNeed(params?: Record<string, string>) {

--- a/components/search/Search.vue
+++ b/components/search/Search.vue
@@ -8,14 +8,14 @@
     <div class="columns mb-0">
       <NeoField class="column is-8 mb-0 mr-2" :class="searchColumnClass">
         <slot name="next-filter"></slot>
-        <SearchBarInput
+        <SearchBar
           v-if="!hideSearchInput"
           ref="searchRef"
           v-model="name"
           :query="query"
           @redirect="redirectToGalleryPageIfNeed"
           @enter="nativeSearch"
-          @blur="onBlur"></SearchBarInput>
+          @blur="onBlur" />
         <div v-if="!isVisible && hideSearchInput">
           <div v-if="priceRangeDirty" class="is-size-7">
             <PriceRange inline />
@@ -26,301 +26,248 @@
   </div>
 </template>
 
-<script lang="ts">
-import {
-  Component,
-  Emit,
-  Prop,
-  Ref,
-  Watch,
-  mixins,
-} from 'nuxt-property-decorator'
-import { Debounce } from 'vue-debounce-decorator'
+<script lang="ts" setup>
 import { exist, existArray } from '@/utils/exist'
 import { SearchQuery } from './types'
-import PrefixMixin from '~/utils/mixins/prefixMixin'
-import KeyboardEventsMixin from '~/utils/mixins/keyboardEventsMixin'
 import { NFT_SQUID_SORT_CONDITION_LIST } from '@/utils/constants'
-import ChainMixin from '~/utils/mixins/chainMixin'
-import { usePreferencesStore } from '@/stores/preferences'
 import { NeoField } from '@kodadot1/brick'
-
+import PriceRange from '@/components/shared/format/PriceRange.vue'
 import { useCollectionSearch } from '@/components/search/utils/useCollectionSearch'
-const SearchPageRoutePathList = ['collectibles', 'items']
 
-@Component({
-  components: {
-    SearchBarInput: () => import('./SearchBar.vue'),
-    SearchPriceRange: () => import('./SearchPriceRange.vue'),
-    Pagination: () => import('@/components/rmrk/Gallery/Pagination.vue'),
-    BasicSwitch: () => import('@/components/shared/form/BasicSwitch.vue'),
-    BasicImage: () => import('@/components/shared/view/BasicImage.vue'),
-    PriceRange: () => import('@/components/shared/format/PriceRange.vue'),
-    Money: () => import('@/components/shared/format/Money.vue'),
-    NeoField,
+const searchPageRoutePathList = ['collectibles', 'items']
+
+const props = withDefaults(
+  defineProps<{
+    search?: string
+    sortByMultiple?: string[]
+    searchColumnClass?: string
+    listed?: boolean
+    hideFilter?: boolean
+    hideSearchInput?: boolean
+  }>(),
+  {
+    search: '',
+    sortByMultiple: () => [],
+    searchColumnClass: '',
+    listed: false,
+    hideFilter: false,
+    hideSearchInput: false,
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'update:search', value: string): void
+  (e: 'update:sortByMultiple', value: string[]): void
+  (e: 'update:listed', listed: boolean): void
+  (e: 'resetPage'): void
+  (e: 'update:priceMin', value?: number): void
+  (e: 'update:priceMax', value?: number): void
+}>()
+
+const { $route, $router, $consola } = useNuxtApp()
+const { urlPrefix } = usePrefix()
+const { decimals } = useChain()
+
+const searchRef = ref(null)
+const isVisible = ref(false)
+const name = ref('')
+const priceRange = ref<
+  [number | string | undefined, number | string | undefined]
+>([undefined, undefined])
+const priceRangeDirty = ref(false)
+
+const query = reactive<SearchQuery>({
+  search: $route.query?.search?.toString() ?? '',
+  type: $route.query?.type?.toString() ?? '',
+  sortByMultiple: props.sortByMultiple ?? [],
+  listed: $route.query?.listed?.toString() === 'true',
+})
+
+const urlSearchQuery = computed(() => $route.query.search)
+const routePathList = computed(() =>
+  searchPageRoutePathList.map((route) => `/${urlPrefix.value}/explore/${route}`)
+)
+const searchQuery = computed({
+  get() {
+    return props.search
+  },
+  set(value: string) {
+    updateSearch(value)
   },
 })
-export default class Search extends mixins(
-  PrefixMixin,
-  KeyboardEventsMixin,
-  ChainMixin
-) {
-  @Prop(String) public search!: string
-  @Prop(String) public type!: string
-  @Prop({ type: Array, default: () => [] }) public sortByMultiple!: string[]
-  @Prop(String) public searchColumnClass!: string
-  @Prop({ type: Boolean, default: false }) public listed!: boolean
-  @Prop(Boolean) public hideFilter!: boolean
-  @Prop(Boolean) public isMoonRiver!: boolean
-  @Prop(Boolean) public hideSearchInput!: boolean
-  @Ref('searchRef') readonly searchRef
-  public isVisible = false
-  public query: SearchQuery = {
-    search: this.$route.query?.search?.toString() ?? '',
-    type: this.$route.query?.type?.toString() ?? '',
-    sortByMultiple: this.sortByMultiple ?? [],
-    listed: this.$route.query?.listed?.toString() === 'true',
-  }
-  public name = ''
-  public priceRange: [
-    number | string | undefined,
-    number | string | undefined
-  ] = [undefined, undefined]
-  public priceRangeDirty = false
-  private preferencesStore = usePreferencesStore()
+const isExplorePage = computed(() => routePathList.value.includes($route.path))
 
-  get urlSearchQuery() {
-    return this.$route.query.search
-  }
+type Listed = boolean | { listed: boolean; min?: string; max?: string }
+const vListed = computed({
+  get() {
+    query.listed = props.listed
+    return props.listed
+  },
+  set(listed: Listed) {
+    updateListed(listed)
+  },
+})
 
-  get routePathList() {
-    return SearchPageRoutePathList.map(
-      (route) => `/${this.urlPrefix}/explore/${route}`
-    )
-  }
-
-  // clear search bar value when search is cannceled via breadcrumbs
-  @Watch('urlSearchQuery')
-  syncSearchfromUrl(urlSearchQuery) {
-    if (urlSearchQuery == undefined) {
-      this.name = ''
-    }
-  }
-
-  public created() {
-    this.initKeyboardEventHandler({
-      f: this.bindFilterEvents,
+const updateListed = useDebounceFn((value: string | Listed): boolean => {
+  let v: string
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    v = String(value)
+    replaceUrl({ listed: v })
+  } else {
+    const { listed, max, min } = value
+    v = String(listed)
+    replaceUrl({
+      listed,
+      max,
+      min,
     })
-    if (!this.name && this.$route.query.search) {
-      this.name = Array.isArray(this.$route.query.search)
-        ? ''
-        : this.$route.query.search
-    }
   }
 
-  public mounted(): void {
-    exist(this.$route.query.search, this.updateSearch)
-    exist(this.$route.query.min, (v) => this.updatePriceRangeByQuery(v))
-    exist(this.$route.query.max, (v) =>
-      this.updatePriceRangeByQuery(undefined, v)
-    )
-    existArray(this.$route.query.sort as string[], this.updateSortBy)
-    exist(this.$route.query.listed, this.updateListed)
-  }
+  const listed = v === 'true'
 
-  private bindFilterEvents(event) {
-    switch (event.key) {
-      case 'b':
-        this.updateListed(!this.vListed)
-        break
-      case 'n':
-        this.updateSortBy(['BLOCK_NUMBER_DESC'])
-        break
-      case 'o':
-        this.updateSortBy(['BLOCK_NUMBER_ASC'])
-        break
-      case 'e':
-        this.updateSortBy(['PRICE_DESC'])
-        break
-      case 'c':
-        this.updateSortBy(['PRICE_ASC'])
-        break
-    }
-  }
+  emit('update:listed', listed)
 
-  get vListed(): boolean {
-    this.query.listed = this.listed
-    return this.listed
-  }
+  return listed
+}, 50)
 
-  set vListed(
-    listed: boolean | { listed: boolean; min?: string; max?: string }
-  ) {
-    this.updateListed(listed)
-  }
-
-  get searchQuery(): string {
-    return this.search
-  }
-
-  set searchQuery(value: string) {
-    this.updateSearch(value)
-  }
-
-  get replaceBuyNowWithYolo(): boolean {
-    return this.preferencesStore.getReplaceBuyNowWithYolo
-  }
-
-  get isExplorePage() {
-    return this.routePathList.includes(this.$route.path)
-  }
-
-  @Emit('update:listed')
-  @Debounce(50)
-  updateListed(
-    value: string | boolean | { listed: boolean; min?: string; max?: string }
-  ): boolean {
-    let v = ''
-    if (typeof value === 'string' || typeof value === 'boolean') {
-      v = String(value)
-      this.replaceUrl({ listed: v })
-    } else {
-      const { listed, max, min } = value
-      v = String(listed)
-      this.replaceUrl({
-        listed,
-        max,
-        min,
-      })
-    }
-    return v === 'true'
-  }
-
-  @Emit('update:sortByMultiple')
-  @Debounce(400)
-  updateSortBy(value: string[] | string, $event?): string[] {
-    const final = (Array.isArray(value) ? value : [value]).filter((condition) =>
-      NFT_SQUID_SORT_CONDITION_LIST.includes(condition)
-    )
-    const listed = final.some(
-      (condition) => condition.toLowerCase().indexOf('price') > -1
-    )
-    if (listed && !this.vListed) {
-      this.vListed = true
-    }
-
-    if ($event?.length > final.length || !$event) {
-      this.replaceUrl({ sort: final })
-      return final
-    }
-    let newFinal: string[] = []
-    if (final.length > 0) {
-      const newlySelected = final[final.length - 1].split('_')[0]
-      newFinal = $event.filter(
-        (option) => option.split('_')[0] !== newlySelected
-      )
-      newFinal.push(final[final.length - 1])
-    }
-    this.replaceUrl({ sort: newFinal })
-    return newFinal
-  }
-
-  onBlur() {
-    if (this.isExplorePage) {
-      this.updateSearch(this.name)
-    }
-  }
-
-  @Emit('update:search')
-  @Debounce(50)
-  updateSearch(value: string): string {
-    if (value !== this.$route.query.search && value !== this.searchQuery) {
-      this.replaceUrl({ search: value ? value : undefined }, this.$route.path)
-    }
-    return value
-  }
-
-  updatePriceRangeByQuery(minValue?: string, maxValue?: string) {
-    const min = Number(minValue)
-    const max = Number(maxValue)
-    if (Number.isNaN(min) && Number.isNaN(max)) {
-      return
-    }
-    this.priceRangeDirty = true
-    if (minValue) {
-      this.priceRange = [min, this.priceRange[1]]
-      this.priceRangeChangeMin(min * 10 ** this.decimals)
-    } else {
-      this.priceRange = [this.priceRange[0], max]
-      this.priceRangeChangeMax(max * 10 ** this.decimals)
-    }
-  }
-
-  nativeSearch() {
-    this.redirectToGalleryPageIfNeed()
-    this.searchQuery = this.name
-    this.updateSearch(this.name)
-  }
-
-  public focusInput(): void {
-    this.searchRef?.focusInput()
-  }
-
-  @Debounce(100)
-  replaceUrl(queryCondition: { [key: string]: any }, pathName?: string): void {
-    if (pathName && pathName !== this.$route.path) {
+const replaceUrl = useDebounceFn(
+  (queryCondition: Record<string, any>, pathName?: string) => {
+    if (pathName && pathName !== $route.path) {
       return
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { page, ...restQuery } = this.$route.query
-    this.$router
+    const { page, ...restQuery } = $route.query
+    $router
       .replace({
-        path: this.$route.path,
+        path: $route.path,
         query: {
           ...restQuery,
-          search: this.searchQuery || this.$route.query.search || undefined,
+          search: searchQuery.value || $route.query.search || undefined,
           ...queryCondition,
         },
       })
-      .catch(this.$consola.warn)
-    // if searchbar request or filter is set, pagination should always revert to page 1
-    this.$emit('resetPage')
+      .catch($consola.warn)
+    // if a searchbar request or filter is set, pagination should always revert to page 1
+    emit('resetPage')
+  },
+  100
+)
+
+const updateSortBy = useDebounceFn((value: string[] | string) => {
+  const final = (Array.isArray(value) ? value : [value]).filter((condition) =>
+    NFT_SQUID_SORT_CONDITION_LIST.includes(condition)
+  )
+  const listed = final.some(
+    (condition) => condition.toLowerCase().indexOf('price') > -1
+  )
+  if (listed && !vListed.value) {
+    vListed.value = true
   }
 
-  redirectToGalleryPageIfNeed(params?: Record<string, string>) {
-    const { isCollectionSearchMode } = useCollectionSearch()
-    if (!this.isExplorePage && !isCollectionSearchMode.value) {
-      this.$router.push({
-        path: `/${this.urlPrefix}/explore/items`,
-        query: {
-          ...this.$route.query,
-          ...params,
-        },
-      })
-    }
-  }
+  replaceUrl({ sort: final })
 
-  public priceRangeChange([min, max]: [
-    number | undefined,
-    number | undefined
-  ]): void {
-    this.priceRangeDirty = true
-    this.priceRangeChangeMin(min ? min * 10 ** this.decimals : undefined)
-    this.priceRangeChangeMax(max ? max * 10 ** this.decimals : undefined)
-    const priceMin = min ? String(min) : undefined
-    const priceMax = max ? String(max) : undefined
-    this.query.listed = true
-    this.vListed = { listed: true, min: priceMin, max: priceMax }
-  }
+  emit('update:sortByMultiple', final)
 
-  @Emit('update:priceMin')
-  private priceRangeChangeMin(min?: number): void {
-    this.query.priceMin = min
-  }
+  return final
+}, 400)
 
-  @Emit('update:priceMax')
-  private priceRangeChangeMax(max?: number): void {
-    this.query.priceMax = max
+const updateSearch = useDebounceFn((value: string): string => {
+  if (value !== $route.query.search && value !== searchQuery.value) {
+    replaceUrl({ search: value ? value : undefined }, $route.path)
+  }
+  emit('update:search', value)
+  return value
+}, 50)
+
+function bindFilterEvents(event: KeyboardEvent) {
+  switch (event.key) {
+    case 'b':
+      updateListed(!vListed.value)
+      break
+    case 'n':
+      updateSortBy(['BLOCK_NUMBER_DESC'])
+      break
+    case 'o':
+      updateSortBy(['BLOCK_NUMBER_ASC'])
+      break
+    case 'e':
+      updateSortBy(['PRICE_DESC'])
+      break
+    case 'c':
+      updateSortBy(['PRICE_ASC'])
+      break
   }
 }
+
+function updatePriceRangeByQuery(minValue?: string, maxValue?: string) {
+  const min = Number(minValue)
+  const max = Number(maxValue)
+  if (Number.isNaN(min) && Number.isNaN(max)) {
+    return
+  }
+  priceRangeDirty.value = true
+  if (minValue) {
+    priceRange.value = [min, priceRange.value[1]]
+    priceRangeChangeMin(min * 10 ** decimals.value)
+  } else {
+    priceRange.value = [priceRange.value[0], max]
+    priceRangeChangeMax(max * 10 ** decimals.value)
+  }
+}
+
+function nativeSearch() {
+  redirectToGalleryPageIfNeed()
+  searchQuery.value = name.value
+  updateSearch(name.value)
+}
+
+function redirectToGalleryPageIfNeed(params?: Record<string, string>) {
+  const { isCollectionSearchMode } = useCollectionSearch()
+  if (!isExplorePage.value && !isCollectionSearchMode.value) {
+    $router.push({
+      path: `/${urlPrefix.value}/explore/items`,
+      query: {
+        ...$route.query,
+        ...params,
+      },
+    })
+  }
+}
+
+function priceRangeChangeMin(min?: number): void {
+  query.priceMin = min
+  emit('update:priceMin', min)
+}
+
+function priceRangeChangeMax(max?: number): void {
+  query.priceMax = max
+  emit('update:priceMax', max)
+}
+
+function onBlur() {
+  if (isExplorePage.value) {
+    updateSearch(name.value)
+  }
+}
+
+// clear search bar value when search is canceled via breadcrumbs
+watch(urlSearchQuery, (urlSearchQuery) => {
+  if (urlSearchQuery == undefined) {
+    name.value = ''
+  }
+})
+
+useKeyboardEvents({ f: bindFilterEvents })
+
+onMounted(() => {
+  if (!name.value && $route.query.search) {
+    name.value = Array.isArray($route.query.search) ? '' : $route.query.search
+  }
+
+  exist($route.query.search, updateSearch)
+  exist($route.query.min, (v) => updatePriceRangeByQuery(v))
+  exist($route.query.max, (v) => updatePriceRangeByQuery(undefined, v))
+  existArray($route.query.sort as string[], updateSortBy)
+  exist($route.query.listed, updateListed)
+})
 </script>

--- a/components/search/SearchBar.vue
+++ b/components/search/SearchBar.vue
@@ -117,7 +117,6 @@ function onEnter() {
   // insert search term in history
   searchSuggestionRef.value?.insertNewHistory()
   emits('enter')
-  emits('redirect')
 }
 
 function focusInput() {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Needs QA check

- @kodadot/qa-guild please help to review the search function

## Context

- [x] Related with #4750 
- [ ] Requires deployment <snek/rubick/worker>

Other minor adjustments during the refactoring:
1. remove unused props: `type` + `isMoonRiver`
2. remove unused param `$event` of function `updateSortBy`
3. Remove [redundant redirect event emit](https://github.com/kodadot/nft-gallery/pull/6985/files#diff-158e4134d32a8fda6880702fd80ddb55ae87b661f816e390f96ff99e0e73ccd9L120): The parent component has event handlers for both `redirect` and `enter`, and the logic for redirect is already included in `@enter`, so emitting `redirect` again after emitting `enter` will result in a duplicate redirect.

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at landing page
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=12RA5J7wGg6bDWPTZG359Pn5bCzXSJRfsifo3UktqVAjhJ9k&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9043ed</samp>

Simplified the search functionality by removing the unused `redirect` event and using the `search` event instead. Updated the `SearchBar` and `Search` components accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d9043ed</samp>

> _`SearchBar` simplifies_
> _No more `redirect` event_
> _Autumn leaves search results_
