### PR TITLE
:memo: remove property decorator

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -88,35 +88,6 @@ onMounted(() => {
 ```
 For more details make sure to checkout [Vue's official documentation](https://vuejs.org/guide/introduction.html).
 
-
-### Property Decorators DEPRECATED! (only use this syntax for maintenance reasons)
-We rely on the package 'nuxt-property-decorator', hence, we urge you to comply with the [Nuxt Class Component Syntax](https://github.com/nuxt-community/nuxt-property-decorator/)
-```typescript
-import {
-  Component,
-  Inject,
-  Model,
-  Prop,
-  Provide,
-  Vue,
-  Watch,
-} from "nuxt-property-decorator"
-
-@Component({})
-export class MyComponent extends Vue {
-  @Inject() foo!: string
-
-  @Model("change") checked!: boolean
-
-  @Prop() propA!: number
-
-  @Provide() foo = "foo"
-
-  @Watch("child")
-  onChildChanged(val: string, oldVal: string) {}
-}
-```
-
 ### Using Components In Templates
 Custom components and prop bindings should be used like this
 ```vue


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Docs

## Context

Removing nuxt-property-decorator because we finally can

Related - #4750 

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00898a9</samp>

Updated `STYLE_GUIDE.md` to reflect current coding practices and conventions.


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 00898a9</samp>

> _`STYLE_GUIDE.md` changed_
> _Outdated section removed_
> _Fresh like spring cleaning_
