### PR TITLE
fix: sort button semi-hidden on mobile

### DIFF
--- a/components/profile/OrderByDropdown.vue
+++ b/components/profile/OrderByDropdown.vue
@@ -11,7 +11,6 @@
       @change="onChange">
       <template #trigger="{ active }">
         <NeoButton
-          ref="buttonRef"
           :active="active"
           type="button"
           :icon="active ? 'chevron-up' : 'chevron-down'"

--- a/components/profile/OrderByDropdown.vue
+++ b/components/profile/OrderByDropdown.vue
@@ -7,10 +7,11 @@
       multiple
       :mobile-modal="false"
       aria-role="list"
-      position="bottom-left"
+      :position="dropdownPosition"
       @change="onChange">
       <template #trigger="{ active }">
         <NeoButton
+          ref="buttonRef"
           :active="active"
           type="button"
           :icon="active ? 'chevron-up' : 'chevron-down'"
@@ -110,6 +111,20 @@ function onChange(selected) {
   })
 }
 
+const dropdownPosition = ref('bottom-left')
+const buttonRef = ref<Vue | null>(null)
+
+function calcDropdownPosition() {
+  // calc the dropdown position based on the button postion
+  // if the button is in the right side of the screen,
+  // make the dropdown position to bottom-left
+  const ele = buttonRef.value?.$el as unknown as HTMLElement
+  dropdownPosition.value =
+    ele.getBoundingClientRect().left < window.innerWidth / 2
+      ? 'bottom-right'
+      : 'bottom-left'
+}
+
 watch(
   () => route.query.sort,
   (sort) => {
@@ -127,6 +142,7 @@ onMounted(() => {
       selectedSort.value = [sort] as string[]
     }
   }
+  calcDropdownPosition()
 })
 </script>
 

--- a/components/profile/OrderByDropdown.vue
+++ b/components/profile/OrderByDropdown.vue
@@ -118,7 +118,7 @@ function calcDropdownPosition() {
   // calc the dropdown position based on the button postion
   // if the button is in the right side of the screen,
   // make the dropdown position to bottom-left
-  const ele = buttonRef.value?.$el as unknown as HTMLElement
+  const ele = buttonRef.value?.$el as HTMLElement
   dropdownPosition.value =
     ele.getBoundingClientRect().left < window.innerWidth / 2
       ? 'bottom-right'

--- a/components/profile/OrderByDropdown.vue
+++ b/components/profile/OrderByDropdown.vue
@@ -7,7 +7,7 @@
       multiple
       :mobile-modal="false"
       aria-role="list"
-      :position="dropdownPosition"
+      position="bottom-auto"
       @change="onChange">
       <template #trigger="{ active }">
         <NeoButton
@@ -111,20 +111,6 @@ function onChange(selected) {
   })
 }
 
-const dropdownPosition = ref('bottom-left')
-const buttonRef = ref<Vue | null>(null)
-
-function calcDropdownPosition() {
-  // calc the dropdown position based on the button postion
-  // if the button is in the right side of the screen,
-  // make the dropdown position to bottom-left
-  const ele = buttonRef.value?.$el as HTMLElement
-  dropdownPosition.value =
-    ele.getBoundingClientRect().left < window.innerWidth / 2
-      ? 'bottom-right'
-      : 'bottom-left'
-}
-
 watch(
   () => route.query.sort,
   (sort) => {
@@ -142,7 +128,6 @@ onMounted(() => {
       selectedSort.value = [sort] as string[]
     }
   }
-  calcDropdownPosition()
 })
 </script>
 

--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -118,9 +118,9 @@
           :text="tab"
           class="is-capitalized"
           @click.native="() => switchToTab(tab)" />
-        <div class="is-flex mt-4">
-          <ChainDropdown />
-          <OrderByDropdown v-if="activeTab !== 'activity'" class="ml-4" />
+        <div class="is-flex mt-4 is-flex-wrap-wrap">
+          <ChainDropdown class="mr-4" />
+          <OrderByDropdown v-if="activeTab !== 'activity'" />
         </div>
       </div>
     </div>

--- a/libs/ui/src/components/NeoDropdown/NeoDropdown.vue
+++ b/libs/ui/src/components/NeoDropdown/NeoDropdown.vue
@@ -9,6 +9,11 @@ export default {
       default: false,
     },
   },
+  data() {
+    return {
+      autoPosition: '',
+    }
+  },
   computed: {
     rootClasses() {
       return [
@@ -28,6 +33,48 @@ export default {
             this.isMobileModal && this.isMatchMedia && !this.hoverable,
         },
       ]
+    },
+    menuClasses() {
+      return [
+        this.computedClass('menuClass', 'o-drop__menu'),
+        {
+          [this.computedClass(
+            'menuPositionClass',
+            'o-drop__menu--',
+            this.autoPosition
+          )]: this.autoPosition,
+        },
+        {
+          [this.computedClass('menuActiveClass', 'o-drop__menu--active')]:
+            this.isActive || this.inline,
+        },
+      ]
+    },
+    isAutoPosition() {
+      return this.position?.includes('auto')
+    },
+  },
+  mounted() {
+    if (this.isAutoPosition) {
+      this.calcDropdownPosition()
+      window.addEventListener('resize', this.calcDropdownPosition)
+    } else {
+      this.autoPosition = this.position
+    }
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.calcDropdownPosition)
+  },
+  methods: {
+    calcDropdownPosition() {
+      // support pass `position` type of `top-auto` or `bottom-auto`
+      // calc the dropdown position based on the trigger position
+      const ele = this.$refs.trigger
+      const side =
+        ele.getBoundingClientRect().left < window.innerWidth / 2
+          ? 'right'
+          : 'left'
+      this.autoPosition = this.position.replace('auto', side)
     },
   },
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).


👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7154
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="382" alt="image" src="https://github.com/kodadot/nft-gallery/assets/16473062/a9c1c426-7df0-4975-bc47-d15a8349e28f">
<img width="383" alt="image" src="https://github.com/kodadot/nft-gallery/assets/16473062/21e027f8-6d53-4b55-b3ee-61aa706160e9">


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8d2144</samp>

Improved the responsiveness and layout of the `OrderByDropdown` and `ChainDropdown` components in the profile page. Added a function to position the `OrderByDropdown` dynamically and adjusted the spacing and wrapping of the components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c8d2144</samp>

> _To make the profile detail look nice_
> _We tweaked the spacing and the size_
> _We added `calcDropdownPosition`_
> _To avoid any collision_
> _And used `is-flex-wrap-wrap` to wrap the `ChainDropdown` and `OrderByDropdown` twice_

