### PR TITLE
refactor: adjust profile bottom nav

### DIFF
--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -8,14 +8,14 @@
         v-safe-href="menu.to"
         class="wallet-asset-menu">
         <span>{{ menu.label }}</span>
-        <NeoIcon icon="angle-right" class="has-text-grey" />
+        <NeoIcon icon="angle-right" size="medium" class="has-text-grey" />
       </a>
     </div>
     <div
-      class="wallet-asset-footer is-flex is-justify-content-space-between py-4 is-size-7 has-text-grey">
+      class="wallet-asset-footer is-flex is-justify-content-space-between py-5 is-size-7 has-text-grey">
       <!-- light/dark mode -->
-      <div @click="toggleColorMode">
-        <NeoIcon icon="circle-half-stroke" />
+      <div class="is-align-items-center" @click="toggleColorMode">
+        <NeoIcon icon="circle-half-stroke" custom-size="fa-2x" />
         <span v-if="isDarkMode">{{ $t('profileMenu.lightMode') }}</span>
         <span v-else>{{ $t('profileMenu.darkMode') }}</span>
       </div>
@@ -24,8 +24,10 @@
       <div data-cy="sidebar-language">
         <NeoDropdown position="top-left" aria-role="menu" mobile-modal>
           <template #trigger>
-            <NeoIcon icon="globe" />
-            <span>{{ $t('profileMenu.language') }}</span>
+            <div class="is-flex is-align-items-center">
+              <NeoIcon icon="globe" custom-size="fa-2x" class="mr-1" />
+              <span>{{ $t('profileMenu.language') }}</span>
+            </div>
           </template>
 
           <NeoDropdownItem
@@ -42,10 +44,10 @@
       </div>
 
       <!-- settings -->
-      <a href="/settings" class="has-text-grey">
-        <NeoIcon icon="gear" />
+      <nuxt-link to="/settings" class="has-text-grey is-align-items-center">
+        <NeoIcon icon="gear" custom-size="fa-2x" />
         <span>{{ $t('settings') }}</span>
-      </a>
+      </nuxt-link>
     </div>
   </div>
 </template>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #7015
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6744e0</samp>

Improved the UI and UX of the wallet asset menu component. Used `nuxt-link` for settings to optimize performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c6744e0</samp>

> _Oh we're the crew of the nuxt-link ship, and we sail the web so fast_
> _We tweak the icons and align the elements, to make the wallet asset menu last_
> _Heave away, me hearties, heave away with glee_
> _We'll raise the yardarm with our code, on the count of one, two, three_
