### PR TITLE
feat: Fix denomination to single decimal and bigger numbers short wit…

### DIFF
--- a/components/balance/MultipleBalances.vue
+++ b/components/balance/MultipleBalances.vue
@@ -31,10 +31,10 @@
           </div>
 
           <div class="has-text-right is-flex-grow-2">
-            {{ token.details?.balance }}
+            {{ formatNumber(token.details?.balance) }}
           </div>
           <div class="has-text-right is-flex-grow-2">
-            ${{ delimiter(token.details?.usd || '0') }}
+            ${{ formatNumber(token.details?.usd || '0') }}
           </div>
         </div>
       </div>
@@ -48,7 +48,9 @@
     <hr class="my-2" />
     <p class="is-flex is-justify-content-space-between is-align-items-flex-end">
       <span class="is-size-7"> {{ $i18n.t('spotlight.total') }}: </span>
-      <span class="is-size-6">${{ delimiter(identityStore.getTotalUsd) }}</span>
+      <span class="is-size-6"
+        >${{ formatNumber(identityStore.getTotalUsd) }}</span
+      >
     </p>
   </div>
 </template>
@@ -60,8 +62,7 @@ import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
 import { CHAINS, ENDPOINT_MAP } from '@kodadot1/static'
 import { NeoSkeleton } from '@kodadot1/brick'
 import { balanceOf } from '@kodadot1/sub-api'
-
-import format from '@/utils/format/balance'
+import format, { formatNumber } from '@/utils/format/balance'
 import { useFiatStore } from '@/stores/fiat'
 import { calculateExactUsdFromToken } from '@/utils/calculation'
 import { getAssetIdByAccount } from '@/utils/api/bsx/query'
@@ -115,16 +116,6 @@ const currentNetwork = computed(() =>
   isTestnet.value ? 'test-network' : 'main-network'
 )
 
-function delimiter(amount: string | number) {
-  const formatAmount = typeof amount === 'number' ? amount.toString() : amount
-  const number = parseFloat(formatAmount.replace(/,/g, ''))
-
-  return number.toLocaleString('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  })
-}
-
 const fiatStore = useFiatStore()
 function calculateUsd(amount: string, token = 'KSM') {
   if (!amount) {
@@ -174,8 +165,7 @@ async function getBalance(chainName: string, token = 'KSM', tokenId = 0) {
     selectedTokenId = await getAssetIdByAccount(api, prefixAddress)
   }
 
-  const balance = delimiter(currentBalance)
-  const usd = calculateUsd(balance, token)
+  const usd = calculateUsd(currentBalance, token)
 
   identityStore.setMultiBalances({
     address: defaultAddress,
@@ -183,7 +173,7 @@ async function getBalance(chainName: string, token = 'KSM', tokenId = 0) {
       [chainName]: {
         [token.toLowerCase()]: {
           address: prefixAddress,
-          balance,
+          balance: currentBalance,
           nativeBalance,
           usd,
           selected: selectedTokenId === String(tokenId),

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -103,7 +103,10 @@ import {
   NeoTooltip,
 } from '@kodadot1/brick'
 import { formatToNow } from '@/utils/format/time'
-import formatBalance, { withoutDigitSeparator } from '@/utils/format/balance'
+import formatBalance, {
+  formatNumber,
+  withoutDigitSeparator,
+} from '@/utils/format/balance'
 import { parseDate } from '@/utils/datetime'
 import { getApproximatePriceOf } from '@/utils/coingecko'
 
@@ -169,10 +172,10 @@ watchEffect(() => {
 
 const formatPrice = (price) => {
   const tokenAmount = formatBalance(price, decimals.value, false)
-  const flatPrice = `${Math.round(
+  const flatPrice = `${formatNumber(
     Number(withoutDigitSeparator(tokenAmount)) * tokenPrice.value
   )}`
-  return [tokenAmount, flatPrice]
+  return [formatNumber(tokenAmount), flatPrice]
 }
 </script>
 <style lang="scss" scoped>

--- a/tests/utils/formatBalance.spec.ts
+++ b/tests/utils/formatBalance.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-loss-of-precision */
 
-import { checkInvalidBalanceFilter } from '@/utils/format/balance'
+import { checkInvalidBalanceFilter, formatNumber } from '@/utils/format/balance'
 import format from '@/utils/format/balance'
 
 describe('FORMAT BALANCE TEST', (): void => {
@@ -28,5 +28,31 @@ describe('FORMAT BALANCE TEST', (): void => {
     expect(formatBalance(1567020000000000)).toBe('1,567.0200')
     expect(formatBalance(1089218822222222.2)).toBe('1,089.2188')
     expect(formatBalance(1060330916129032.2)).toBe('1,060.3309')
+  })
+
+  it('TEST formatNumber', () => {
+    const cases = [
+      [0, '0'],
+      [1, '1'],
+      [1.1, '1.1'],
+      [1.15, '1.1'],
+      [1.16, '1.2'],
+      [0.1, '0.1'],
+      [0.09, '0.09'],
+      [0.009, '0.009'],
+      [0.0009, '0.0009'],
+      [0.00009, '0.0001'],
+      [1000, '1k'],
+      [1200, '1.2k'],
+      [1900, '1.9k'],
+      [1000000, '1M'],
+      [1100000, '1.1M'],
+      [1110000, '1.1M'],
+      [10000000, '10M'],
+    ]
+
+    cases.forEach(([input, expected]) => {
+      expect(formatNumber(input)).toBe(expected)
+    })
   })
 })

--- a/tests/utils/formatBalance.spec.ts
+++ b/tests/utils/formatBalance.spec.ts
@@ -51,6 +51,12 @@ describe('FORMAT BALANCE TEST', (): void => {
       [10000000, '10M'],
     ]
 
+    // string input
+    cases.forEach(([input, expected]) => {
+      expect(formatNumber(String(input))).toBe(expected)
+    })
+
+    // number input
     cases.forEach(([input, expected]) => {
       expect(formatNumber(input)).toBe(expected)
     })

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -27,21 +27,26 @@ export function formatNumber(amount?: string | number): string {
   if (!amount) {
     return '0'
   }
-  const numStr = typeof amount === 'number' ? amount.toString() : amount
-  const number = Number(withoutDigitSeparator(numStr))
+  const number =
+    typeof amount === 'number' ? amount : Number(withoutDigitSeparator(amount))
 
+  let formattedNumber
   if (number >= 1000000) {
-    return (number / 1000000).toFixed(1).replace(/\.0$/, '') + 'M'
+    formattedNumber = (number / 1000000).toFixed(1).replace(/\.0$/, '') + 'M'
   } else if (number >= 1000) {
-    return (number / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
+    formattedNumber = (number / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
+  } else if (number === 0) {
+    formattedNumber = '0'
   } else if (number < 0.001) {
-    return number.toFixed(4)
+    formattedNumber = number.toFixed(4)
   } else if (number < 0.01) {
-    return number.toFixed(3)
+    formattedNumber = number.toFixed(3)
   } else if (number < 0.1) {
-    return number.toFixed(2)
+    formattedNumber = number.toFixed(2)
+  } else {
+    formattedNumber = number.toFixed(1).replace(/\.0$/, '')
   }
-  return number.toFixed(1).replace(/\.0$/, '')
+  return formattedNumber
 }
 
 export function calculateBalance(value: number, decimals = 12): number {

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -23,6 +23,31 @@ function format(
   }
 }
 
+export function formatNumber(amount?: string | number): string {
+  if (!amount) {
+    return '0'
+  }
+  const numStr = typeof amount === 'number' ? amount.toString() : amount
+  const number = Number(withoutDigitSeparator(numStr))
+
+  if (number >= 1000000) {
+    return (number / 1000000).toFixed(1).replace(/\.0$/, '') + 'M'
+  }
+  if (number >= 1000) {
+    return (number / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
+  }
+  if (number < 0.001) {
+    return number.toFixed(4).replace(/\0{1,}$/, '')
+  }
+  if (number < 0.01) {
+    return number.toFixed(3).replace(/\0{1,}$/, '')
+  }
+  if (number < 0.1) {
+    return number.toFixed(2).replace(/\0{1,}$/, '')
+  }
+  return number.toFixed(1).replace(/\.0$/, '')
+}
+
 export function calculateBalance(value: number, decimals = 12): number {
   return Math.trunc(value * Math.pow(10, decimals))
 }

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -32,18 +32,14 @@ export function formatNumber(amount?: string | number): string {
 
   if (number >= 1000000) {
     return (number / 1000000).toFixed(1).replace(/\.0$/, '') + 'M'
-  }
-  if (number >= 1000) {
+  } else if (number >= 1000) {
     return (number / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
-  }
-  if (number < 0.001) {
-    return number.toFixed(4).replace(/\0{1,}$/, '')
-  }
-  if (number < 0.01) {
-    return number.toFixed(3).replace(/\0{1,}$/, '')
-  }
-  if (number < 0.1) {
-    return number.toFixed(2).replace(/\0{1,}$/, '')
+  } else if (number < 0.001) {
+    return number.toFixed(4)
+  } else if (number < 0.01) {
+    return number.toFixed(3)
+  } else if (number < 0.1) {
+    return number.toFixed(2)
   }
   return number.toFixed(1).replace(/\.0$/, '')
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #6998
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="351" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/48a70b15-2255-4e8d-8b55-824cc9c2dc9c">

<img width="641" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/a8ada529-98c6-456e-b3fa-fd47b624b4e6">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9b810b</samp>

The pull request adds a `formatNumber` function to the `format/balance` module and uses it to improve the formatting of token and usd values in the `MultipleBalances` and `GalleryItemActivityTable` components. It also adds a unit test for the `formatNumber` function. The goal is to enhance the readability and consistency of the balance formatting across the app.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c9b810b</samp>

> _`formatNumber` helps_
> _balance and transaction views_
> _autumn of clarity_
  