### PR TITLE
fix: load proper preview

### DIFF
--- a/composables/useNft.ts
+++ b/composables/useNft.ts
@@ -31,7 +31,9 @@ function getGeneralMetadata(nft: NFTWithMetadata) {
     name: nft.name || nft.meta.name || nft.id,
     description: nft.description || nft.meta.description || '',
     image: sanitizeIpfsUrl(nft.meta.image),
-    animationUrl: sanitizeIpfsUrl(nft.meta.animation_url || ''),
+    animationUrl: sanitizeIpfsUrl(
+      nft.meta.animation_url || nft.meta.animationUrl || ''
+    ),
     type: nft.meta.type || '',
   }
 }

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -60,7 +60,7 @@ const props = withDefaults(
   {
     src: '',
     animationSrc: '',
-    mimeType: 'image/png',
+    mimeType: '',
     title: 'KodaDot NFT',
     original: false,
     isLewd: false,
@@ -89,6 +89,7 @@ const resolveComponent = computed(() => {
 const properSrc = computed(() => props.src || props.placeholder)
 
 const updateComponent = async () => {
+  console.log('animationSrc: ', props)
   if (props.animationSrc && !props.mimeType) {
     mimeType.value = await getMimeType(props.animationSrc)
   }

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -89,7 +89,6 @@ const resolveComponent = computed(() => {
 const properSrc = computed(() => props.src || props.placeholder)
 
 const updateComponent = async () => {
-  console.log('animationSrc: ', props)
   if (props.animationSrc && !props.mimeType) {
     mimeType.value = await getMimeType(props.animationSrc)
   }


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7176  
- [ ] Requires deployment <snek/rubick/worker>


#### Did your issue had any of the "$" label on it?

- [x] my DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=12jXHf7yYF4wTRjDPbwFB24V1nVRPRkuU2S8Ke5ZWTfvyBGW&usdamount=8.82&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d3495d</samp>

This pull request enhances the NFT media display and compatibility by removing unnecessary MIME types, adding debug logs, and providing a fallback for the animation URL in `MediaItem.vue` and `useNft.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d3495d</samp>

> _To show NFTs in their glory_
> _We need to handle the animation story_
> _If `animation_url` is not there_
> _We use `animationUrl` as a spare_
> _And remove the MIME type that's hoary_



