### PR TITLE
bug-fix: undefined variable in NeoModalExtend

### DIFF
--- a/libs/ui/src/components/NeoModalExtend/plugin.js
+++ b/libs/ui/src/components/NeoModalExtend/plugin.js
@@ -12,7 +12,7 @@ const ModalProgrammatic = {
     openListener.push(callback)
   },
   removeOpenListener(callback) {
-    for (const listener of openListener) {
+    for (const [i, listener] of openListener.entries()) {
       if (listener === callback) {
         openListener.splice(i, 1)
         break


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] fix bug in NeoModalExtend/plugin, removeOpenListener function had undefined variable `i`

created by this commit: https://github.com/kodadot/nft-gallery/commit/a9ac255f8e45b467453edcb9d148c949dbfbd98b
![image](https://github.com/kodadot/nft-gallery/assets/22791238/d208a961-776b-42e7-af3e-d6953f633e95)



#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2a1378</samp>

Fixed a bug in `ModalProgrammatic` that could remove the wrong or no listener when closing a modal. This affects the `NeoModalExtend` component in `libs/ui`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e2a1378</samp>

> _`ModalProgrammatic`_
> _Splices `openListener` well_
> _No more bugs in fall_
