### PR TITLE
:bug: eslint confusion on single quotes

### DIFF
--- a/pages/carbonless.vue
+++ b/pages/carbonless.vue
@@ -163,7 +163,7 @@ export default {
     const metaData = {
       title,
       description:
-        'Join KodaDot in the quest for a carbon-negative future in digital art. Learn how we\'re pioneering eco-friendly NFT minting, collaborating with Offsetra, and empowering artists and collectors to make a positive environmental impact.',
+        'Join KodaDot in the quest for a carbon-negative future in digital art. Learn how we are pioneering eco-friendly NFT minting, collaborating with Offsetra, and empowering artists and collectors to make a positive environmental impact.',
       url: '/carbonless',
     }
     return {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

I have seen that many times eslint and prettier change quotes on this sentence and then our build fail based on this.


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4524c7</samp>

Edited the carbonless page description to improve readability and style. Fixed a minor grammatical issue with `we're`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b4524c7</samp>

> _`carbonless` page_
> _we are, not we're, in the text_
> _autumn editing_
