### PR TITLE
feat: copy link to tx in transaction dialog

### DIFF
--- a/components/shared/TransactionLoader.vue
+++ b/components/shared/TransactionLoader.vue
@@ -58,15 +58,26 @@
         <div v-if="activeStep === 2" class="text-align-center has-text-grey">
           {{ `Est. waiting time ~ ${estmiatedTimeLeft}` }}
         </div>
-        <div class="is-flex is-justify-content-center">
+        <div v-if="isFinalStep" class="is-flex is-justify-content-center mb-4">
           <NeoButton
-            v-if="isFinalStep"
             v-safe-href="explorerLink"
             tag="a"
             target="_blank"
+            class="px-4"
             no-shadow
             rounded
             :label="$i18n.t('transactionLoader.showTransaction')" />
+
+          <NeoButton
+            v-clipboard:copy="explorerLink"
+            icon="copy"
+            icon-pack="far"
+            class="ml-4 px-4"
+            rounded
+            no-shadow
+            @click.native="
+              toast($i18n.t('transactionLoader.copyTransactionLink'))
+            " />
         </div>
       </div>
     </div>
@@ -95,6 +106,7 @@ const emit = defineEmits(['close'])
 const { $i18n } = useNuxtApp()
 const { urlPrefix } = usePrefix()
 const { blocktime } = useBlockTime()
+const { toast } = useToast()
 
 const estmiatedTimeLeft = computed(() => {
   switch (props.status) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -666,7 +666,8 @@
     "pendingTip": "Your transaction is being confirmed",
     "completed": "Completed",
     "completedTip": "Your transfer was successful!",
-    "showTransaction": "Show Transaction"
+    "showTransaction": "Show Transaction",
+    "copyTransactionLink": "transaction link copied"
   },
   "arweave": {
     "uploadYes": "Upload NFT image to Arweave",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7068
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/33c20e11-cfe5-480a-be50-7f23cd123e89)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8febe42</samp>

This pull request adds a feature to copy the transaction link from the `TransactionLoader` component and provides feedback to the user with a toast message. It also updates the English localization file with the new message.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8febe42</samp>

> _`useToast` to unleash the fire_
> _Burn the bridges of the liars_
> _`copyTransactionLink` to spread the word_
> _The transaction of doom is heard_
  