### PR TITLE
remove required prop console warnings

### DIFF
--- a/components/shared/TabItem.vue
+++ b/components/shared/TabItem.vue
@@ -22,7 +22,7 @@ withDefaults(
     to?: string
     fullWidth?: boolean
     noShadow?: boolean
-    tag: string
+    tag?: string
   }>(),
   {
     to: '',


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] fix console warnings from tab item
![image](https://github.com/kodadot/nft-gallery/assets/22791238/478e35c8-9433-49af-9560-50853970d57c)



#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38b0a2e</samp>

Made `tag` prop optional for `TabItem` component. This enables using the component for tabs that do not need a tag, such as collection tabs in `NftGallery`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 38b0a2e</samp>

> _`TabItem` changes_
> _`tag` prop is optional now_
> _Autumn leaves fall_
