### PR TITLE
Refactor similar blocks

### DIFF
--- a/composables/transaction/transactionMintToken.ts
+++ b/composables/transaction/transactionMintToken.ts
@@ -3,33 +3,18 @@ import { execMintBasilisk } from './mintToken/transactionMintBasilisk'
 import { MintTokenParams } from './types'
 import { execMintStatemine } from './mintToken/transactionMintStatemine'
 
-export function execMintToken({
-  item,
-  api,
-  executeTransaction,
-  isLoading,
-  status,
-}: MintTokenParams) {
+export function execMintToken(mintParams: MintTokenParams) {
+  const { item } = mintParams
+
   if (item.urlPrefix === 'rmrk' || item.urlPrefix === 'ksm') {
-    return execMintRmrk({ item, api, executeTransaction, isLoading, status })
+    return execMintRmrk(mintParams)
   }
 
   if (item.urlPrefix === 'snek' || item.urlPrefix === 'bsx') {
-    return execMintBasilisk({
-      item,
-      api,
-      executeTransaction,
-      isLoading,
-      status,
-    })
+    return execMintBasilisk(mintParams)
   }
+
   if (item.urlPrefix === 'ahk' || item.urlPrefix === 'ahp') {
-    return execMintStatemine({
-      item,
-      api,
-      executeTransaction,
-      isLoading,
-      status,
-    })
+    return execMintStatemine(mintParams)
   }
 }

--- a/utils/math.ts
+++ b/utils/math.ts
@@ -57,17 +57,17 @@ export function getVolume(events: Interaction[]): bigint {
     .reduce((acc, cur) => acc + cur, BigInt(0))
 }
 
-export const after =
-  (date: Date) =>
+const checkBeforeOrAfter =
+  (date: Date, before = true) =>
   (event: Interaction): boolean =>
-    isAfter(parseISO(event.timestamp), date) ||
+    (before
+      ? isBefore(parseISO(event.timestamp), date)
+      : isAfter(parseISO(event.timestamp), date)) ||
     isEqual(parseISO(event.timestamp), date)
 
-export const before =
-  (date: Date) =>
-  (event: Interaction): boolean =>
-    isBefore(parseISO(event.timestamp), date) ||
-    isEqual(parseISO(event.timestamp), date)
+export const after = (date: Date) => checkBeforeOrAfter(date, false)
+
+export const before = (date: Date) => checkBeforeOrAfter(date)
 
 export const between =
   (dateA: Date, dateB: Date) =>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring

## Context

- [X] Part of #6782
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried to respect high code quality standards
- [X] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [X] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16hqk8Tjugo9AwSzKkxXc1dsRK7iJetpx1YBaoXYwdHzuNAt&usdamount=50&donation=true)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f350eb</samp>

Refactored some functions in `composables/transaction/transactionMintToken.ts` and `utils/math.ts` to use parameter objects and helper functions for better code quality and consistency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4f350eb</samp>

> _`execMintToken`_
> _uses one parameter object_
> _refactored for clarity_
