### PR TITLE
fix: force parsing metadata body with json

### DIFF
--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -119,7 +119,9 @@ export const fetchMetadata = async <T>(
       return emptyObject<T>()
     }
 
-    const { status, _data } = await api.raw(sanitizer(rmrk.metadata))
+    const { status, _data } = await api.raw(sanitizer(rmrk.metadata), {
+      responseType: 'json',
+    })
     if (status < 400) {
       return _data as T
     }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7077 
- [ ] Requires deployment <snek/rubick/worker>

Some metadata is a JSON string, but the content-type in the response is incorrect. According to the context of the code, the response data here can only be JSON, so we can force the `responseType` to be specified to ensure that we always get the right result.

https://image-beta.w.kodadot.xyz/ipfs/bafkreieoscse2dcukq73vds4ek2ns7iv2wbxzb47l6uzlcgzdqikgk7tt4

![CleanShot 2023-09-02 at 18 12 03@2x](https://github.com/kodadot/nft-gallery/assets/10708802/841815e5-13a7-4095-a258-25b634833034)


#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f8ffb7</samp>

Fixed a JSON parsing bug in `fetchMetadata` function in `utils/ipfs.ts`. This improved the IPFS metadata handling and caching logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0f8ffb7</samp>

> _`fetchMetadata` changed_
> _`responseType` set to `json`_
> _Winter bug is fixed_
