### PR TITLE
fix: close modal after clicking settings btn

### DIFF
--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -44,7 +44,10 @@
       </div>
 
       <!-- settings -->
-      <nuxt-link to="/settings" class="has-text-grey is-align-items-center">
+      <nuxt-link
+        to="/settings"
+        class="has-text-grey is-align-items-center"
+        @click.native="closeModal">
         <NeoIcon icon="gear" custom-size="fa-2x" />
         <span>{{ $t('settings') }}</span>
       </nuxt-link>
@@ -60,6 +63,7 @@ import { useLangStore } from '@/stores/lang'
 const { urlPrefix } = usePrefix()
 const { isBasilisk } = useIsChain(urlPrefix)
 const { toggleColorMode, isDarkMode } = useTheme()
+const { $neoModal } = useNuxtApp()
 
 const langStore = useLangStore()
 
@@ -91,6 +95,10 @@ onMounted(() => {
     })
   }
 })
+
+const closeModal = () => {
+  $neoModal.closeAll()
+}
 </script>
 
 <style lang="scss" scoped>

--- a/libs/ui/src/components/NeoModalExtend/plugin.js
+++ b/libs/ui/src/components/NeoModalExtend/plugin.js
@@ -14,7 +14,7 @@ const ModalProgrammatic = {
   removeOpenListener(callback) {
     for (const listener of openListener) {
       if (listener === callback) {
-        openListener.splice(i, 1)
+        openListener.splice(openListener.indexOf(listener), 1)
         break
       }
     }

--- a/libs/ui/src/components/NeoModalExtend/plugin.js
+++ b/libs/ui/src/components/NeoModalExtend/plugin.js
@@ -12,12 +12,7 @@ const ModalProgrammatic = {
     openListener.push(callback)
   },
   removeOpenListener(callback) {
-    for (const listener of openListener) {
-      if (listener === callback) {
-        openListener.splice(openListener.indexOf(listener), 1)
-        break
-      }
-    }
+    openListener = openListener.filter((e) => e !== callback)
   },
   open(params) {
     let parent


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7153  
- [ ] Requires deployment <snek/rubick/worker>


#### Did your issue had any of the "$" label on it?

- [x] my DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=12jXHf7yYF4wTRjDPbwFB24V1nVRPRkuU2S8Ke5ZWTfvyBGW&usdamount=8.82&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8280712</samp>

Fixed a bug in the `NeoModalExtend` plugin that prevented removing modal listeners. Improved the user experience of the wallet asset menu by closing it when not needed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8280712</samp>

> _Oh we splice the `openListener` with a clever trick_
> _We find the index with `indexOf` and we do it quick_
> _We close the wallet modal when we change the route_
> _We use the `useNuxtApp` hook and the `NeoModalExtend` to boot_

