### PR TITLE
fix: null collection in /drops pages

### DIFF
--- a/components/collection/drop/const.ts
+++ b/components/collection/drop/const.ts
@@ -4,7 +4,7 @@ const now = new Date()
 export const countDownTime = endOfWeek(now).getTime()
 
 export const STMN_COLLECTION_ID = '6'
-export const STT_COLLECTION_ID = '8'
+export const STT_COLLECTION_ID = 'u-8'
 export const pricePerMint = '9000000000' // '100000000'
 export const displayPricePerMint = 1e10
 export const STMN_DROP_CAMPAIGN = 'copenhagen'

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -70,8 +70,6 @@ watch(urlPrefix, () => checkRouteAvailability())
 onBeforeMount(() => {
   checkRouteAvailability()
 })
-
-console.log('drops', statemintDrops)
 </script>
 
 <style lang="scss" scoped>

--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -30,7 +30,7 @@ export function useDrops(collectionId: string, clientName?: string) {
   })
 
   watch(collectionData, () => {
-    if (collectionData.value) {
+    if (collectionData.value?.collectionEntity) {
       const { collectionEntity, nftEntitiesConnection } = collectionData.value
       const drops: Drop[] = []
       drops.push({

--- a/composables/useSubscriptionGraphql.ts
+++ b/composables/useSubscriptionGraphql.ts
@@ -41,7 +41,7 @@ export default function ({
     },
     {
       next: (data) => {
-        $consola.log(`ws subscription: New changes: ${JSON.stringify(data)}`)
+        // ws subscription: New change received
         onChange(data)
       },
       error: (error) => {

--- a/composables/useSubscriptionGraphql.ts
+++ b/composables/useSubscriptionGraphql.ts
@@ -41,7 +41,7 @@ export default function ({
     },
     {
       next: (data) => {
-        // ws subscription: New change received
+        $consola.log(`ws subscription: New changes: ${JSON.stringify(data)}`)
         onChange(data)
       },
       error: (error) => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #6992
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

<img width="1298" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/78c7d38b-8962-4c2d-87de-caa2910df96a">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 255ad14</samp>

Updated the collection ID format and fixed a bug in the `useDrops` function. These changes enable user collections and improve the stability of the drops feature.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 255ad14</samp>

> _`STT_COLLECTION_ID`_
> _New format with prefix `u-`_
> _User collections bloom_
  