### PR TITLE
feat: Add popular collections on AHK to sidebar on explore

### DIFF
--- a/components/shared/filters/modules/PopularCollections.vue
+++ b/components/shared/filters/modules/PopularCollections.vue
@@ -46,7 +46,7 @@
               <div
                 class="is-flex is-justify-content-space-between is-size-7 has-text-grey">
                 <div>{{ $t('search.owners') }}: {{ collection.owners }}</div>
-                <div>{{ getChainName(collection.chain) }}</div>
+                <div class="is-capitalized">{{ collection.chain }}</div>
               </div>
             </div>
           </div>
@@ -77,13 +77,9 @@ const exploreFiltersStore = useExploreFiltersStore()
 const route = useRoute()
 const router = useRouter()
 const { replaceUrl: replaceURL } = useReplaceUrl()
-const { availableChains } = useChain()
 const { urlPrefix, setUrlPrefix } = usePrefix()
 const { collections } = usePopularCollections(urlPrefix.value)
 
-const getChainName = (chain: string): string => {
-  return availableChains.value.find((item) => item.value === chain)?.text || ''
-}
 const isCutArray = computed(() => collections.value.map(() => ref(false)))
 
 const assignRefAndUpdateArray = (el, index) => {

--- a/components/shared/filters/modules/constants.ts
+++ b/components/shared/filters/modules/constants.ts
@@ -43,5 +43,14 @@ export const POPULAR_COLLECTIONS = {
     '2334273319', //Guardians and Creatures
     '1635680444', //KODACHAINS
   ],
-  ahk: ['u-2024', 'u-2023', '110', '30', '14', 'u-117', 'u-2022', 'u-31848'],
+  ahk: [
+    'u-2024', // The Decoded Hybrid Collection
+    'u-2023', // The Decoded Hybrid Collection: Gold Edition
+    '110', // Proof Of Chaos Sendout #0
+    '30', //  Copenhagen (Unlockable) Waifus
+    '14', // Zenuko #1
+    'u-117', // InvArch Access Passes
+    'u-2022', // Polkadot Decoded 2022 POAPs
+    'u-31848', // Ajuna Network Promo Collection
+  ],
 }

--- a/components/shared/filters/modules/constants.ts
+++ b/components/shared/filters/modules/constants.ts
@@ -43,4 +43,5 @@ export const POPULAR_COLLECTIONS = {
     '2334273319', //Guardians and Creatures
     '1635680444', //KODACHAINS
   ],
+  ahk: ['u-2024', 'u-2023', '110', '30', '14', 'u-117', 'u-2022', 'u-31848'],
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  - [x] Feature
  - [ ] Refactoring

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7131
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="340" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/905bed19-c95b-4afe-956d-cf8ff238e985">




  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce5fd6e</samp>

Added `ahk` chain to popular collections filter and improved its UI. Removed unused code and simplified the display of collection chain names using CSS.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ce5fd6e</samp>

> _We filter the collections of doom_
> _We choose the `ahk` chain of gloom_
> _We purge the code of useless waste_
> _We style the names with CSS grace_
  