### PR TITLE
feat: Replace free drop with new one

### DIFF
--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -40,7 +40,7 @@
           <div class="my-5">
             <UnlockableSlider :value="currentMintedCount / MAX_PER_WINDOW" />
           </div>
-          <div class="my-5">
+          <div v-if="!currentMintedLoading" class="my-5">
             <template v-if="!hasUserMinted">
               <NeoButton
                 ref="root"
@@ -209,7 +209,11 @@ const { data: collectionData } = useGraphql({
   },
 })
 
-const { data: stats, refetch: tryAgain } = useGraphql({
+const {
+  data: stats,
+  loading: currentMintedLoading,
+  refetch: tryAgain,
+} = useGraphql({
   queryName: 'firstNftOwnedByAccountAndCollectionId',
   variables: {
     id: collectionId,

--- a/components/collection/unlockable/UnlockableLandingTag.vue
+++ b/components/collection/unlockable/UnlockableLandingTag.vue
@@ -41,7 +41,7 @@
     <div class="separator mx-2" />
     <nuxt-link
       class="is-flex is-align-items-center has-text-weight-bold my-2"
-      to="/ahk/drops/free-drop">
+      to="/ahp/drops/free-drop">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -71,7 +71,7 @@ const displaySeconds = computed(() => {
 
 const twitterText = computed(
   () =>
-    'Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Do not miss your chance! \n\n https://kodadot.xyz/ahk/drops/free-drop'
+    `Just minted an exclusive NFT with unlockable items on @Kodadot! 🎉 So excited to add this unique collectible to my collection. Do not miss your chance! \n\n ${location.href}`
 )
 const postTwitterUrl = computed(
   () =>

--- a/components/collection/unlockable/const.ts
+++ b/components/collection/unlockable/const.ts
@@ -4,6 +4,6 @@ const now = new Date()
 export const countDownTime = endOfHour(now).getTime()
 
 export const slidesCountOnTimeCountdown = 10
-export const collectionId = '32'
+export const collectionId = '6'
 
 export const DISPLAY_SLIDE_IMAGE_COUNT = 4

--- a/components/collection/unlockable/utils.ts
+++ b/components/collection/unlockable/utils.ts
@@ -2,8 +2,9 @@ import { createMetadata, unSanitizeIpfsUrl } from '@kodadot1/minimark/utils'
 import { preheatFileFromIPFS } from '@/utils/ipfs'
 import { pinJson } from '@/services/nftStorage'
 
-export const UNLOCKABLE_CAMPAIGN = 'sha'
-export const UNLOCKABLE_NAME = 'Shanghai Waifu'
+export const UNLOCKABLE_CAMPAIGN = 'bbw2023'
+export const UNLOCKABLE_NAME = 'Berlin (Blockchain) Waifus'
+
 export const unlockableDesc = (value: number) => `
   This anime waifu is a demonstration of unlockables at [KodaDot](https://kodadot.xyz)
 

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -9,7 +9,7 @@
         :key="`${drop.collection.id}=${index}`"
         class="w-full h-full"
         :data-cy="index">
-        <DropCard :drop="drop" />
+        <DropCard :drop="drop" override-url-prefix="ahp" />
       </div>
       <template v-if="statemintDrops.drops.length">
         <div
@@ -55,7 +55,7 @@ import { useDrops } from './useDrops'
 import { dropsVisible } from '@/utils/config/permission.config'
 
 const { $i18n } = useNuxtApp()
-const drops = useDrops(collectionId)
+const drops = useDrops(collectionId, 'ahp')
 const statemintDrops = useDrops(STT_COLLECTION_ID, 'ahp')
 const { urlPrefix } = usePrefix()
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7197
  - [x] Closes #7186
  - [x] Related with https://github.com/kodadot/nft-gallery/issues/7194#issuecomment-1708807685 


  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="524" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/78a6ebec-06f3-48a0-a58b-76f98ebb5101">

<img width="1008" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/84ae7bc5-b325-45ee-ac41-44f7d7a7eeae">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 201f02c</samp>

This pull request enhances the unlockable NFT feature by adding support for statemint chain drops, fixing a typo, and updating the metadata constants. It also improves the UX of minting unlockable NFTs by hiding the button until the user's NFTs are loaded.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 201f02c</samp>

> _We are the Berlin Waifus, we rule the blockchain_
> _We mint our NFTs with the power of the statemint_
> _We fix our typos and update our constants_
> _We hide our buttons until we load our mints_
  