### PR TITLE
feature: show original content if the user clicks the preview button

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -176,7 +176,7 @@ import GalleryItemAction from './GalleryItemAction/GalleryItemAction.vue'
 import GalleryItemPreviewer from './GalleryItemPreviewer.vue'
 import { convertMarkdownToText } from '@/utils/markdown'
 import { exist } from '@/utils/exist'
-import { sanitizeIpfsUrl } from '@/utils/ipfs'
+import { sanitizeIpfsUrl, toOriginalContentUrl } from '@/utils/ipfs'
 import { generateNftImage } from '@/utils/seoImageGenerator'
 import { formatBalanceEmptyOnZero } from '@/utils/format/balance'
 import { MediaType } from '@/components/rmrk/types'
@@ -234,9 +234,11 @@ const hasAnimatedResources = computed(
     nftResources.value[1].animation
 )
 
-const previewItemSrc = computed(
-  () => (hasResources.value && activeCarouselImage.value) || nftImage.value
-)
+const previewItemSrc = computed(() => {
+  const baseUrl =
+    (hasResources.value && activeCarouselImage.value) || nftImage.value
+  return baseUrl ? toOriginalContentUrl(baseUrl) : baseUrl
+})
 
 const onNFTBought = () => {
   activeTab.value = tabs.activity


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #6638
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=129QwMHtmhf7qGF5EoMxVT7dosyb9SYZTkJTfQHYQ3kUQap4&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
https://github.com/kodadot/nft-gallery/assets/17610879/a2a2a15e-7c47-4e54-ac4f-26ec71b4de5f

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0558524</samp>

Improved gallery preview images by using IPFS original content URLs. Modified `GalleryItem.vue` to use the `toOriginalContentUrl` utility function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0558524</samp>

> _`toOriginalContentUrl`_
> _transforms IPFS base links_
> _gallery shines in spring_
