### PR TITLE
Fix/copies-on-basilisk

### DIFF
--- a/components/bsx/Create/CreateToken.vue
+++ b/components/bsx/Create/CreateToken.vue
@@ -41,7 +41,6 @@
         <NeoField key="advanced">
           <CollapseWrapper
             v-if="base.copies > 1"
-            \
             visible="mint.expert.show"
             hidden="mint.expert.hide"
             class="mt-3">

--- a/components/bsx/Create/CreateToken.vue
+++ b/components/bsx/Create/CreateToken.vue
@@ -40,7 +40,8 @@
       <template #footer>
         <NeoField key="advanced">
           <CollapseWrapper
-            v-if="base.edition > 1"
+            v-if="base.copies > 1"
+            \
             visible="mint.expert.show"
             hidden="mint.expert.hide"
             class="mt-3">
@@ -147,7 +148,7 @@ const base = ref<BaseTokenType>({
   file: null,
   description: '',
   selectedCollection: null,
-  edition: 1,
+  copies: 1,
   secondFile: null,
 })
 const collections = ref<MintedCollection[]>([])
@@ -161,7 +162,7 @@ const hasRoyalty = ref(true)
 const feesToken = ref<Token>('BSX')
 const royalty = ref<Royalty>({
   amount: 0.15,
-  address: '',
+  address: accountId.value,
 })
 const balanceNotEnough = ref(false)
 

--- a/composables/transaction/mintToken/transactionMintBasilisk.ts
+++ b/composables/transaction/mintToken/transactionMintBasilisk.ts
@@ -2,7 +2,7 @@ import type { ActionMintToken, MintedCollection, TokenToMint } from '../types'
 import { isRoyaltyValid } from '@/utils/royalty'
 import { constructMeta } from './constructMeta'
 import { BaseMintedCollection } from '@/components/base/types'
-import { transactionFactory } from './utils'
+import { expandCopies, transactionFactory } from './utils'
 
 const prepareTokenMintArgs = async (
   token: TokenToMint,
@@ -38,8 +38,9 @@ const prepareTokenMintArgs = async (
 const getArgs = async (item: ActionMintToken, api) => {
   const { $consola } = useNuxtApp()
 
-  const tokens = Array.isArray(item.token) ? item.token : [item.token]
-
+  const tokens = expandCopies(
+    Array.isArray(item.token) ? item.token : [item.token]
+  )
   const arg = (
     await Promise.all(
       tokens.map((token, i) => {

--- a/composables/transaction/mintToken/transactionMintStatemine.ts
+++ b/composables/transaction/mintToken/transactionMintStatemine.ts
@@ -2,12 +2,7 @@ import { BaseMintedCollection } from '@/components/base/types'
 import type { ActionMintToken, MintedCollection } from '../types'
 import { TokenToMint } from '../types'
 import { constructMeta } from './constructMeta'
-import {
-  calculateFees,
-  copiesToMint,
-  expandCopies,
-  transactionFactory,
-} from './utils'
+import { calculateFees, expandCopies, transactionFactory } from './utils'
 import { canSupport } from '@/utils/support'
 
 type id = { id: number }

--- a/composables/transaction/mintToken/transactionMintStatemine.ts
+++ b/composables/transaction/mintToken/transactionMintStatemine.ts
@@ -2,7 +2,12 @@ import { BaseMintedCollection } from '@/components/base/types'
 import type { ActionMintToken, MintedCollection } from '../types'
 import { TokenToMint } from '../types'
 import { constructMeta } from './constructMeta'
-import { calculateFees, copiesToMint, transactionFactory } from './utils'
+import {
+  calculateFees,
+  copiesToMint,
+  expandCopies,
+  transactionFactory,
+} from './utils'
 import { canSupport } from '@/utils/support'
 
 type id = { id: number }
@@ -20,24 +25,6 @@ export const assignIds = <T extends TokenToMint>(tokens: T[]): (T & id)[] => {
       ...token,
       id: ++lastId,
     }
-  })
-}
-
-export const expandCopies = <T extends TokenToMint>(tokens: T[]): T[] => {
-  return tokens.flatMap((token) => {
-    const copies = copiesToMint(token)
-    if (copies === 1) {
-      return token
-    }
-
-    return Array(copies)
-      .fill(null)
-      .map((_, index) => {
-        return {
-          ...token,
-          name: token.postfix ? `${token.name} #${index + 1}` : token.name,
-        }
-      })
   })
 }
 

--- a/composables/transaction/mintToken/utils.ts
+++ b/composables/transaction/mintToken/utils.ts
@@ -62,3 +62,21 @@ export const transactionFactory = (getArgs) => {
     })
   }
 }
+
+export const expandCopies = <T extends TokenToMint>(tokens: T[]): T[] => {
+  return tokens.flatMap((token) => {
+    const copies = copiesToMint(token)
+    if (copies === 1) {
+      return token
+    }
+
+    return Array(copies)
+      .fill(null)
+      .map((_, index) => {
+        return {
+          ...token,
+          name: token.postfix ? `${token.name} #${index + 1}` : token.name,
+        }
+      })
+  })
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review
-  testing is possibly blocked by https://github.com/kodadot/nft-gallery/issues/6995

## Context

- [x] Closes #6918
- [x] fixes an unreported bug: royalty didn't work


https://basilisk.subscan.io/extrinsic/4090104-2
https://canary.kodadot.xyz/bsx/gallery/3103123271-2

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6fcb30</samp>

This pull request improves the functionality and user experience of minting multiple tokens on Basilisk and Statemine networks. It renames the `edition` field to `copies` and sets a default royalty recipient. It also refactors the code to use a common `expandCopies` function from the `utils` module to generate the tokens array.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d6fcb30</samp>

> _Sing, O Muse, of the skillful coder who refines his craft_
> _With `expandCopies`, a function of great utility and power_
> _That multiplies the tokens with their names and metadata_
> _And sends them forth to mint on different networks with ease._
