### PR TITLE
:broom: another eslint single quote

### DIFF
--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -71,7 +71,7 @@ const displaySeconds = computed(() => {
 
 const twitterText = computed(
   () =>
-    'Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Don\'t miss your chance! \n\n https://kodadot.xyz/ahk/drops/free-drop'
+    'Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Do not miss your chance! \n\n https://kodadot.xyz/ahk/drops/free-drop'
 )
 const postTwitterUrl = computed(
   () =>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

another single quoute that is breaking eslint

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

#### Community participation

- [ ] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f3f7cc</samp>

Fixed a bug in the tweet text for minting NFTs with unlockable items. Replaced an apostrophe with a word in `UnlockableLoader.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5f3f7cc</samp>

> _`don't` becomes `not`_
> _URL encoding is fixed_
> _tweet text like autumn leaves_
