### PR TITLE
fix: `page` not get reset after filter changes

### DIFF
--- a/components/profile/activityTab/History.vue
+++ b/components/profile/activityTab/History.vue
@@ -90,7 +90,7 @@ const prop = withDefaults(
 )
 const emit = defineEmits(['setPriceChartData'])
 
-const { $route } = useNuxtApp()
+const $route = useRoute()
 const { decimals } = useChain()
 
 const currentPage = ref(parseInt($route.query?.page) || 1)
@@ -258,4 +258,11 @@ const createTable = (): void => {
 watch(() => prop.events, createTable)
 
 watch(event, updateDataByEvent)
+
+watch(
+  () => $route.query?.page,
+  (newPage) => {
+    currentPage.value = parseInt(newPage as string) || 1
+  }
+)
 </script>

--- a/components/profile/activityTab/History.vue
+++ b/components/profile/activityTab/History.vue
@@ -90,10 +90,10 @@ const prop = withDefaults(
 )
 const emit = defineEmits(['setPriceChartData'])
 
-const $route = useRoute()
+const route = useRoute()
 const { decimals } = useChain()
 
-const currentPage = ref(parseInt($route.query?.page) || 1)
+const currentPage = ref(parseInt(route.query?.page) || 1)
 const event = ref<HistoryEventType>(HistoryEventType.BUY)
 const data = ref<Event[]>([])
 const copyTableData = ref([])
@@ -101,7 +101,7 @@ const isOpen = ref(false)
 const preferencesStore = usePreferencesStore()
 
 onMounted(() => {
-  exist($route.query.event, (val) => {
+  exist(route.query.event, (val) => {
     event.value = (val as HistoryEventType) ?? HistoryEventType.ALL
   })
   isOpen.value = prop.openOnDefault
@@ -260,7 +260,7 @@ watch(() => prop.events, createTable)
 watch(event, updateDataByEvent)
 
 watch(
-  () => $route.query?.page,
+  () => route.query?.page,
   (newPage) => {
     currentPage.value = parseInt(newPage as string) || 1
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #6853 
- [ ] Requires deployment <snek/rubick/worker>

**Why use `useRoute`?**
The `$route` provided in `useNuxtApp()` has a bug where it doesn't get updated when the page parameter in the URL is updated (https://github.com/nuxt/nuxt/issues/13032), replacing it with `useRoute` fixes this.

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77548c9</samp>

Refactored `History.vue` to use Vue Router 4 and pagination. This improves the performance and usability of the profile history tab.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 77548c9</samp>

> _`History.vue` changed_
> _Vue Router 4 and pagination_
> _Autumn leaves fall fast_
