### PR TITLE
fix: 3D NFT Thumbnail Preview - mimeType

### DIFF
--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -60,7 +60,7 @@ const props = withDefaults(
   {
     src: '',
     animationSrc: '',
-    mimeType: 'image/png',
+    mimeType: '',
     title: 'KodaDot NFT',
     original: false,
     isLewd: false,
@@ -83,8 +83,7 @@ const components = {
 }
 
 const resolveComponent = computed(() => {
-  const type = props.mimeType || mimeType.value
-  return components[resolveMedia(type) + SUFFIX]
+  return components[resolveMedia(mimeType.value) + SUFFIX]
 })
 const properSrc = computed(() => props.src || props.placeholder)
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #6953
  - [x] This bug was introduced by https://github.com/kodadot/nft-gallery/pull/7062

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1823" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/3c9129c6-8608-48d6-b88f-a62909ae057a">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c98c55</samp>

Refactored `MediaItem` component to use computed media type instead of prop. This improves the flexibility and readability of the component for different media sources.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5c98c55</samp>

> _To render different media types_
> _The `MediaItem` component was ripe_
> _For a refactor that would_
> _Make the code more understood_
> _By using `src` to compute `mimeType`_
  