### PR TITLE
chore: add vitest coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@types/markdown-it": "^12.2.3",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "@vitest/coverage-istanbul": "^0.34.3",
     "@vue/test-utils": "^1.3.6",
     "@vueuse/core": "^9.13.0",
     "@vueuse/nuxt": "^9.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.62.0
         version: 5.62.0(eslint@8.48.0)(typescript@4.9.5)
+      '@vitest/coverage-istanbul':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       '@vue/test-utils':
         specifier: ^1.3.6
         version: 1.3.6(vue@2.7.14)
@@ -9105,6 +9108,22 @@ packages:
       vitest: 0.34.3(jsdom@19.0.0)(sass@1.66.1)
     dev: true
 
+  /@vitest/coverage-istanbul@0.34.3(vitest@0.34.3):
+    resolution: {integrity: sha512-RdEGzydbbalyDLmmJ5Qm+T3Lrubw/U9iCnhzM2B1V57t4cVa1t6uyfIHdv68d1au4PRzkLhY7Xouwuhb7BeG+Q==}
+    peerDependencies:
+      vitest: '>=0.32.0 <1'
+    dependencies:
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-instrument: 6.0.0
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.5
+      test-exclude: 6.0.0
+      vitest: 0.34.3(jsdom@19.0.0)(sass@1.66.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vitest/expect@0.34.3:
     resolution: {integrity: sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==}
     dependencies:
@@ -16512,6 +16531,19 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /istanbul-lib-instrument@6.0.0:
+    resolution: {integrity: sha512-x58orMzEVfzPUKqlbLd1hXCnySCxKdDKa6Rjg97CwuLLRI4g3FHTdnExu1OqffVFay6zeMW+T6/DowFLndWnIw==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@babel/core': 7.22.11
+      '@babel/parser': 7.22.14
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /istanbul-lib-report@3.0.0:
     resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
     engines: {node: '>=8'}
@@ -16519,6 +16551,26 @@ packages:
       istanbul-lib-coverage: 3.2.0
       make-dir: 3.1.0
       supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.0
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.3.4(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.0
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /istanbul-reports@3.1.5:
@@ -17341,6 +17393,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       semver: 6.3.1
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.5.4
+    dev: true
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -24340,7 +24399,7 @@ packages:
     dev: true
 
   github.com/thisismydesign/sitemap-module/cd4dc22293b9b67e8ebb5b3c49840e67c108e312:
-    resolution: {tarball: https://codeload.github.com/thisismydesign/sitemap-module/tar.gz/cd4dc22293b9b67e8ebb5b3c49840e67c108e312}
+    resolution: {commit: cd4dc22293b9b67e8ebb5b3c49840e67c108e312, repo: git+ssh://git@github.com/thisismydesign/sitemap-module.git, type: git}
     name: '@nuxtjs/sitemap'
     version: 2.4.0
     engines: {node: '>=8.9.0', npm: '>=5.0.0'}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
     environment: 'jsdom',
     alias: [{ find: /^vue$/, replacement: 'vue/dist/vue.runtime.common.js' }],
     coverage: {
+      provider: 'istanbul',
       reporter: ['text', 'json', 'html'],
     },
   },


### PR DESCRIPTION
add @vitest/coverage-istanbul otherwise test coverage cannot be generated now

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [ ] Closes #7203 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0b4f23</samp>

This pull request adds code coverage reporting for the project using the `@vitest/coverage-istanbul` package and the Vitest testing framework. It modifies the `pnpm-lock.yaml`, `package.json`, and `vitest.config.js` files to install and configure the coverage tool. It also updates the `@nuxtjs/sitemap` package to a forked version that fixes a bug.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c0b4f23</samp>

> _To test their code with Vitest_
> _They added a package request_
> _`@vitest/coverage-istanbul`_
> _Was the tool that they chose_
> _To generate reports of their progress_
