### PR TITLE
fix: targetAddresses might be empty

### DIFF
--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -733,7 +733,7 @@ const routerReplace = ({ params = {}, query = {} }) => {
 }
 
 watchDebounced(
-  () => targetAddresses.value[0].usd,
+  () => targetAddresses.value[0]?.usd,
   (usdamount) => {
     routerReplace({ query: { usdamount: (usdamount || 0).toString() } })
   },


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7146 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23e7649</samp>

Added optional chaining to `usd` property access in `Transfer.vue` to prevent errors and ensure correct query parameter update. This is part of a bug fix for the transfer component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 23e7649</samp>

> _`?.` operator_
> _avoids error in transfer_
> _autumn of bugs ends_
