### PR TITLE
fix: Collection Gallery Image low quality

### DIFF
--- a/components/collection/CollectionHeader/CollectionBanner.vue
+++ b/components/collection/CollectionHeader/CollectionBanner.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="collection-banner"
-    :style="{ backgroundImage: `url(${collectionAvatar})` }">
+    :style="{ backgroundImage: `url(${bannerImageUrl})` }">
     <div class="collection-banner-shadow"></div>
 
     <section class="h-full py-8">
@@ -26,7 +26,7 @@
 <script setup lang="ts">
 import type { NFTMetadata } from '@/components/rmrk/service/scheme'
 import { processSingleMetadata } from '@/utils/cachingStrategy'
-import { sanitizeIpfsUrl } from '@/utils/ipfs'
+import { sanitizeIpfsUrl, toOriginalContentUrl } from '@/utils/ipfs'
 import HeroButtons from '@/components/collection/HeroButtons.vue'
 import { generateCollectionImage } from '@/utils/seoImageGenerator'
 import { convertMarkdownToText } from '@/utils/markdown'
@@ -43,6 +43,10 @@ const { data } = useGraphql({
 
 const collectionAvatar = ref('')
 const collectionName = ref('--')
+
+const bannerImageUrl = computed(
+  () => collectionAvatar.value && toOriginalContentUrl(collectionAvatar.value)
+)
 
 watchEffect(async () => {
   const collection = data.value?.collectionEntity


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7141
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)


  ## Screenshot 📸

  - [x] My fix has changed UI


<img width="1837" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/5b042c80-dbcc-463c-99e6-07338f3e849e">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6290d3</samp>

Added custom banner images for collections. Updated `collection-banner` component to use `toOriginalContentUrl` function for IPFS images.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e6290d3</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous feature for the `collection-banner` component,_
> _That it might display the glorious images of collections_
> _Fetched from the IPFS hash by the `toOriginalContentUrl` function._
  