### PR TITLE
fix: change auth routing to param based routing

### DIFF
--- a/components/common/ChainDropdown.vue
+++ b/components/common/ChainDropdown.vue
@@ -21,24 +21,11 @@
 
 <script setup lang="ts">
 import { NeoButton, NeoDropdown, NeoDropdownItem } from '@kodadot1/brick'
-import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
-import { CHAINS } from '@kodadot1/static'
 
 const route = useRoute()
-const router = useRouter()
-const { accountId } = useAuth()
-
 const { setUrlPrefix } = usePrefix()
 const { availableChains } = useChain()
-
-const getAddress = (chain: string) => {
-  if (!accountId.value) {
-    return ''
-  }
-  const publicKey = decodeAddress(accountId.value)
-
-  return encodeAddress(publicKey, CHAINS[chain].ss58Format)
-}
+const { redirectAfterChainChange } = useChainRedirect()
 
 const selected = computed(() =>
   availableChains.value.find((chain) => chain.value === route.params.prefix)
@@ -46,16 +33,6 @@ const selected = computed(() =>
 
 function onSwitchChain(chain) {
   setUrlPrefix(chain)
-  const { ...restQuery } = route.query
-  router.push({
-    params: {
-      prefix: chain,
-      id: getAddress(chain),
-    },
-    query: {
-      ...restQuery,
-      collections: null,
-    },
-  })
+  redirectAfterChainChange(chain)
 }
 </script>

--- a/composables/useChainRedirect.ts
+++ b/composables/useChainRedirect.ts
@@ -1,4 +1,5 @@
-import { Prefix } from '@kodadot1/static'
+import { CHAINS, Prefix } from '@kodadot1/static'
+import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
 import {
   assetsVisible,
   createVisible,
@@ -17,6 +18,11 @@ const NO_REDIRECT_ROUTE_NAMES = [
 
 function isNoRedirect(routeName: string): boolean {
   return NO_REDIRECT_ROUTE_NAMES.includes(routeName)
+}
+
+const getAddress = (chain: string, accountId: string) => {
+  const publicKey = decodeAddress(accountId)
+  return encodeAddress(publicKey, CHAINS[chain].ss58Format)
 }
 
 function getRedirectPathForPrefix({
@@ -64,10 +70,14 @@ function getRedirectPathForPrefix({
 export default function () {
   const route = useRoute()
   const router = useRouter()
-  const { accountId } = useAuth()
 
   const redirectAfterChainChange = (newChain: Prefix): void => {
     const routeName = route.name as string
+    let accountId = route.params?.id
+
+    if (accountId) {
+      accountId = getAddress(newChain, accountId)
+    }
 
     if (isNoRedirect(routeName)) {
       return
@@ -83,7 +93,7 @@ export default function () {
       redirectLocation = getRedirectPathForPrefix({
         routeName,
         chain: newChain,
-        accountId: accountId.value,
+        accountId,
         route,
       })
     } else if (isAssets && assetsVisible(newChain)) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #<issue_number>
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Comments
This is quite a tricky one for me since I'm not very familiar with the routing system in this project, however from what I can see is the routing is based on the authenticated
users account id and not the id in the url params and that why it changes to the authenticated user each time the chain is switched.

I have switched it around so it param based as this is the general flow of app of this type but may need advise from you guys here.

Let the roast begin!

## Copilot Summary
copilot:summary

copilot:poem
