### PR TITLE
feat(Profile activity): Responsive visual changes

### DIFF
--- a/components/profile/activityTab/Activity.vue
+++ b/components/profile/activityTab/Activity.vue
@@ -1,24 +1,44 @@
 <template>
   <div>
-    <div
-      class="is-flex is-justify-content-space-between pb-4 pt-5 is-align-content-center">
-      <div class="is-flex gap-4">
-        <NeoButton
-          no-shadow
-          rounded
-          label="All"
-          variant="text"
-          @click.native="activateAllFilter" />
-        <FilterButton
-          v-for="param in filters"
-          :key="param"
-          :label="param"
-          class="is-capitalized"
-          :url-param="param" />
-      </div>
-    </div>
-    <hr class="my-0" />
-    <History :id="id" :events="filteredEvents" display-item />
+    <History :id="id" :events="filteredEvents" display-item>
+      <template
+        #header="{
+          currentPage,
+          total,
+          itemsPerPage,
+          desktop,
+          updateCurrentPage,
+        }">
+        <div
+          class="is-flex is-justify-content-space-between pb-4 pt-5 is-align-content-center">
+          <div class="is-flex gap-4">
+            <NeoButton
+              no-shadow
+              rounded
+              label="All"
+              variant="text"
+              @click.native="activateAllFilter" />
+            <FilterButton
+              v-for="param in filters"
+              :key="param"
+              :label="param"
+              class="is-capitalized"
+              :url-param="param" />
+          </div>
+          <div v-if="desktop">
+            <Pagination
+              :value="currentPage"
+              :total="total"
+              :per-page="itemsPerPage"
+              replace
+              enable-listen-keyboard-event
+              preserve-scroll
+              @input="updateCurrentPage" />
+          </div>
+        </div>
+        <hr class="my-0" />
+      </template>
+    </History>
   </div>
 </template>
 
@@ -28,6 +48,7 @@ import { Interaction } from '@/components/rmrk/service/scheme'
 import { sortedEventByDate } from '@/utils/sorting'
 import FilterButton from '@/components/profile/FilterButton.vue'
 import { Interaction as InteractionEnum } from '@kodadot1/minimark/v1'
+import Pagination from '@/components/rmrk/Gallery/Pagination.vue'
 import { NeoButton } from '@kodadot1/brick'
 const route = useRoute()
 const { replaceUrl } = useReplaceUrl()

--- a/components/profile/activityTab/History.vue
+++ b/components/profile/activityTab/History.vue
@@ -1,7 +1,16 @@
 <template>
-  <div class="block">
+  <div ref="container" class="block">
+    <slot
+      name="header"
+      :current-page="currentPage"
+      :total="total"
+      :per-page="itemsPerPage"
+      :desktop="desktop"
+      :update-current-page="updateCurrentPage" />
+
     <div class="is-flex is-justify-content-flex-end my-4">
       <Pagination
+        v-if="!desktop"
         v-model="currentPage"
         :total="total"
         :per-page="itemsPerPage"
@@ -93,6 +102,9 @@ const emit = defineEmits(['setPriceChartData'])
 const { $route } = useNuxtApp()
 const { decimals } = useChain()
 
+const container = ref<HTMLDivElement | null>(null)
+const { desktop } = useResponsive(container)
+
 const currentPage = ref(parseInt($route.query?.page) || 1)
 const event = ref<HistoryEventType>(HistoryEventType.BUY)
 const data = ref<Event[]>([])
@@ -106,6 +118,10 @@ onMounted(() => {
   })
   isOpen.value = prop.openOnDefault
 })
+
+const updateCurrentPage = (value) => {
+  currentPage.value = value
+}
 
 const total = computed(() => data.value.length)
 const itemsPerPage = computed(() => preferencesStore.getHistoryItemsPerPage)

--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -44,7 +44,7 @@
             }}
           </NeoButton>
           <a
-            href="https://www.youtube.com/watch?v=3gPvGym8H7I"
+            v-safe-href="`https://www.youtube.com/watch?v=3gPvGym8H7I`"
             target="_blank"
             class="ml-2 is-size-7 is-blue">
             {{ $t('helper.learnMore') }}

--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -46,7 +46,7 @@
           <a
             href="https://www.youtube.com/watch?v=3gPvGym8H7I"
             target="_blank"
-            class="ml-2 is-size-7">
+            class="ml-2 is-size-7 is-blue">
             {{ $t('helper.learnMore') }}
           </a>
         </div>
@@ -90,7 +90,6 @@ const props = defineProps<{
 const { chainProperties, unit } = useChain()
 const { urlPrefix } = usePrefix()
 const ss58Format = computed(() => chainProperties.value?.ss58Format)
-const chainName = computed(() => chainNames[urlPrefix.value])
 const addressCheck = ref<AddressCheck | null>(null)
 const showAddressCheck = ref(false)
 const showChanged = ref(false)
@@ -172,7 +171,7 @@ watch(addressCheck, () => {
 <style lang="scss" scoped>
 @import '@/styles/abstracts/variables';
 
-a {
+.is-blue {
   @include ktheme() {
     color: theme('k-blue') !important;
   }

--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -66,7 +66,7 @@ import correctFormat from '@/utils/ss58Format'
 import { CHAINS } from '@/libs/static/src/chains'
 import InfoBox from '@/components/shared/view/InfoBox.vue'
 import { NeoButton } from '@kodadot1/brick'
-import { type Prefix, chainNames } from '@kodadot1/static'
+import { type Prefix } from '@kodadot1/static'
 
 enum AddressType {
   ETHEREUM = 'ethereum',
@@ -88,7 +88,6 @@ const props = defineProps<{
 }>()
 
 const { chainProperties, unit } = useChain()
-const { urlPrefix } = usePrefix()
 const ss58Format = computed(() => chainProperties.value?.ss58Format)
 const addressCheck = ref<AddressCheck | null>(null)
 const showAddressCheck = ref(false)

--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -4,18 +4,17 @@
       v-if="showChanged"
       variant="success"
       :title="
-        $t(`transfers.invalidAddress.addressChanged`, { selectedChain: unit })
+        $t('transfers.invalidAddress.addressChanged.title', {
+          selectedChain: unit,
+        })
       "
       @close="onClose">
-      <p>
-        Address was successfully changed for
-        {{ chainName }} network. You can double check correctness
-        <nuxt-link
-          target="_blank"
-          to="https://kusama.subscan.io/tools/format_transform"
-          >here</nuxt-link
-        >
-      </p>
+      <Markdown
+        :source="
+          $t('transfers.invalidAddress.addressChanged.content', {
+            selectedChain: unit,
+          })
+        " />
     </InfoBox>
 
     <InfoBox
@@ -32,13 +31,25 @@
         " />
 
       <template v-if="isWrongSubstrateNetworkAddress" #footer>
-        <NeoButton no-shadow rounded size="small" @click.native="changeAddress">
-          {{
-            $t(`transfers.invalidAddress.changeToChainAddress`, {
-              selectedChain: unit,
-            })
-          }}
-        </NeoButton>
+        <div class="is-flex is-align-items-center">
+          <NeoButton
+            no-shadow
+            rounded
+            size="small"
+            @click.native="changeAddress">
+            {{
+              $t(`transfers.invalidAddress.changeToChainAddress`, {
+                selectedChain: unit,
+              })
+            }}
+          </NeoButton>
+          <a
+            href="https://www.youtube.com/watch?v=3gPvGym8H7I"
+            target="_blank"
+            class="ml-2 is-size-7">
+            {{ $t('helper.learnMore') }}
+          </a>
+        </div>
       </template>
     </InfoBox>
   </div>
@@ -158,3 +169,12 @@ watch(addressCheck, () => {
   emit('check', isValid)
 })
 </script>
+<style lang="scss" scoped>
+@import '@/styles/abstracts/variables';
+
+a {
+  @include ktheme() {
+    color: theme('k-blue') !important;
+  }
+}
+</style>

--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -21,13 +21,13 @@
       variant="fail"
       :title="$t(`transfers.invalidAddress.${addressCheck.type}.title`)"
       @close="onClose">
-      <p
-        v-html="
+      <Markdown
+        :source="
           $t(`transfers.invalidAddress.${addressCheck.type}.content`, {
             addressChain: addressCheck.value,
             selectedChain: unit,
           })
-        "></p>
+        " />
 
       <template #footer>
         <NeoButton

--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -1,0 +1,155 @@
+<template>
+  <div>
+    <InfoBox
+      v-if="showChanged"
+      variant="success"
+      :title="
+        $t(`transfers.invalidAddress.addressChanged`, getTranslationVariables())
+      "
+      @close="onClose">
+      <p>
+        Address was successfully changed for
+        {{ getTranslationVariables().selectedChain }} network. You can double
+        check correctness
+        <nuxt-link as="a" to="https://kusama.subscan.io/tools/format_transform"
+          >here</nuxt-link
+        >
+      </p>
+    </InfoBox>
+
+    <InfoBox
+      v-else-if="addressCheck && !addressCheck.valid"
+      variant="fail"
+      :title="$t(`transfers.invalidAddress.${addressCheck.type}.title`)"
+      @close="onClose">
+      <p
+        v-html="
+          $t(
+            `transfers.invalidAddress.${addressCheck.type}.content`,
+            getTranslationVariables()
+          )
+        "></p>
+
+      <template #footer>
+        <NeoButton
+          v-if="isWrongSubstrateNetworkAddress"
+          no-shadow
+          rounded
+          size="small"
+          @click.native="changeAddress">
+          {{
+            $t(
+              `transfers.invalidAddress.changeToChainAddress`,
+              getTranslationVariables()
+            )
+          }}
+        </NeoButton>
+      </template>
+    </InfoBox>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  checkAddress,
+  decodeAddress,
+  encodeAddress,
+  isEthereumAddress,
+} from '@polkadot/util-crypto'
+import correctFormat from '@/utils/ss58Format'
+import { CHAINS, chainNames } from '@/libs/static/src/chains'
+import InfoBox from '@/components/shared/view/InfoBox.vue'
+import { NeoButton } from '@kodadot1/brick'
+
+const emit = defineEmits(['check', 'change'])
+const props = defineProps<{
+  address: string
+}>()
+
+const { chainProperties } = useChain()
+const { urlPrefix } = usePrefix()
+const ss58Format = computed(() => chainProperties.value?.ss58Format)
+
+const addressCheck = ref<AddressCheck | null>(null)
+const showChanged = ref(false)
+
+enum AddressType {
+  ETHEREUM = 'ethereum',
+  WRONG_SUBSTRATE_NETWORK_ADDRESS = 'wrong_substrate_network_address',
+  UNKNOWN = 'unknown',
+}
+
+const isWrongSubstrateNetworkAddress = computed(
+  () => addressCheck.value?.type === AddressType.WRONG_SUBSTRATE_NETWORK_ADDRESS
+)
+
+type AddressCheck = {
+  valid: boolean
+  type?: AddressType
+  value?: string[]
+}
+
+const checkAddressByss58Format = (value: string, ss58: number) =>
+  checkAddress(value, correctFormat(ss58))
+
+const getAddressCheck = (value: string): AddressCheck => {
+  if (isEthereumAddress(value)) {
+    return { valid: false, type: AddressType.ETHEREUM }
+  }
+
+  const [isValidCurrentChainAddress] = checkAddressByss58Format(
+    value,
+    ss58Format.value
+  )
+
+  if (isValidCurrentChainAddress) {
+    return { valid: true }
+  }
+
+  const validAddressesChains = Object.keys(CHAINS).filter((chain) => {
+    const [isValid] = checkAddressByss58Format(value, CHAINS[chain].ss58Format)
+    return isValid
+  })
+
+  if (validAddressesChains.length > 0) {
+    return {
+      valid: false,
+      type: AddressType.WRONG_SUBSTRATE_NETWORK_ADDRESS,
+      value: validAddressesChains,
+    }
+  }
+
+  return { valid: false, type: AddressType.UNKNOWN }
+}
+
+const onClose = () => {
+  addressCheck.value = null
+}
+
+const changeAddress = () => {
+  const publicKey = decodeAddress(props.address)
+  const chainAddress = encodeAddress(publicKey, ss58Format.value)
+  showChanged.value = true
+  emit('change', chainAddress)
+}
+
+const getTranslationVariables = () => ({
+  addressChain: addressCheck.value?.value, // TODO: TEMP
+  selectedChain: chainNames[urlPrefix.value],
+})
+
+watch(
+  () => props.address,
+  (address) => {
+    if (address !== '') {
+      addressCheck.value = getAddressCheck(address)
+    } else {
+      addressCheck.value = null
+    }
+  }
+)
+
+watch(addressCheck, () => {
+  emit('check', addressCheck.value ? addressCheck.value.valid : false)
+})
+</script>

--- a/components/shared/AddressInput.vue
+++ b/components/shared/AddressInput.vue
@@ -25,6 +25,7 @@ const props = withDefaults(
     strict: boolean
     icon?: string
     placeholder?: string
+    disableError?: boolean
   }>(),
   {
     label: 'Insert Address',
@@ -57,6 +58,11 @@ const clearIconClick = () => {
 
 const handleInput = (value: string) => {
   emit('input', value)
+
+  if (props.disableError) {
+    return value
+  }
+
   if (props.strict) {
     const [, err] = checkAddress(value, correctFormat(ss58Format.value))
     error.value = value ? err : ''

--- a/components/shared/AddressInput.vue
+++ b/components/shared/AddressInput.vue
@@ -8,15 +8,79 @@
         icon-right-clickable
         @icon-right-click="clearIconClick" />
     </NeoField>
+
+    <InfoBox
+      v-if="addressCheck && !addressCheck.valid"
+      variant="fail"
+      :title="$t(`transfers.invalidAddress.${addressCheck.type}.title`)"
+      @close="addressCheck = null">
+      <p
+        v-html="
+          $t(
+            `transfers.invalidAddress.${addressCheck.type}.content`,
+            getTranslationVariables()
+          )
+        "></p>
+
+      <template #footer>
+        <NeoButton
+          v-if="
+            addressCheck.type === AddressType.WRONG_SUBSTRATE_NETWORK_ADDRESS
+          "
+          no-shadow
+          rounded
+          size="small"
+          @click.native="changeAddress">
+          {{
+            $t(
+              `transfers.invalidAddress.changeToChainAddress`,
+              getTranslationVariables()
+            )
+          }}
+        </NeoButton>
+      </template>
+    </InfoBox>
+
+    <InfoBox
+      v-else-if="showChanged"
+      variant="success"
+      :title="
+        $t(`transfers.invalidAddress.addressChanged`, getTranslationVariables())
+      "
+      @close="addressCheck = null">
+      <p>
+        Address was successfully changed for
+        {{ getTranslationVariables().selectedChain }} network. You can double
+        check correctness
+        <nuxt-link
+          as="a"
+          to="https://kusama.subscan.io/tools/format_transform"
+          target="_blank"
+          >here</nuxt-link
+        >
+      </p>
+    </InfoBox>
   </div>
 </template>
 
 <script lang="ts" setup>
 import correctFormat from '@/utils/ss58Format'
-import { checkAddress, isAddress } from '@polkadot/util-crypto'
+import {
+  checkAddress,
+  decodeAddress,
+  encodeAddress,
+  isAddress,
+  isEthereumAddress,
+} from '@polkadot/util-crypto'
 import { NeoField, NeoInput } from '@kodadot1/brick'
+import InfoBox from '@/components/shared/view/InfoBox.vue'
+import { CHAINS } from '~~/libs/static/dist'
+import { chainNames } from '@/libs/static/src/chains'
+import { NeoButton } from '@kodadot1/brick'
 
-const emit = defineEmits(['input'])
+const { urlPrefix } = usePrefix()
+
+const emit = defineEmits(['input', 'invalid'])
 const props = withDefaults(
   defineProps<{
     value: string
@@ -25,6 +89,7 @@ const props = withDefaults(
     strict: boolean
     icon?: string
     placeholder?: string
+    withAddressChecker?: boolean
   }>(),
   {
     label: 'Insert Address',
@@ -55,10 +120,77 @@ const clearIconClick = () => {
   emit('input', '')
 }
 
+const addressCheck = ref<AddressCheck | null>(null)
+const showChanged = ref(false)
+
+enum AddressType {
+  ETHEREUM = 'ethereum',
+  WRONG_SUBSTRATE_NETWORK_ADDRESS = 'wrong_substrate_network_address',
+  UNKNOWN = 'unknown',
+}
+
+type AddressCheck = {
+  valid: boolean
+  type?: AddressType
+  value?: string[]
+}
+
+const getAddressCheck = (value: string): AddressCheck => {
+  if (isEthereumAddress(value)) {
+    return { valid: false, type: AddressType.ETHEREUM }
+  }
+
+  const [isValidCurrentChainAddress] = checkAddressByss58Format(
+    value,
+    ss58Format.value
+  )
+
+  if (isValidCurrentChainAddress) {
+    return { valid: true }
+  }
+
+  const validAddressesChains = Object.keys(CHAINS).filter((chain) => {
+    const [isValid] = checkAddressByss58Format(value, CHAINS[chain].ss58Format)
+    return isValid
+  })
+
+  if (validAddressesChains.length > 0) {
+    return {
+      valid: false,
+      type: AddressType.WRONG_SUBSTRATE_NETWORK_ADDRESS,
+      value: validAddressesChains,
+    }
+  }
+
+  return { valid: false, type: AddressType.UNKNOWN }
+}
+
+const changeAddress = () => {
+  const publicKey = decodeAddress(inputValue.value)
+  const chainAddress = encodeAddress(publicKey, ss58Format.value)
+  inputValue.value = chainAddress
+  showChanged.value = true
+}
+
+const getTranslationVariables = () => ({
+  addressChain: addressCheck.value?.value, // TODO: TEMP
+  selectedChain: chainNames[urlPrefix.value],
+})
+
+const checkAddressByss58Format = (value: string, ss58: number) =>
+  checkAddress(value, correctFormat(ss58))
+
 const handleInput = (value: string) => {
   emit('input', value)
+
+  if (props.withAddressChecker && !!value) {
+    addressCheck.value = null
+    addressCheck.value = getAddressCheck(value)
+    return
+  }
+
   if (props.strict) {
-    const [, err] = checkAddress(value, correctFormat(ss58Format.value))
+    const [, err] = checkAddressByss58Format(value, ss58Format.value)
     error.value = value ? err : ''
   } else {
     if (!props.emptyOnError && !value) {

--- a/components/shared/AddressInput.vue
+++ b/components/shared/AddressInput.vue
@@ -16,7 +16,7 @@ import correctFormat from '@/utils/ss58Format'
 import { checkAddress, isAddress } from '@polkadot/util-crypto'
 import { NeoField, NeoInput } from '@kodadot1/brick'
 
-const emit = defineEmits(['input', 'invalid'])
+const emit = defineEmits(['input'])
 const props = withDefaults(
   defineProps<{
     value: string
@@ -57,7 +57,6 @@ const clearIconClick = () => {
 
 const handleInput = (value: string) => {
   emit('input', value)
-
   if (props.strict) {
     const [, err] = checkAddress(value, correctFormat(ss58Format.value))
     error.value = value ? err : ''

--- a/components/shared/AddressInput.vue
+++ b/components/shared/AddressInput.vue
@@ -8,77 +8,13 @@
         icon-right-clickable
         @icon-right-click="clearIconClick" />
     </NeoField>
-
-    <InfoBox
-      v-if="addressCheck && !addressCheck.valid"
-      variant="fail"
-      :title="$t(`transfers.invalidAddress.${addressCheck.type}.title`)"
-      @close="addressCheck = null">
-      <p
-        v-html="
-          $t(
-            `transfers.invalidAddress.${addressCheck.type}.content`,
-            getTranslationVariables()
-          )
-        "></p>
-
-      <template #footer>
-        <NeoButton
-          v-if="
-            addressCheck.type === AddressType.WRONG_SUBSTRATE_NETWORK_ADDRESS
-          "
-          no-shadow
-          rounded
-          size="small"
-          @click.native="changeAddress">
-          {{
-            $t(
-              `transfers.invalidAddress.changeToChainAddress`,
-              getTranslationVariables()
-            )
-          }}
-        </NeoButton>
-      </template>
-    </InfoBox>
-
-    <InfoBox
-      v-else-if="showChanged"
-      variant="success"
-      :title="
-        $t(`transfers.invalidAddress.addressChanged`, getTranslationVariables())
-      "
-      @close="addressCheck = null">
-      <p>
-        Address was successfully changed for
-        {{ getTranslationVariables().selectedChain }} network. You can double
-        check correctness
-        <nuxt-link
-          as="a"
-          to="https://kusama.subscan.io/tools/format_transform"
-          target="_blank"
-          >here</nuxt-link
-        >
-      </p>
-    </InfoBox>
   </div>
 </template>
 
 <script lang="ts" setup>
 import correctFormat from '@/utils/ss58Format'
-import {
-  checkAddress,
-  decodeAddress,
-  encodeAddress,
-  isAddress,
-  isEthereumAddress,
-} from '@polkadot/util-crypto'
+import { checkAddress, isAddress } from '@polkadot/util-crypto'
 import { NeoField, NeoInput } from '@kodadot1/brick'
-import InfoBox from '@/components/shared/view/InfoBox.vue'
-import { CHAINS } from '~~/libs/static/dist'
-import { chainNames } from '@/libs/static/src/chains'
-import { NeoButton } from '@kodadot1/brick'
-
-const { urlPrefix } = usePrefix()
 
 const emit = defineEmits(['input', 'invalid'])
 const props = withDefaults(
@@ -89,7 +25,6 @@ const props = withDefaults(
     strict: boolean
     icon?: string
     placeholder?: string
-    withAddressChecker?: boolean
   }>(),
   {
     label: 'Insert Address',
@@ -120,77 +55,11 @@ const clearIconClick = () => {
   emit('input', '')
 }
 
-const addressCheck = ref<AddressCheck | null>(null)
-const showChanged = ref(false)
-
-enum AddressType {
-  ETHEREUM = 'ethereum',
-  WRONG_SUBSTRATE_NETWORK_ADDRESS = 'wrong_substrate_network_address',
-  UNKNOWN = 'unknown',
-}
-
-type AddressCheck = {
-  valid: boolean
-  type?: AddressType
-  value?: string[]
-}
-
-const getAddressCheck = (value: string): AddressCheck => {
-  if (isEthereumAddress(value)) {
-    return { valid: false, type: AddressType.ETHEREUM }
-  }
-
-  const [isValidCurrentChainAddress] = checkAddressByss58Format(
-    value,
-    ss58Format.value
-  )
-
-  if (isValidCurrentChainAddress) {
-    return { valid: true }
-  }
-
-  const validAddressesChains = Object.keys(CHAINS).filter((chain) => {
-    const [isValid] = checkAddressByss58Format(value, CHAINS[chain].ss58Format)
-    return isValid
-  })
-
-  if (validAddressesChains.length > 0) {
-    return {
-      valid: false,
-      type: AddressType.WRONG_SUBSTRATE_NETWORK_ADDRESS,
-      value: validAddressesChains,
-    }
-  }
-
-  return { valid: false, type: AddressType.UNKNOWN }
-}
-
-const changeAddress = () => {
-  const publicKey = decodeAddress(inputValue.value)
-  const chainAddress = encodeAddress(publicKey, ss58Format.value)
-  inputValue.value = chainAddress
-  showChanged.value = true
-}
-
-const getTranslationVariables = () => ({
-  addressChain: addressCheck.value?.value, // TODO: TEMP
-  selectedChain: chainNames[urlPrefix.value],
-})
-
-const checkAddressByss58Format = (value: string, ss58: number) =>
-  checkAddress(value, correctFormat(ss58))
-
 const handleInput = (value: string) => {
   emit('input', value)
 
-  if (props.withAddressChecker && !!value) {
-    addressCheck.value = null
-    addressCheck.value = getAddressCheck(value)
-    return
-  }
-
   if (props.strict) {
-    const [, err] = checkAddressByss58Format(value, ss58Format.value)
+    const [, err] = checkAddress(value, correctFormat(ss58Format.value))
     error.value = value ? err : ''
   } else {
     if (!props.emptyOnError && !value) {

--- a/components/shared/ResponsiveTable.vue
+++ b/components/shared/ResponsiveTable.vue
@@ -18,13 +18,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps, ref, withDefaults } from 'vue'
-import { useResizeObserver } from '@vueuse/core'
+import { defineProps, ref, withDefaults } from 'vue'
 
-const desktop = ref(true)
-const desktopBreakPoint = 1024
 const container = ref<HTMLDivElement | null>(null)
-const variant = computed(() => (desktop.value ? 'Desktop' : 'Touch'))
+const { variant, desktop } = useResponsive(container)
 
 withDefaults(
   defineProps<{
@@ -40,12 +37,4 @@ withDefaults(
     showNoResults: false,
   }
 )
-
-useResizeObserver(container, (entry) => {
-  if (entry[0].contentRect.width >= desktopBreakPoint) {
-    desktop.value = true
-  } else {
-    desktop.value = false
-  }
-})
 </script>

--- a/components/shared/view/InfoBox.vue
+++ b/components/shared/view/InfoBox.vue
@@ -2,9 +2,15 @@
   <div class="info-box" :class="`info-box__${variant}`">
     <div class="header-container box-padding">
       <p class="is-size-6 title">{{ title }}</p>
-      <div class="cross">
-        <NeoIcon icon="x" @click.native="onClose" />
-      </div>
+
+      <NeoButton
+        variant="text"
+        no-shadow
+        icon="xmark"
+        icon-pack="fa-sharp"
+        size="medium"
+        class="cross"
+        @click.native="emit('close')" />
     </div>
     <div class="box-padding">
       <slot />
@@ -17,7 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 
 const emit = defineEmits(['close'])
 
@@ -52,10 +58,6 @@ $border_size: 1px;
       font-weight: bold;
       margin-bottom: 0;
     }
-
-    .cross {
-      cursor: pointer;
-    }
   }
 
   &__success {
@@ -64,6 +66,10 @@ $border_size: 1px;
     }
 
     background-color: #e6f7e6;
+
+    .cross {
+      background-color: #e6f7e6;
+    }
 
     .header-container {
       @include ktheme() {
@@ -78,6 +84,9 @@ $border_size: 1px;
     }
 
     background-color: #ffe6e6;
+    .cross {
+      background-color: #ffe6e6 !important;
+    }
 
     .header-container {
       @include ktheme() {

--- a/components/shared/view/InfoBox.vue
+++ b/components/shared/view/InfoBox.vue
@@ -10,7 +10,7 @@
         icon-pack="fa-sharp"
         size="medium"
         class="cross"
-        @click.native="emit('close')" />
+        @click.native="onClose" />
     </div>
     <div class="box-padding">
       <slot />

--- a/components/shared/view/InfoBox.vue
+++ b/components/shared/view/InfoBox.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="info-box" :class="`info-box__${variant}`">
+    <div class="title-container box-padding is-flex">
+      <p class="is-size-6 title">{{ title }}</p>
+      <NeoIcon icon="x" class="cursor" @click.native="onClose" />
+    </div>
+    <div class="content box-padding">
+      <slot />
+    </div>
+
+    <div v-if="$slots.footer" class="box-padding">
+      <slot name="footer"></slot>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { NeoIcon } from '@kodadot1/brick'
+
+const emit = defineEmits(['close'])
+
+defineProps<{
+  title: string
+  variant: 'success' | 'fail'
+}>()
+
+const onClose = () => {
+  emit('close')
+}
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/abstracts/variables';
+
+.box-padding {
+  padding: 12px 16px;
+}
+
+$border_size: 1px;
+
+.info-box {
+  width: 100%;
+
+  .title-container {
+    .title {
+      font-weight: bold;
+    }
+  }
+
+  &__success {
+    @include ktheme() {
+      border: $border_size solid theme('k-green');
+    }
+
+    background-color: #e6f7e6;
+
+    .title-container {
+      @include ktheme() {
+        border-bottom: $border_size solid theme('k-green');
+      }
+    }
+  }
+
+  &__fail {
+    @include ktheme() {
+      border: $border_size solid theme('k-red');
+    }
+
+    background-color: #ffe6e6;
+
+    .title-container {
+      @include ktheme() {
+        border-bottom: $border_size solid theme('k-red');
+      }
+    }
+  }
+}
+</style>

--- a/components/shared/view/InfoBox.vue
+++ b/components/shared/view/InfoBox.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="info-box" :class="`info-box__${variant}`">
-    <div class="title-container box-padding is-flex">
+    <div class="header-container box-padding">
       <p class="is-size-6 title">{{ title }}</p>
-      <NeoIcon icon="x" class="cursor" @click.native="onClose" />
+      <div class="cross">
+        <NeoIcon icon="x" @click.native="onClose" />
+      </div>
     </div>
-    <div class="content box-padding">
+    <div class="box-padding">
       <slot />
     </div>
 
@@ -41,9 +43,18 @@ $border_size: 1px;
 .info-box {
   width: 100%;
 
-  .title-container {
+  .header-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
     .title {
       font-weight: bold;
+      margin-bottom: 0;
+    }
+
+    .cross {
+      cursor: pointer;
     }
   }
 
@@ -54,7 +65,7 @@ $border_size: 1px;
 
     background-color: #e6f7e6;
 
-    .title-container {
+    .header-container {
       @include ktheme() {
         border-bottom: $border_size solid theme('k-green');
       }
@@ -68,7 +79,7 @@ $border_size: 1px;
 
     background-color: #ffe6e6;
 
-    .title-container {
+    .header-container {
       @include ktheme() {
         border-bottom: $border_size solid theme('k-red');
       }

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -111,7 +111,7 @@
                 },
               ]"
               placeholder="Enter wallet address"
-              with-address-checker />
+              empty-on-error />
             <NeoInput
               v-if="displayUnit === 'token'"
               v-model="destinationAddress.token"
@@ -132,6 +132,16 @@
               icon-right-class="search"
               class="is-flex-1"
               @input="onUsdFieldChange(destinationAddress)" />
+          </div>
+          <div>
+            <AddressChecker
+              :address="destinationAddress.address"
+              @check="
+                (isValid) => handleAddressCheck(destinationAddress, isValid)
+              "
+              @change="
+                (address) => handleAddressChange(destinationAddress, address)
+              " />
           </div>
         </div>
       </div>
@@ -285,6 +295,7 @@ import AddressInput from '@/components/shared/AddressInput.vue'
 import TransactionLoader from '@/components/shared/TransactionLoader.vue'
 import { KODADOT_DAO } from '@/utils/support'
 import { toDefaultAddress } from '@/utils/account'
+import AddressChecker from '@/components/shared/AddressChecker.vue'
 
 const Money = defineAsyncComponent(
   () => import('@/components/shared/format/Money.vue')
@@ -317,6 +328,7 @@ export type TargetAddress = {
   address: string
   usd?: number | string
   token?: number | string
+  isInvalid?: boolean
 }
 
 const isMobile = computed(() => useWindowSize().width.value <= 1024)
@@ -337,7 +349,9 @@ const tokenTabs = ref<TransferTokenTab[]>([])
 const targetAddresses = ref<TargetAddress[]>([{ address: '' }])
 
 const hasValidTarget = computed(() =>
-  targetAddresses.value.some((item) => isAddress(item.address) && item.token)
+  targetAddresses.value.some(
+    (item) => isAddress(item.address) && !item.isInvalid && item.token
+  )
 )
 
 const getDisplayUnitBasedValues = (
@@ -515,6 +529,18 @@ const onUsdFieldChange = (target: TargetAddress) => {
   if (sendSameAmount.value) {
     unifyAddressAmount(target)
   }
+}
+
+const handleAddressCheck = (target: TargetAddress, isValid: boolean) => {
+  target.isInvalid = !isValid
+
+  targetAddresses.value = [...targetAddresses.value]
+}
+
+const handleAddressChange = (target: TargetAddress, newAddress: string) => {
+  target.address = newAddress
+
+  targetAddresses.value = [...targetAddresses.value]
 }
 
 const unifyAddressAmount = (target: TargetAddress) => {

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -111,7 +111,7 @@
                 },
               ]"
               placeholder="Enter wallet address"
-              empty-on-error />
+              disable-error />
             <NeoInput
               v-if="displayUnit === 'token'"
               v-model="destinationAddress.token"

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -111,7 +111,7 @@
                 },
               ]"
               placeholder="Enter wallet address"
-              :strict="false" />
+              with-address-checker />
             <NeoInput
               v-if="displayUnit === 'token'"
               v-model="destinationAddress.token"

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -133,7 +133,7 @@
               class="is-flex-1"
               @input="onUsdFieldChange(destinationAddress)" />
           </div>
-          <div>
+          <div class="mt-2">
             <AddressChecker
               :address="destinationAddress.address"
               @check="

--- a/composables/useResponsive.ts
+++ b/composables/useResponsive.ts
@@ -1,0 +1,18 @@
+import { useResizeObserver } from '@vueuse/core'
+import { type Ref } from 'vue/types'
+
+export default function (container: Ref<HTMLDivElement | null>) {
+  const desktop = ref(true)
+  const desktopBreakPoint = 1024
+  const variant = computed(() => (desktop.value ? 'Desktop' : 'Touch'))
+
+  useResizeObserver(container, (entry) => {
+    if (entry[0].contentRect.width >= desktopBreakPoint) {
+      desktop.value = true
+    } else {
+      desktop.value = false
+    }
+  })
+
+  return { variant, desktop }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -103,7 +103,23 @@
     "recipients": "recipients",
     "totalAmount": "Total Amount",
     "transferable": "Transferable",
-    "networkFee": "Network fee"
+    "networkFee": "Network fee",
+    "invalidAddress":{
+      "changeToChainAddress": "Change to {selectedChain} address",
+      "addressChanged": "Changed to {selectedChain} address",
+      "ethereum": {
+        "title": "Not Polkadot ecosystem address",
+        "content": "Oops! You have entered ETH address which <strong>is not supported by Polkadot ecosystem.</strong> Please enter Polkadot supported address to proceed with the transaction."
+      },
+      "unknown": {
+        "title": "Not Polkadot ecosystem address",
+        "content": "Oops! The address you entered is not supported by Polkadot ecosystem. Please enter Polkadot supported address to proceed with the transaction."
+      },
+      "wrong_substrate_network_address": {
+        "title": "Wrong polkadot Network address",
+        "content": "Oops! You have entered {addressChain} address. Enter a <strong>{selectedChain} address </strong> to proceed with the transaction or allow us to change it for you."
+      }
+    }
   },
   "topCollections": {
     "timeFrames": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -106,7 +106,10 @@
     "networkFee": "Network fee",
     "invalidAddress":{
       "changeToChainAddress": "Change to {selectedChain} address",
-      "addressChanged": "Changed to {selectedChain} address",
+      "addressChanged": {
+        "title": "Changed to {selectedChain} address",
+        "content": "Address was successfully changed for {selectedChain} network. You can double check correctness <a href='https://kusama.subscan.io/tools/format_transform' target='_blank'>here</a>."
+      },
       "ethereum": {
         "title": "Not Polkadot ecosystem address",
         "content": "Oops! You have entered ETH address which <strong>is not supported by Polkadot ecosystem.</strong> Please enter Polkadot supported address to proceed with the transaction."


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7094
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8e29d7</samp>

The pull request refactored some components to improve reusability and responsiveness, added new components and props to enhance address validation and feedback, and updated the translations for the new messages. The main files affected are `components/profile/activityTab/Activity.vue`, `components/profile/activityTab/History.vue`, `components/transfer/Transfer.vue`, `components/shared/AddressInput.vue`, `components/shared/AddressChecker.vue`, `components/shared/view/InfoBox.vue`, `components/shared/ResponsiveTable.vue`, `composables/useResponsive.ts`, and `locales/en.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a8e29d7</samp>

> _Oh, we're the coders of the sea, and we work on the `transfer` form_
> _We check the `AddressInput` and the `AddressChecker` too_
> _We make the `History` and the `ResponsiveTable` shine_
> _And we sing this shanty as we push and pull and review_


