### PR TITLE
add missing translation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -640,6 +640,7 @@
     "empty": "There are currently no offers."
   },
   "loader": {
+    "broadcast": "Broadcating the tx to blockchain",
     "casting": "(1/3) Casting the tx to blockchain",
     "finalized": "(3/3) Finalized",
     "block": "(2/3) Transaction in block",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context
fix bug where the loader shown while minting
would show the string `"loader.broadcast`"
due to the addition of this status for transfer loader time estimation

fix by adding this string to translations

## test

Mint something:
on canary: loader will show "loader.broadcast"
on this branch: loader will show "Broadcating the tx to blockchain"

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 391eae0</samp>

Added a new localization message for transaction broadcasting. Updated `locales/en.json` with the new key-value pair.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 391eae0</samp>

> _`en.json` updated_
> _Broadcasting the tx to blockchain_
> _A winter message_
