### PR TITLE
refactor seoMetaGenrator.ts

### DIFF
--- a/plugins/seoMetaGenerator.ts
+++ b/plugins/seoMetaGenerator.ts
@@ -1,5 +1,5 @@
-import { MediaType } from '~/components/rmrk/types'
-import { resolveMedia } from '~/utils/gallery/media'
+import { MediaType } from '@/components/rmrk/types'
+import { resolveMedia } from '@/utils/gallery/media'
 import { convertMarkdownToText } from '@/utils/markdown'
 declare module 'vue/types/vue' {
   // this.$seoMeta inside Vue components
@@ -26,21 +26,132 @@ interface MetaTag {
   content?: string
 }
 
-export default function ({ app }, inject): void {
-  const getMetaType = (mediaType: MediaType | string | undefined): string => {
-    switch (mediaType) {
-      case MediaType.VIDEO:
-        return 'video:other'
-      case MediaType.AUDIO:
-        return 'music:song'
-      case MediaType.IMAGE:
-      case MediaType.JSON:
-      case MediaType.OBJECT:
-      default:
-        return 'website'
-    }
+const getMetaType = (mediaType: MediaType | string | undefined): string => {
+  switch (mediaType) {
+    case MediaType.VIDEO:
+      return 'video:other'
+    case MediaType.AUDIO:
+      return 'music:song'
+    case MediaType.IMAGE:
+    case MediaType.JSON:
+    case MediaType.OBJECT:
+    default:
+      return 'website'
   }
+}
 
+const getSeoTags = (meta, title, description, type, baseUrl, image) => [
+  {
+    hid: 'title',
+    name: 'title',
+    content: meta?.title ? `${meta.title} | ${title}` : title,
+  },
+  {
+    hid: 'description',
+    name: 'description',
+    content: convertMarkdownToText(meta?.description || description),
+  },
+  {
+    hid: 'og:type',
+    property: 'og:type',
+    content: getMetaType(type),
+  },
+  {
+    hid: 'og:url',
+    property: 'og:url',
+    content: `${baseUrl}${meta?.url || ''}`,
+  },
+  {
+    hid: 'og:title',
+    property: 'og:title',
+    content: meta?.title ? `${meta.title} | ${title}` : title,
+  },
+  {
+    hid: 'og:site_name',
+    property: 'og:site_name',
+    content: 'KodaDot - Polkadot / Kusama NFT explorer',
+  },
+  {
+    hid: 'og:description',
+    property: 'og:description',
+    content: convertMarkdownToText(meta?.description || description),
+  },
+  {
+    hid: 'og:image',
+    property: 'og:image',
+    content: meta?.image || image,
+  },
+  {
+    hid: 'twitter:url',
+    property: 'twitter:url',
+    content: `${baseUrl}${meta?.url || ''}`,
+  },
+  {
+    hid: 'twitter:title',
+    property: 'twitter:title',
+    content: meta?.title || title,
+  },
+  {
+    hid: 'twitter:description',
+    property: 'twitter:description',
+    content: convertMarkdownToText(meta?.description || description),
+  },
+  {
+    hid: 'twitter:image',
+    property: 'twitter:image',
+    content: meta?.image || image,
+  },
+  {
+    hid: 'twitter:card',
+    property: 'twitter:card',
+    content: 'summary_large_image',
+  },
+]
+
+const getVideoMetaTags = (meta) => [
+  {
+    hid: 'og:video',
+    property: 'og:video',
+    content: meta?.video,
+  },
+  {
+    hid: 'og:video:width',
+    property: 'og:video:width',
+    content: '1280',
+  },
+  {
+    hid: 'og:video:height',
+    property: 'og:video:height',
+    content: '720',
+  },
+  {
+    hid: 'og:video:type',
+    property: 'og:video:type',
+    content: meta?.mime,
+  },
+  {
+    hid: 'twitter:player:width',
+    property: 'twitter:player:width',
+    content: '1280',
+  },
+  {
+    hid: 'twitter:player:height',
+    property: 'twitter:player:height',
+    content: '720',
+  },
+  {
+    hid: 'twitter:card',
+    property: 'twitter:card',
+    content: 'player',
+  },
+  {
+    hid: 'twitter:player',
+    property: 'twitter:player',
+    content: meta?.video,
+  },
+]
+
+export default function ({ app }, inject): void {
   const seoMeta = (meta: MetaProperties): MetaTag[] => {
     const baseUrl: string = app.$config.public.baseUrl
     const title = 'KodaDot - NFT Market Explorer'
@@ -48,73 +159,14 @@ export default function ({ app }, inject): void {
     const image = `${baseUrl}/k_card.png`
     const type = resolveMedia(meta?.mime)
 
-    const seoTags: MetaTag[] = [
-      {
-        hid: 'title',
-        name: 'title',
-        content: meta?.title ? `${meta.title} | ${title}` : title,
-      },
-      {
-        hid: 'description',
-        name: 'description',
-        content: convertMarkdownToText(meta?.description || description),
-      },
-      {
-        hid: 'og:type',
-        property: 'og:type',
-        content: getMetaType(type),
-      },
-      {
-        hid: 'og:url',
-        property: 'og:url',
-        content: `${baseUrl}${meta?.url || ''}`,
-      },
-      {
-        hid: 'og:title',
-        property: 'og:title',
-        content: meta?.title ? `${meta.title} | ${title}` : title,
-      },
-      {
-        hid: 'og:site_name',
-        property: 'og:site_name',
-        content: 'KodaDot - Polkadot / Kusama NFT explorer',
-      },
-      {
-        hid: 'og:description',
-        property: 'og:description',
-        content: convertMarkdownToText(meta?.description || description),
-      },
-      {
-        hid: 'og:image',
-        property: 'og:image',
-        content: meta?.image || image,
-      },
-      {
-        hid: 'twitter:url',
-        property: 'twitter:url',
-        content: `${baseUrl}${meta?.url || ''}`,
-      },
-      {
-        hid: 'twitter:title',
-        property: 'twitter:title',
-        content: meta?.title || title,
-      },
-      {
-        hid: 'twitter:description',
-        property: 'twitter:description',
-        content: convertMarkdownToText(meta?.description || description),
-      },
-      {
-        hid: 'twitter:image',
-        property: 'twitter:image',
-        content: meta?.image || image,
-      },
-      {
-        hid: 'twitter:card',
-        property: 'twitter:card',
-        content: 'summary_large_image',
-      },
-    ]
+    const seoTags: MetaTag[] = getSeoTags(
+      meta,
+      title,
+      description,
+      type,
+      baseUrl,
+      image
+    )
 
     if (type === MediaType.IMAGE) {
       const imageMetaTags: MetaTag[] = [
@@ -128,48 +180,7 @@ export default function ({ app }, inject): void {
     }
 
     if (type === MediaType.VIDEO) {
-      const videoMetaTags: MetaTag[] = [
-        {
-          hid: 'og:video',
-          property: 'og:video',
-          content: meta?.video,
-        },
-        {
-          hid: 'og:video:width',
-          property: 'og:video:width',
-          content: '1280',
-        },
-        {
-          hid: 'og:video:height',
-          property: 'og:video:height',
-          content: '720',
-        },
-        {
-          hid: 'og:video:type',
-          property: 'og:video:type',
-          content: meta?.mime,
-        },
-        {
-          hid: 'twitter:player:width',
-          property: 'twitter:player:width',
-          content: '1280',
-        },
-        {
-          hid: 'twitter:player:height',
-          property: 'twitter:player:height',
-          content: '720',
-        },
-        {
-          hid: 'twitter:card',
-          property: 'twitter:card',
-          content: 'player',
-        },
-        {
-          hid: 'twitter:player',
-          property: 'twitter:player',
-          content: meta?.video,
-        },
-      ]
+      const videoMetaTags: MetaTag[] = getVideoMetaTags(meta)
       seoTags.push(...videoMetaTags)
     }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring

## Context

- [X] Part of #6782
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried to respect high code quality standards
- [X] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [X] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16hqk8Tjugo9AwSzKkxXc1dsRK7iJetpx1YBaoXYwdHzuNAt&usdamount=50&donation=true)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e21f50c</samp>

Improved the code quality and readability of the `seoMetaGenerator` plugin. The plugin creates SEO-friendly meta tags for different media types in the NFT gallery.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e21f50c</samp>

> _There once was a plugin called `seoMetaGenerator`_
> _That made meta tags for SEO with some parameters_
> _But the code was a mess_
> _With imports and excess_
> _So it got a nice refactoring and simplifier_
