### PR TITLE
fix: hover tooltip keep open when hovered over

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
@@ -7,6 +7,7 @@
             :active="disabled"
             class="w-full"
             content-class="buy-tooltip"
+            :auto-close="isMobileDevice ? true : ['outside']"
             :position="isMobileDevice ? 'top' : 'left'"
             :triggers="[isMobileDevice ? 'click' : 'hover']"
             multiline>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).


👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7032 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

https://github.com/kodadot/nft-gallery/assets/16473062/9b4c3b74-3055-4564-bf26-a4db45203e64


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5accdbb</samp>

Added a prop to `b-dropdown` in `GalleryItemBuy.vue` to control the menu auto-close behavior based on the device type. This improves the UX and accessibility of the gallery item actions menu.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5accdbb</samp>

> _`b-dropdown` prop_
> _controls menu auto-close_
> _on `isMobileDevice`_
