### PR TITLE
Set close button size

### DIFF
--- a/components/common/NotificationBox/NotificationBoxModal.vue
+++ b/components/common/NotificationBox/NotificationBoxModal.vue
@@ -3,7 +3,7 @@
     v-if="isOpen"
     class="notification-modal-container theme-background-color border-left is-flex is-flex-direction-column">
     <header
-      class="py-5 px-6 is-flex is-justify-content-space-between border-bottom mb-4">
+      class="py-5 px-6 is-flex is-justify-content-space-between border-bottom mb-4 is-align-items-center">
       <span class="modal-card-title is-size-6 has-text-weight-bold">
         {{ $t('notification.notifications') }}
       </span>

--- a/components/common/confirmPurchaseModal/ConfirmPurchaseModal.vue
+++ b/components/common/confirmPurchaseModal/ConfirmPurchaseModal.vue
@@ -7,7 +7,7 @@
     @close="onClose">
     <div class="modal-width">
       <header
-        class="py-5 px-6 is-flex is-justify-content-space-between border-bottom">
+        class="py-5 px-6 is-flex is-justify-content-space-between border-bottom is-align-items-center">
         <span class="modal-card-title is-size-6 has-text-weight-bold">
           {{ $t('confirmPurchase.action') }}
         </span>

--- a/components/common/shoppingCart/ShoppingCartModal.vue
+++ b/components/common/shoppingCart/ShoppingCartModal.vue
@@ -3,7 +3,7 @@
     <div
       class="shopping-cart-modal-container theme-background-color border-left is-flex is-flex-direction-column">
       <header
-        class="py-5 px-6 is-flex is-justify-content-space-between border-bottom">
+        class="py-5 px-6 is-flex is-justify-content-space-between border-bottom is-align-items-center">
         <span class="modal-card-title is-size-6 has-text-weight-bold">
           {{ $t('shoppingCart.title') }}
         </span>

--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -216,8 +216,3 @@
 .is-fixed-width {
   width: 10rem;
 }
-
-.is-close-btn {
-  width: 24px;
-  height: 24px;
-}

--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -216,3 +216,8 @@
 .is-fixed-width {
   width: 10rem;
 }
+
+.is-close-btn {
+  width: 24px;
+  height: 24px;
+}

--- a/libs/ui/src/components/NeoButton/NeoButton.vue
+++ b/libs/ui/src/components/NeoButton/NeoButton.vue
@@ -5,7 +5,9 @@
       'is-fixed-width': fixedWidth,
       'no-shadow': noShadow,
       'loading-with-label': loadingWithLabel,
-      'is-close-btn': icon === 'xmark' || icon === 'close',
+      'p-2': size === 'small' && isCloseBtn,
+      'p-1': size === 'medium' && isCloseBtn,
+      'px-1': size === 'large' && isCloseBtn,
     }"
     :size="size"
     :icon-right="icon"
@@ -26,7 +28,7 @@
 import { OButton } from '@oruga-ui/oruga'
 import { NeoButtonVariant } from '@kodadot1/brick'
 
-defineProps<{
+const prop = defineProps<{
   size?: 'small' | 'medium' | 'large'
   disabled?: boolean
   expanded?: boolean
@@ -41,6 +43,8 @@ defineProps<{
   tag?: string
   loadingWithLabel?: boolean
 }>()
+
+const isCloseBtn = prop.icon === 'xmark' || prop.icon === 'close'
 </script>
 
 <style lang="scss">

--- a/libs/ui/src/components/NeoButton/NeoButton.vue
+++ b/libs/ui/src/components/NeoButton/NeoButton.vue
@@ -5,6 +5,7 @@
       'is-fixed-width': fixedWidth,
       'no-shadow': noShadow,
       'loading-with-label': loadingWithLabel,
+      'is-close-btn': icon === 'xmark' || icon === 'close',
     }"
     :size="size"
     :icon-right="icon"
@@ -25,21 +26,21 @@
 import { OButton } from '@oruga-ui/oruga'
 import { NeoButtonVariant } from '@kodadot1/brick'
 
-  defineProps<{
-    size?: 'small' | 'medium' | 'large'
-    disabled?: boolean
-    expanded?: boolean
-    icon?: string
-    iconPack?: string
-    label?: string
-    active?: boolean
-    fixedWidth?: boolean
-    noShadow?: boolean
-    variant?: NeoButtonVariant
-    rounded?: boolean
-    tag?: string
-    loadingWithLabel?: boolean
-  }>()
+defineProps<{
+  size?: 'small' | 'medium' | 'large'
+  disabled?: boolean
+  expanded?: boolean
+  icon?: string
+  iconPack?: string
+  label?: string
+  active?: boolean
+  fixedWidth?: boolean
+  noShadow?: boolean
+  variant?: NeoButtonVariant
+  rounded?: boolean
+  tag?: string
+  loadingWithLabel?: boolean
+}>()
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring

## Context

- [X] Part of #6988
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried to respect high code quality standards
- [X] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [X] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16hqk8Tjugo9AwSzKkxXc1dsRK7iJetpx1YBaoXYwdHzuNAt&usdamount=50&donation=true)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [X] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
![Screenshot from 2023-08-28 11-39-25](https://github.com/kodadot/nft-gallery/assets/47194071/4f98579d-840d-4036-bf68-e46ad36e90a5)
![Screenshot from 2023-08-28 11-39-17](https://github.com/kodadot/nft-gallery/assets/47194071/348c4c37-5395-42dc-a42e-6068a2bb388d)



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3718fd</samp>

Added a new class and a new prop type to the `NeoButton` component to enable more customization and functionality, and used them to improve the appearance and behavior of the close button in the shopping cart modal.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c3718fd</samp>

> _Oh, we're the coders of the sea, and we work on the UI_
> _We add some classes and some props to make the buttons look nice_
> _We heave and ho on the `is-align-items-center`_
> _And we sing a merry tune as we close the modal with `is-close-btn`_
