### PR TITLE
Conversion: Old cypress tests and data-cy attribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ We are currently in the process of installing [Playwright](https://playwright.de
   class="btn btn-large"
   name="submission"
   role="button"
-  data-cy="submit">
+  data-testid="submit">
   Submit
 </button>
 ```

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -83,7 +83,7 @@
         <!-- NAV END -->
         <div class="navbar-end">
           <nuxt-link to="/ahk/drops" rel="nofollow">
-            <div class="navbar-item" data-cy="drops">
+            <div class="navbar-item" data-testid="drops">
               {{ $t('drops.title') }}
 
               <NeoIcon
@@ -101,20 +101,20 @@
           <ExploreDropdown
             v-else
             class="navbar-explore custom-navbar-item"
-            data-cy="explore" />
+            data-testid="explore" />
 
           <a
             href="https://hello.kodadot.xyz"
             rel="nofollow noopener noreferrer"
             target="_blank"
             class="navbar-item"
-            data-cy="learn">
+            data-testid="learn">
             {{ $t('learn') }}
           </a>
           <CreateDropdown
             v-show="isCreateVisible"
             class="navbar-create custom-navbar-item ml-0"
-            data-cy="create"
+            data-testid="create"
             :is-mobile="isMobile"
             :chain="urlPrefix"
             @closeMobileNavbar="showMobileNavbar" />
@@ -122,7 +122,7 @@
           <!-- commenting as part of #5889-->
           <!-- <StatsDropdown
           class="navbar-stats custom-navbar-item"
-          data-cy="stats"
+          data-testid="stats"
           :is-mobile="isMobile"
           :chain="urlPrefix" /> -->
 
@@ -137,7 +137,7 @@
             v-else
             id="NavChainSelect"
             class="navbar-chain custom-navbar-item"
-            data-cy="chain-select" />
+            data-testid="chain-select" />
 
           <NotificationBoxButton
             v-if="account"
@@ -176,7 +176,7 @@
             v-if="!isMobile"
             id="NavProfile"
             :chain="urlPrefix"
-            data-cy="profileDropdown"
+            data-testid="profileDropdown"
             @closeBurgerMenu="closeBurgerMenu" />
         </div>
         <!-- END NAV END -->

--- a/components/balance/MultipleBalances.vue
+++ b/components/balance/MultipleBalances.vue
@@ -41,7 +41,7 @@
 
       <NeoSkeleton
         v-if="isBalanceLoading"
-        data-cy="skeleton-multiple-balances"
+        data-testid="skeleton-multiple-balances"
         animated />
     </div>
 

--- a/components/carousel/CarouselTypeLatestSales.vue
+++ b/components/carousel/CarouselTypeLatestSales.vue
@@ -1,7 +1,7 @@
 <template>
   <CarouselIndex
     :key="ids"
-    data-cy="latest-sales"
+    data-testid="latest-sales"
     :title="$t('general.latestSales')"
     :subtitle="`${$t('general.latestSalesheading')} ${urlPrefix}`"
     :nfts="nfts"

--- a/components/collection/CollectionGrid.vue
+++ b/components/collection/CollectionGrid.vue
@@ -14,7 +14,7 @@
         v-for="(collection, index) in collections"
         :key="collection.id"
         :class="scrollItemClassName"
-        :data-cy="`collection-index-${index}`">
+        :data-testid="`collection-index-${index}`">
         <CollectionCard :collection="collection" />
       </div>
     </DynamicGrid>

--- a/components/collection/HeroButtons.vue
+++ b/components/collection/HeroButtons.vue
@@ -24,7 +24,7 @@
             <NeoButton
               icon="share-alt"
               class="square-32 mr-3"
-              data-cy="share-button"
+              data-testid="share-button"
               :active="active" />
           </template>
 
@@ -58,7 +58,7 @@
             <NeoButton
               icon="ellipsis-vertical"
               class="square-32"
-              data-cy="more-actions-button"
+              data-testid="more-actions-button"
               :active="active" />
           </template>
 

--- a/components/collection/unlockable/UnlockableHeroButtons.vue
+++ b/components/collection/unlockable/UnlockableHeroButtons.vue
@@ -8,7 +8,7 @@
             <NeoButton
               icon="share-alt"
               class="square-32 mr-3"
-              data-cy="share-button"
+              data-testid="share-button"
               :active="active" />
           </template>
 

--- a/components/collectionDetailsPopover/CollectionDetailsPopover.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopover.vue
@@ -5,7 +5,7 @@
     :animate-fill="false"
     placement="bottom"
     :delay="[showDelay, hideDelay]"
-    data-cy="identity"
+    data-testid="identity"
     :on-show="() => (show = true)">
     <template #trigger>
       <slot name="trigger" />

--- a/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
@@ -10,7 +10,7 @@
             :to="`/${urlPrefix}/collection/${
               nft?.collection?.id || nft.collectionId
             }`">
-            <span data-cy="identity-display">
+            <span data-testid="identity-display">
               {{ nft?.collection?.name || nft?.collectionName || '--' }}</span
             >
           </nuxt-link>
@@ -24,7 +24,7 @@
           class="is-flex is-align-items-center is-justify-content-space-between">
           <span class="is-size-6">{{ $t('statsOverview.uniqueOwners') }}</span>
 
-          <p class="is-size-6" data-cy="identity-collected">
+          <p class="is-size-6" data-testid="identity-collected">
             {{ stats.uniqueOwnersPercent }}
           </p>
         </div>
@@ -32,7 +32,7 @@
           class="is-flex is-align-items-center is-justify-content-space-between">
           <span class="is-size-6">{{ $t('statsOverview.highestSale') }}</span>
 
-          <p class="is-size-6" data-cy="identity-collected">
+          <p class="is-size-6" data-testid="identity-collected">
             <CommonTokenMoney :value="highestBuyPrice" inline />
           </p>
         </div>
@@ -40,7 +40,7 @@
           class="is-flex is-align-items-center is-justify-content-space-between">
           <span class="is-size-6">{{ $t('statsOverview.floorPrice') }}</span>
 
-          <p class="is-size-6" data-cy="identity-collected">
+          <p class="is-size-6" data-testid="identity-collected">
             <CommonTokenMoney :value="stats.collectionFloorPrice" inline />
           </p>
         </div>
@@ -48,7 +48,7 @@
           class="is-flex is-align-items-center is-justify-content-space-between">
           <span class="is-size-6">{{ $t('statsOverview.totalVolume') }}</span>
 
-          <p class="is-size-6" data-cy="identity-collected">
+          <p class="is-size-6" data-testid="identity-collected">
             <CommonTokenMoney
               :value="stats.collectionTradedVolumeNumber"
               inline />
@@ -67,7 +67,7 @@
               :metadata="nftItem.metadata"
               :current-owner="nftItem.currentOwner"
               :route="`/${urlPrefix}/gallery`"
-              :data-cy="soldItems.indexOf(nftItem)" />
+              :data-testid="soldItems.indexOf(nftItem)" />
           </div>
         </div>
       </div>

--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -21,7 +21,7 @@
       </div>
 
       <!-- language -->
-      <div data-cy="sidebar-language">
+      <div data-testid="sidebar-language">
         <NeoDropdown position="top-left" aria-role="menu" mobile-modal>
           <template #trigger>
             <div class="is-flex is-align-items-center">
@@ -34,7 +34,7 @@
             v-for="lang in langsFlags"
             :key="lang.value"
             aria-role="listitem"
-            :data-cy="`sidebar-language-${lang.value}`"
+            :data-testid="`sidebar-language-${lang.value}`"
             :value="lang.value"
             :class="{ 'is-active': langStore.getUserLang === lang.value }"
             @click="langStore.setLanguage({ userLang: lang.value })">

--- a/components/common/confirmPurchaseModal/ConfirmPurchaseModal.vue
+++ b/components/common/confirmPurchaseModal/ConfirmPurchaseModal.vue
@@ -29,7 +29,7 @@
             :prefix="urlPrefix"
             :account="accountId"
             class="identity-name-font-weight-regular"
-            data-cy="item-creator" />
+            data-testid="item-creator" />
         </div>
       </div>
       <div class="py-2">

--- a/components/common/listingCart/ListingCartModal.vue
+++ b/components/common/listingCart/ListingCartModal.vue
@@ -29,7 +29,7 @@
               :prefix="urlPrefix"
               :account="accountId"
               class="identity-name-font-weight-regular"
-              data-cy="item-creator" />
+              data-testid="item-creator" />
           </div>
           <div class="pt-4 has-text-weight-bold">Set All To</div>
           <div class="pt-4">

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -8,7 +8,7 @@
         v-for="(drop, index) in drops.drops"
         :key="`${drop.collection.id}=${index}`"
         class="w-full h-full"
-        :data-cy="index">
+        :data-testid="index">
         <DropCard :drop="drop" />
       </div>
       <template v-if="statemintDrops.drops.length">
@@ -16,7 +16,7 @@
           v-for="(drop, index) in statemintDrops.drops"
           :key="`${drop.collection.id}=${index}`"
           class="w-full h-full"
-          :data-cy="index">
+          :data-testid="index">
           <DropCard
             :drop="drop"
             override-url-prefix="ahp"
@@ -32,7 +32,7 @@
         v-for="(drop, index) in drops.futureDrops"
         :key="`${drop.collection.id}=${index}`"
         class="w-full h-full"
-        :data-cy="index">
+        :data-testid="index">
         <DropCard :drop="drop" />
       </div>
     </div>

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -8,7 +8,7 @@
         v-for="(drop, index) in drops.drops"
         :key="`${drop.collection.id}=${index}`"
         class="w-full h-full"
-        :data-cy="index">
+        :data-testid="index">
         <DropCard :drop="drop" override-url-prefix="ahp" />
       </div>
       <template v-if="statemintDrops.drops.length">

--- a/components/explore/ExploreSort.vue
+++ b/components/explore/ExploreSort.vue
@@ -15,14 +15,14 @@
           type="button"
           :icon="active ? 'chevron-up' : 'chevron-down'"
           class="has-text-left is-hidden-mobile"
-          data-cy="explore-sort">
+          data-testid="explore-sort">
           {{ $i18n.t('sort.collection.sortBy') }}
         </NeoButton>
         <NeoButton
           type="button"
           icon="filter"
           class="is-hidden-tablet"
-          data-cy="explore-sort" />
+          data-testid="explore-sort" />
 
         <ActiveCount v-if="selectedSort.length" :count="selectedSort.length" />
       </template>
@@ -32,7 +32,7 @@
         :key="option"
         aria-role="listitem"
         class="is-flex"
-        :data-cy="option"
+        :data-testid="option"
         :value="option">
         <span>
           {{

--- a/components/explore/ExploreTabs.vue
+++ b/components/explore/ExploreTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="has-addons is-flex is-align-items-center" data-cy="tabs">
+  <div class="has-addons is-flex is-align-items-center" data-testid="tabs">
     <TabOnCollection v-if="route.name?.includes('prefix-collection-id')" />
     <TabOnExplore v-else />
   </div>

--- a/components/explore/FilterMenuButton.vue
+++ b/components/explore/FilterMenuButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="has-addons is-flex is-align-items-center" data-cy="tabs">
+  <div class="has-addons is-flex is-align-items-center" data-testid="tabs">
     <a
       :class="[
         { disabled: disabled },

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -67,11 +67,11 @@
           <div class="pb-4">
             <div class="is-flex is-justify-content-space-between">
               <div class="name-container">
-                <h1 class="title" data-cy="item-title">
+                <h1 class="title" data-testid="item-title">
                   {{ nftMetadata?.name }}
                   <span v-if="nft?.burned" class="has-text-danger">「🔥」</span>
                 </h1>
-                <h2 class="subtitle" data-cy="item-collection">
+                <h2 class="subtitle" data-testid="item-collection">
                   <CollectionDetailsPopover
                     v-if="nft?.collection.id"
                     :nft="nft">
@@ -98,14 +98,14 @@
                 :label="$t('Creator')"
                 :prefix="urlPrefix"
                 :account="nft?.issuer"
-                data-cy="item-creator" />
+                data-testid="item-creator" />
               <IdentityItem
                 v-if="nft?.currentOwner !== nft?.issuer"
                 class="gallery-avatar"
                 :label="$t('Owner')"
                 :prefix="urlPrefix"
                 :account="nft?.currentOwner || ''"
-                data-cy="item-owner" />
+                data-testid="item-owner" />
             </div>
           </div>
 
@@ -148,7 +148,7 @@
       v-if="nft?.collection.id"
       class="mt-8"
       :collection-id="nft?.collection.id"
-      data-cy="carousel-related" />
+      data-testid="carousel-related" />
 
     <CarouselTypeVisited class="mt-8" />
 

--- a/components/gallery/GalleryItemAction/GalleryItemActionSection.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionSection.vue
@@ -6,10 +6,10 @@
       </div>
       <div
         class="is-flex gallery-action-section-price-box"
-        data-cy="item-price">
+        data-testid="item-price">
         <div
           v-if="Number(price)"
-          data-cy="money"
+          data-testid="money"
           class="gallery-action-section-price has-text-weight-bold">
           {{ priceChain }}
         </div>

--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-cy="item-section-buy">
+  <div data-testid="item-section-buy">
     <GalleryItemPriceSection v-if="nft.price" title="Price" :price="nft.price">
       <div v-if="Number(nft.price)" class="is-flex desktop-full-w">
         <div class="is-flex buy-button-width">
@@ -36,14 +36,14 @@
               class="button-height w-full"
               variant="k-accent"
               :disabled="disabled"
-              data-cy="item-buy"
+              data-testid="item-buy"
               @click.native="onClick" />
           </NeoTooltip>
         </div>
 
         <NeoButton
           class="button-height no-border-left"
-          data-cy="item-add-to-cart"
+          data-testid="item-add-to-cart"
           @click.native="onClickShoppingCart">
           <img :src="cartIcon" class="image is-32x32" />
         </NeoButton>

--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemOffer.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemOffer.vue
@@ -13,7 +13,7 @@
             size="large"
             variant="k-blue"
             class="full-width-action-button"
-            data-cy="make-offer"
+            data-testid="make-offer"
             no-shadow
             @click.native="toggleActive" />
         </template>

--- a/components/gallery/GalleryItemDescription.vue
+++ b/components/gallery/GalleryItemDescription.vue
@@ -119,7 +119,7 @@
       <div v-if="nftImage" class="is-flex is-justify-content-space-between">
         <p>{{ $t('tabs.tabDetails.media') }}</p>
         <div @click="openLink(nftImage)">
-          <a class="has-text-link" data-cy="media-link">
+          <a class="has-text-link" data-testid="media-link">
             {{ nftMimeType }}
           </a>
         </div>
@@ -139,7 +139,7 @@
           class="has-text-link"
           target="_blank"
           rel="nofollow noopener noreferrer"
-          data-cy="metadata-link"
+          data-testid="metadata-link"
           >{{ metadataMimeType }}</a
         >
       </div>

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivity.vue
@@ -3,7 +3,7 @@
     <div class="events py-5 px-6 is-flex is-flex-direction-column">
       <div
         class="events-filter is-flex is-flex-wrap-wrap"
-        data-cy="events-filter">
+        data-testid="events-filter">
         <a
           class="is-capitalized is-flex is-align-items-center"
           @click="checkAll">
@@ -14,7 +14,7 @@
           v-for="(value, name) in filters"
           :key="name"
           class="is-clickable is-capitalized events-checkbox-container"
-          :data-cy="name"
+          :data-testid="name"
           :class="cssActive(value)">
           <input
             :id="name"

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemTabsPanel.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemTabsPanel.vue
@@ -3,12 +3,12 @@
     v-model="activeTab"
     type="toggle"
     expanded
-    data-cy="gallery-item-tabs"
+    data-testid="gallery-item-tabs"
     content-class="o-tabs__content--fixed gallery-item-tab-panel">
     <!-- offers -->
     <NeoTabItem
       value="0"
-      data-cy="offer-list"
+      data-testid="offer-list"
       :disabled="offersDisabled"
       :label="$t('tabs.offers')"
       tag="div"
@@ -36,7 +36,10 @@
     </NeoTabItem>
 
     <!-- activity -->
-    <NeoTabItem value="1" :label="$t('tabs.activity')" data-cy="offer-activity">
+    <NeoTabItem
+      value="1"
+      :label="$t('tabs.activity')"
+      data-testid="offer-activity">
       <GalleryItemActivity v-if="nft?.id" :nft-id="nft?.id" />
     </NeoTabItem>
 

--- a/components/generative/ContactForm.vue
+++ b/components/generative/ContactForm.vue
@@ -12,7 +12,7 @@
       expanded
       type="email"
       spellcheck="true"
-      data-cy="input-name" />
+      data-testid="input-name" />
 
     <SubmitButton
       label="submit"

--- a/components/identity/module/IdentityPopover.vue
+++ b/components/identity/module/IdentityPopover.vue
@@ -6,7 +6,7 @@
     boundary="viewport"
     placement="bottom"
     :delay="0"
-    data-cy="identity">
+    data-testid="identity">
     <template #trigger>
       <slot name="trigger" />
     </template>

--- a/components/identity/module/IdentityPopoverFooter.vue
+++ b/components/identity/module/IdentityPopoverFooter.vue
@@ -5,7 +5,7 @@
         class="is-flex is-align-items-center is-justify-content-space-between">
         <span class="is-size-6">{{ $t('profile.collected') }}</span>
 
-        <p class="is-size-6" data-cy="identity-collected">
+        <p class="is-size-6" data-testid="identity-collected">
           {{ totalCollected }}
         </p>
       </div>
@@ -13,7 +13,7 @@
         class="is-flex is-align-items-center is-justify-content-space-between">
         <span class="is-size-6">{{ $t('profile.created') }}</span>
 
-        <p class="is-size-6" data-cy="identity-created">
+        <p class="is-size-6" data-testid="identity-created">
           {{ totalCreated }}
         </p>
       </div>
@@ -21,7 +21,7 @@
         class="is-flex is-align-items-center is-justify-content-space-between">
         <span class="is-size-6">{{ $t('profile.sold') }}</span>
 
-        <p class="is-size-6" data-cy="identity-sold">
+        <p class="is-size-6" data-testid="identity-sold">
           {{ totalSold }}
         </p>
       </div>
@@ -38,7 +38,7 @@
             :metadata="nft.metadata"
             :current-owner="nft.currentOwner"
             :route="`/${urlPrefix}/gallery`"
-            :data-cy="soldItems.indexOf(nft)" />
+            :data-testid="soldItems.indexOf(nft)" />
         </div>
       </div>
     </div>

--- a/components/identity/module/IdentityPopoverHeader.vue
+++ b/components/identity/module/IdentityPopoverHeader.vue
@@ -6,7 +6,7 @@
         <nuxt-link
           class="is-size-6 break-word mr-2 has-text-link"
           :to="`/${urlPrefix}/u/${address}`">
-          <span data-cy="identity-display">
+          <span data-testid="identity-display">
             {{ identity?.display || shortenedAddress }}</span
           >
         </nuxt-link>
@@ -14,7 +14,7 @@
           v-clipboard:copy="address"
           icon="copy"
           class="has-text-link is-clickable"
-          data-cy="identity-clipboard"
+          data-testid="identity-clipboard"
           @click.native="toast('Copied to clipboard')" />
       </div>
       <a
@@ -22,7 +22,7 @@
         v-safe-href="`https://twitter.com/${identity?.twitter}`"
         target="_blank"
         rel="nofollow noopener noreferrer"
-        data-cy="identity-twitter">
+        data-testid="identity-twitter">
         <NeoIcon pack="fab" icon="x-twitter" class="has-text-link" />
       </a>
     </div>

--- a/components/items/ItemsGrid/ItemsGrid.vue
+++ b/components/items/ItemsGrid/ItemsGrid.vue
@@ -12,7 +12,7 @@
       <div
         v-for="(nft, index) in nfts"
         :key="`${nft.id}=${index}`"
-        :data-cy="index"
+        :data-testid="index"
         :class="scrollItemClassName">
         <ItemsGridImage
           :nft="nft"

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -19,7 +19,7 @@
       <div v-if="!isOwner && Number(nft?.price)" class="is-flex">
         <NeoButton
           :label="buyLabel"
-          data-cy="item-buy"
+          data-testid="item-buy"
           no-shadow
           :loading="showActionSection"
           class="is-flex-grow-1 btn-height"
@@ -27,7 +27,7 @@
           @click.native.prevent="onClickBuy">
         </NeoButton>
         <NeoButton
-          data-cy="item-add-to-cart"
+          data-testid="item-add-to-cart"
           no-shadow
           class="fixed-width p-1 no-border-left btn-height override-wrapper-width"
           @click.native.prevent="onClickShoppingCart">
@@ -37,7 +37,7 @@
       <div v-else-if="isOwner" class="is-flex">
         <NeoButton
           :label="listLabel"
-          data-cy="item-buy"
+          data-testid="item-buy"
           no-shadow
           class="is-flex-grow-1 btn-height"
           @click.native.prevent="onClickListingCart">

--- a/components/media/type/AudioMedia.vue
+++ b/components/media/type/AudioMedia.vue
@@ -8,7 +8,7 @@
       played-line-color="rgba(0,0,0,0.74)"
       noplayed-line-color="#d32e79"
       playtime-font-color="rgba(0,0,0,0.74)"
-      data-cy="type-audio" />
+      data-testid="type-audio" />
   </div>
 </template>
 

--- a/components/media/type/ImageMedia.vue
+++ b/components/media/type/ImageMedia.vue
@@ -4,7 +4,7 @@
       class="image-media__image"
       :src="src"
       :alt="mimeType"
-      data-cy="type-image" />
+      data-testid="type-image" />
   </figure>
 </template>
 

--- a/components/media/type/ModelMedia.vue
+++ b/components/media/type/ModelMedia.vue
@@ -13,7 +13,7 @@
       ar-modes="webxr scene-viewer quick-look"
       shadow-intensity="1"
       autoplay
-      data-cy="type-3d">
+      data-testid="type-3d">
       <button id="ar-button" slot="ar-button">Activate AR</button>
     </model-viewer>
   </div>

--- a/components/media/type/VideoMedia.vue
+++ b/components/media/type/VideoMedia.vue
@@ -12,7 +12,7 @@
       :poster="poster"
       :type="mimeType"
       controlslist="nodownload"
-      data-cy="type-video" />
+      data-testid="type-video" />
   </div>
 </template>
 

--- a/components/navbar/ChainSelectDropdown.vue
+++ b/components/navbar/ChainSelectDropdown.vue
@@ -5,7 +5,7 @@
     :triggers="['click']"
     position="bottom-left">
     <template #trigger>
-      <div class="navbar-item" data-cy="chain">{{ chainName }}</div>
+      <div class="navbar-item" data-testid="chain">{{ chainName }}</div>
     </template>
 
     <NeoDropdownItem
@@ -15,7 +15,7 @@
       aria-role="listitem"
       :value="option.value"
       :class="{ 'is-active': selected === option.value }"
-      :data-cy="`chain-dropdown-${option.value}`">
+      :data-testid="`chain-dropdown-${option.value}`">
       {{ option.text }}
     </NeoDropdownItem>
   </NeoDropdown>

--- a/components/navbar/CreateDropdown.vue
+++ b/components/navbar/CreateDropdown.vue
@@ -13,7 +13,10 @@
           full-width
           :label="$t('createDropdown.start')"
           multiline>
-          <nuxt-link data-cy="classic" :to="`/${urlPrefix}/create`" tag="div">
+          <nuxt-link
+            data-testid="classic"
+            :to="`/${urlPrefix}/create`"
+            tag="div">
             {{ $t('classic') }}
           </nuxt-link>
         </NeoTooltip>
@@ -24,7 +27,7 @@
           position="left"
           :label="$t('createDropdown.waifu')"
           multiline>
-          <nuxt-link data-cy="waifu" :to="`/${urlPrefix}/waifu`" tag="div">
+          <nuxt-link data-testid="waifu" :to="`/${urlPrefix}/waifu`" tag="div">
             {{ $t('navbar.create.waifu') }}
           </nuxt-link>
         </NeoTooltip>
@@ -37,7 +40,10 @@
             full-width
             :label="$t('createDropdown.simplifiedNft')"
             multiline>
-            <nuxt-link data-cy="simple" :to="`/${urlPrefix}/mint`" tag="div">
+            <nuxt-link
+              data-testid="simple"
+              :to="`/${urlPrefix}/mint`"
+              tag="div">
               {{ $t('simple') }}
             </nuxt-link>
           </NeoTooltip>
@@ -50,7 +56,7 @@
           :label="$t('createDropdown.massmint')"
           multiline>
           <nuxt-link
-            data-cy="massmint"
+            data-testid="massmint"
             :to="`/${urlPrefix}/massmint`"
             tag="div">
             {{ $t('multipleNFTS') }}
@@ -62,7 +68,7 @@
     <MobileExpandableSection v-else :no-padding="true" :title="$t('create')">
       <nuxt-link
         class="navbar-item"
-        data-cy="classic"
+        data-testid="classic"
         :to="`/${urlPrefix}/create`"
         @click.native="emit('closeMobileNavbar')">
         {{ $t('classic') }}
@@ -70,7 +76,7 @@
       <nuxt-link
         v-if="chain === 'ahk'"
         class="navbar-item"
-        data-cy="waifu"
+        data-testid="waifu"
         :to="`/${urlPrefix}/waifu`"
         @click.native="emit('closeMobileNavbar')">
         {{ $t('waifu') }}
@@ -78,7 +84,7 @@
       <template v-if="chain === 'rmrk'">
         <nuxt-link
           class="navbar-item"
-          data-cy="simple"
+          data-testid="simple"
           :to="`/${urlPrefix}/mint`"
           @click.native="emit('closeMobileNavbar')">
           {{ $t('simple') }}
@@ -86,7 +92,7 @@
       </template>
       <nuxt-link
         class="navbar-item"
-        data-cy="massmint"
+        data-testid="massmint"
         :to="`/${urlPrefix}/massmint`"
         @click.native="emit('closeMobileNavbar')">
         {{ $t('multipleNFTS') }}

--- a/components/navbar/ExploreDropdown.vue
+++ b/components/navbar/ExploreDropdown.vue
@@ -3,7 +3,7 @@
     <template #trigger>
       <div>
         <nuxt-link :to="`/${urlPrefix}/explore/collectibles`">
-          <div class="navbar-item" data-cy="explore">
+          <div class="navbar-item" data-testid="explore">
             {{ $t('explore') }}
             <svg
               v-if="!isMobileDevice"

--- a/components/navbar/NavbarExploreOptions.vue
+++ b/components/navbar/NavbarExploreOptions.vue
@@ -4,7 +4,7 @@
       <nuxt-link
         :to="`/${urlPrefix}/explore/items`"
         class="menu-item mr-6"
-        data-cy="explore-items"
+        data-testid="explore-items"
         @click.native="emit('closeMobileNavbar')">
         {{ $t('items') }}
       </nuxt-link>

--- a/components/navbar/StatsDropdown.vue
+++ b/components/navbar/StatsDropdown.vue
@@ -4,53 +4,53 @@
       <NeoDropdown
         v-if="showSnekBsxOptions"
         aria-role="list"
-        data-cy="stats"
+        data-testid="stats"
         :triggers="['click']">
         <template #trigger>
-          <div class="navbar-item" data-cy="stats">
+          <div class="navbar-item" data-testid="stats">
             {{ $t('stats') }}
           </div>
         </template>
         <NeoDropdownItem>
-          <nuxt-link data-cy="global-offers" :to="offersUrl">
+          <nuxt-link data-testid="global-offers" :to="offersUrl">
             {{ $t('navbar.globalOffers') }}
           </nuxt-link>
         </NeoDropdownItem>
         <NeoDropdownItem>
-          <nuxt-link data-cy="offers-stats" :to="statsUrl">
+          <nuxt-link data-testid="offers-stats" :to="statsUrl">
             {{ $t('navbar.offerStats') }}
           </nuxt-link>
         </NeoDropdownItem>
         <NeoDropdownItem>
-          <nuxt-link data-cy="series-insight" to="/series-insight">
+          <nuxt-link data-testid="series-insight" to="/series-insight">
             Series</nuxt-link
           >
         </NeoDropdownItem>
       </NeoDropdown>
       <NeoDropdown
         v-if="chain === 'rmrk' || chain === 'ksm'"
-        data-cy="stats"
+        data-testid="stats"
         :triggers="['click']">
         <template #trigger>
-          <div class="navbar-item" data-cy="stats">
+          <div class="navbar-item" data-testid="stats">
             {{ $t('stats') }}
           </div>
         </template>
         <NeoDropdownItem aria-role="menu-item">
-          <nuxt-link data-cy="spotlight" to="/spotlight">
+          <nuxt-link data-testid="spotlight" to="/spotlight">
             {{ $t('spotlight.page') }}
           </nuxt-link>
         </NeoDropdownItem>
         <NeoDropdownItem>
-          <nuxt-link data-cy="series-insight" to="/series-insight">
+          <nuxt-link data-testid="series-insight" to="/series-insight">
             Series</nuxt-link
           >
         </NeoDropdownItem>
         <NeoDropdownItem>
-          <nuxt-link data-cy="sales" to="/sales"> Sales</nuxt-link>
+          <nuxt-link data-testid="sales" to="/sales"> Sales</nuxt-link>
         </NeoDropdownItem>
         <NeoDropdownItem>
-          <nuxt-link data-cy="hot" to="/hot"> Hot</nuxt-link>
+          <nuxt-link data-testid="hot" to="/hot"> Hot</nuxt-link>
         </NeoDropdownItem>
       </NeoDropdown>
     </div>
@@ -59,35 +59,41 @@
       <template>
         <template v-if="showSnekBsxOptions">
           <b-navbar-item
-            data-cy="global-offers"
+            data-testid="global-offers"
             :to="offersUrl"
             tag="nuxt-link">
             {{ $t('navbar.globalOffers') }}
           </b-navbar-item>
-          <b-navbar-item data-cy="offers-stats" :to="statsUrl" tag="nuxt-link">
+          <b-navbar-item
+            data-testid="offers-stats"
+            :to="statsUrl"
+            tag="nuxt-link">
             {{ $t('navbar.offerStats') }}
           </b-navbar-item>
           <b-navbar-item
-            data-cy="series-insight"
+            data-testid="series-insight"
             to="/series-insight"
             tag="nuxt-link">
             {{ $t('series.label') }}
           </b-navbar-item>
         </template>
         <template v-if="chain === 'rmrk' || chain === 'ksm'">
-          <b-navbar-item data-cy="spotlight" to="/spotlight" tag="nuxt-link">
+          <b-navbar-item
+            data-testid="spotlight"
+            to="/spotlight"
+            tag="nuxt-link">
             {{ $t('spotlight.page') }}
           </b-navbar-item>
           <b-navbar-item
-            data-cy="series-insight"
+            data-testid="series-insight"
             to="/series-insight"
             tag="nuxt-link">
             {{ $t('series.label') }}
           </b-navbar-item>
-          <b-navbar-item data-cy="sales" to="/sales" tag="nuxt-link">
+          <b-navbar-item data-testid="sales" to="/sales" tag="nuxt-link">
             {{ $t('sales.page') }}
           </b-navbar-item>
-          <b-navbar-item data-cy="hot" to="/hot" tag="nuxt-link">
+          <b-navbar-item data-testid="hot" to="/hot" tag="nuxt-link">
             {{ $t('hot.label') }}
           </b-navbar-item>
         </template>

--- a/components/profile/OrderByDropdown.vue
+++ b/components/profile/OrderByDropdown.vue
@@ -15,7 +15,7 @@
           type="button"
           :icon="active ? 'chevron-up' : 'chevron-down'"
           class="has-text-left"
-          data-cy="explore-sort">
+          data-testid="explore-sort">
           {{ $i18n.t('sort.collection.sortBy') }}
         </NeoButton>
 
@@ -27,7 +27,7 @@
         :key="option"
         aria-role="listitem"
         class="is-flex"
-        :data-cy="option"
+        :data-testid="option"
         :value="option">
         <span>
           {{

--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -16,7 +16,7 @@
           <div class="container image is-64x64 mb-2">
             <Avatar :value="id" />
           </div>
-          <h1 class="title is-2" data-cy="user-identity">
+          <h1 class="title is-2" data-testid="user-identity">
             <a
               v-if="hasBlockExplorer"
               v-safe-href="explorer"

--- a/components/rmrk/Create/SimpleMint.vue
+++ b/components/rmrk/Create/SimpleMint.vue
@@ -17,7 +17,7 @@
       :label="$t('mint.nft.drop')"
       expanded
       preview
-      data-cy="input-upload" />
+      data-testid="input-upload" />
 
     <BasicInput
       ref="nftNameInput"
@@ -28,7 +28,7 @@
       :placeholder="$t('mint.nft.name.placeholder')"
       expanded
       spellcheck="true"
-      data-cy="input-name"
+      data-testid="input-name"
       @blur.native.capture="generateSymbol" />
 
     <BasicInput
@@ -40,7 +40,7 @@
       :placeholder="$t('mint.collection.symbol.placeholder')"
       maxlength="10"
       expanded
-      data-cy="input-symbol"
+      data-testid="input-symbol"
       @keydown.native.space.prevent />
 
     <BasicInput
@@ -52,12 +52,12 @@
       :label="$t('mint.nft.description.label')"
       :message="$t('mint.nft.description.message')"
       :placeholder="$t('mint.nft.description.placeholder')"
-      data-cy="input-description" />
+      data-testid="input-description" />
 
     <NeoField
       :label="$t('mint.nft.edition.label')"
       class="mt-5"
-      data-cy="input-edition">
+      data-testid="input-edition">
       <NeoInput
         v-model="rmrkMint.max"
         type="number"
@@ -78,13 +78,13 @@
     <AttributeTagInput
       v-model="rmrkMint.tags"
       placeholder="Get discovered easier through tags"
-      data-cy="input-tags" />
+      data-testid="input-tags" />
 
     <BalanceInput
       :step="0.1"
       label="Price"
       expanded
-      data-cy="input-price"
+      data-testid="input-price"
       @input="updateMeta" />
 
     <div class="content mt-3">
@@ -98,8 +98,8 @@
         v-if="rmrkMint.max > 1"
         visible="mint.expert.show"
         hidden="mint.expert.hide"
-        data-cy="input-advance-settings">
-        <p class="title is-6" data-cy="input-valid-address">
+        data-testid="input-advance-settings">
+        <p class="title is-6" data-testid="input-valid-address">
           {{ $t('mint.expert.count', [parseAddresses.length]) }}
         </p>
         <p v-show="syncVisible" class="sub-title is-6 has-text-warning">
@@ -111,13 +111,13 @@
             type="textarea"
             :placeholder="'Distribute NFTs to multiple addresses like this:\n- HjshJ....3aJk\n- FswhJ....3aVC\n- HjW3J....9c3V'"
             spellcheck="true"
-            data-cy="input-batch-address" />
+            data-testid="input-batch-address" />
         </NeoField>
 
         <NeoField class="mt-4" :label="$t('action.distributionCount')">
           <NeoSlider
             v-model="distribution"
-            data-cy="input-distribution"
+            data-testid="input-distribution"
             :min="0"
             :max="100" />
         </NeoField>
@@ -133,16 +133,16 @@
         <BasicSwitch
           v-model="random"
           label="action.random"
-          data-cy="input-random" />
+          data-testid="input-random" />
         <BasicSwitch
           v-model="postfix"
           label="mint.expert.postfix"
-          data-cy="input-hashtag" />
+          data-testid="input-hashtag" />
       </CollapseWrapper>
     </NeoField>
-    <BasicSwitch v-model="nsfw" label="mint.nfsw" data-cy="input-nsfw" />
+    <BasicSwitch v-model="nsfw" label="mint.nfsw" data-testid="input-nsfw" />
     <NeoField variant="danger" :message="haveNoToSMessage">
-      <NeoSwitch v-model="hasToS" :rounded="false" data-cy="input-tos">
+      <NeoSwitch v-model="hasToS" :rounded="false" data-testid="input-tos">
         {{ $t('termOfService.accept') }}
       </NeoSwitch>
     </NeoField>
@@ -159,7 +159,7 @@
     <NeoField>
       <NeoIcon icon="calculator" />
       <span class="pr-2">{{ $t('mint.estimated') }}</span>
-      <BasicMoney :value="estimated" inline data-cy="fee" />
+      <BasicMoney :value="estimated" inline data-testid="fee" />
       <span class="pl-2"> ({{ getUsdFromKsm().toFixed(2) }} USD) </span>
     </NeoField>
   </section>

--- a/components/rmrk/Gallery/GalleryCardList.vue
+++ b/components/rmrk/Gallery/GalleryCardList.vue
@@ -18,7 +18,7 @@
           :emote-count="nft.emoteCount"
           :current-owner="nft.currentOwner"
           :listed="listed"
-          :data-cy="items.indexOf(nft)" />
+          :data-testid="items.indexOf(nft)" />
       </div>
     </div>
   </div>

--- a/components/rmrk/Gallery/Layout.vue
+++ b/components/rmrk/Gallery/Layout.vue
@@ -8,7 +8,7 @@
           class="collection-radio-btn"
           native-value="is-half-desktop is-half-tablet"
           :disabled="disabled"
-          data-cy="large-display">
+          data-testid="large-display">
           <span>
             <NeoIcon icon="th-large" />
           </span>
@@ -21,7 +21,7 @@
           class="collection-radio-btn"
           native-value="is-one-quarter-desktop is-one-third-tablet"
           :disabled="disabled"
-          data-cy="small-display">
+          data-testid="small-display">
           <span>
             <NeoIcon icon="th" />
           </span>

--- a/components/search/SearchPriceRange.vue
+++ b/components/search/SearchPriceRange.vue
@@ -8,7 +8,7 @@
         step="any"
         class="column is-2"
         :placeholder="$t('query.priceRange.minPrice')"
-        data-cy="input-min" />
+        data-testid="input-min" />
       <NeoInput
         v-model="vrange[1]"
         min="0"
@@ -16,12 +16,12 @@
         type="number"
         class="column is-2"
         :placeholder="$t('query.priceRange.maxPrice')"
-        data-cy="input-max" />
+        data-testid="input-max" />
       <div class="column is-1">
         <NeoButton
           variant="primary"
           :disabled="applyDisabled"
-          data-cy="apply"
+          data-testid="apply"
           @click.native="rangeChange">
           {{ $t('general.apply') }}
         </NeoButton>

--- a/components/search/SearchSortDropdown.vue
+++ b/components/search/SearchSortDropdown.vue
@@ -10,7 +10,7 @@
           type="primary"
           no-shadow
           icon-right="caret-down"
-          data-cy="gallery-sort-by">
+          data-testid="gallery-sort-by">
           {{ $t('sort.collection.sortBy') }}
         </NeoButton>
       </template>
@@ -18,7 +18,7 @@
         v-for="action in actions"
         :key="action"
         :value="action"
-        :data-cy="$t('sort.' + action)">
+        :data-testid="$t('sort.' + action)">
         {{ $t('sort.' + action) }}
       </NeoDropdownItem>
     </NeoDropdown>
@@ -27,7 +27,7 @@
       v-model="selectedAction"
       :placeholder="$t('sort.collection.sortBy')"
       class="select-dropdown"
-      data-cy="collection-sort-by">
+      data-testid="collection-sort-by">
       <option v-for="action in actions" :key="action" :value="action">
         {{
           isCollection ? $t('sort.collection.' + action) : $t('sort.' + action)

--- a/components/shared/CommonTokenMoney.vue
+++ b/components/shared/CommonTokenMoney.vue
@@ -4,10 +4,10 @@
     :value="value"
     :token-id="tokenId"
     :prefix="urlPrefix"
-    :data-cy="dataCy"
+    :data-testid="money"
     :round="round"
     inline />
-  <Money v-else :value="value" :data-cy="dataCy" inline :round="round" />
+  <Money v-else :value="value" :data-testid="money" inline :round="round" />
 </template>
 
 <script lang="ts" setup>

--- a/components/shared/filters/modules/PriceFilter.vue
+++ b/components/shared/filters/modules/PriceFilter.vue
@@ -25,7 +25,7 @@
           min="0"
           step="any"
           placeholder="MIN"
-          data-cy="input-min"
+          data-testid="input-min"
           @focus="toggleInputFocused"
           @blur="toggleInputFocused" />
         <div class="is-flex is-align-items-center">
@@ -47,7 +47,7 @@
           step="any"
           type="number"
           placeholder="MAX"
-          data-cy="input-max"
+          data-testid="input-max"
           @focus="toggleInputFocused"
           @blur="toggleInputFocused" />
       </div>
@@ -56,7 +56,7 @@
           {{ unit }}
         </div>
         <NeoButton
-          data-cy="apply"
+          data-testid="apply"
           :disabled="!isValidFilter(range.min, range.max)"
           no-shadow
           variant="k-accent"

--- a/components/shared/form/BasicSwitch.vue
+++ b/components/shared/form/BasicSwitch.vue
@@ -7,7 +7,7 @@
       :disabled="disabled"
       :class="labelColor"
       :type="type"
-      data-cy="buy-now">
+      data-testid="buy-now">
       <component :is="componentName" :label="message">
         {{ properLabel }}
       </component>

--- a/components/teleport/TeleportTabs.vue
+++ b/components/teleport/TeleportTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="teleport-tabs field has-addons is-flex" data-cy="tabs">
+  <div class="teleport-tabs field has-addons is-flex" data-testid="tabs">
     <p class="control">
       <NeoButton
         v-for="tab in tabs"

--- a/libs/ui/src/components/MediaItem/type/AudioMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/AudioMedia.vue
@@ -7,7 +7,7 @@
     played-line-color="rgba(0,0,0,0.74)"
     noplayed-line-color="#d32e79"
     playtime-font-color="rgba(0,0,0,0.74)"
-    data-cy="type-audio" />
+    data-testid="type-audio" />
 </template>
 
 <script lang="ts" setup>

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -9,7 +9,7 @@
       :src="src"
       class="is-block image-media__image"
       :alt="alt"
-      data-cy="type-image"
+      data-testid="type-image"
       @error="onError" />
   </figure>
 </template>

--- a/libs/ui/src/components/MediaItem/type/ModelMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ModelMedia.vue
@@ -9,7 +9,7 @@
       shadow-intensity="1"
       autoplay
       camera-controls
-      data-cy="type-3d" />
+      data-testid="type-3d" />
   </div>
 </template>
 

--- a/libs/ui/src/components/MediaItem/type/VideoMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/VideoMedia.vue
@@ -10,7 +10,7 @@
       muted
       :src="animationSrc || src"
       controlslist="nodownload"
-      data-cy="type-video"
+      data-testid="type-video"
       :title="alt" />
   </div>
 </template>

--- a/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
+++ b/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
@@ -30,7 +30,7 @@
         <div class="is-flex is-flex-direction-column">
           <span
             class="is-ellipsis has-text-weight-bold"
-            data-cy="nft-name"
+            data-testid="nft-name"
             :title="nft.name"
             >{{ nft.name || '--' }}</span
           >
@@ -64,7 +64,7 @@
           <CommonTokenMoney
             v-if="showPrice"
             :value="nft.price"
-            data-cy="card-money" />
+            data-testid="card-money" />
           <span
             v-if="variant !== 'minimal'"
             class="chain-name is-capitalized is-size-7"

--- a/pages/e2e-login.vue
+++ b/pages/e2e-login.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <p data-cy="mockAddress">{{ mockAddress }}</p>
+    <p data-testid="mockAddress">{{ mockAddress }}</p>
   </div>
 </template>
 

--- a/tests/e2e/language.spec.ts
+++ b/tests/e2e/language.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test'
+
+test('Check Language translations', async ({ page }) => {
+  await page.goto('/e2e-login')
+  await page.waitForTimeout(5000)
+  await expect(page.getByTestId('mockAddress')).toHaveText('true')
+  await page.goto('/')
+  //DE
+  await page.getByTestId('profileDropdown').click()
+  await page.getByTestId('sidebar-language').click()
+  await expect(page.getByRole('menu')).toBeVisible()
+  //await expect(page.getByTestId('skeleton-multiple-balances')).toHaveCount(0)
+  await page.getByTestId('sidebar-language-de').click()
+  await page.getByTestId('profileDropdown').click()
+  await expect(
+    page.getByTestId('create').filter({ has: page.getByText('Erstellen') })
+  ).toHaveCount(1)
+  await expect(
+    page
+      .getByTestId('latest-sales')
+      .filter({ has: page.getByText('Letzte Verkäufe') })
+  ).toHaveCount(1)
+  //FR
+  await page.getByTestId('profileDropdown').click()
+  await page.getByTestId('sidebar-language').click()
+  await expect(page.getByRole('menu')).toBeVisible()
+  await page.getByTestId('sidebar-language-fr').click()
+  await page.getByTestId('profileDropdown').click()
+  await expect(
+    page.getByTestId('create').filter({ has: page.getByText('Créer') })
+  ).toHaveCount(1)
+  await expect(
+    page
+      .getByTestId('latest-sales')
+      .filter({ has: page.getByText('Dernières ventes') })
+  ).toHaveCount(1)
+  //ES
+  await page.getByTestId('profileDropdown').click()
+  await page.getByTestId('sidebar-language').click()
+  await expect(page.getByRole('menu')).toBeVisible()
+  await page.getByTestId('sidebar-language-es').click()
+  await page.getByTestId('profileDropdown').click()
+  await expect(
+    page.getByTestId('create').filter({ has: page.getByText('Crear') })
+  ).toHaveCount(1)
+  await expect(
+    page
+      .getByTestId('latest-sales')
+      .filter({ has: page.getByText('Ventas más recientes') })
+  ).toHaveCount(1)
+})

--- a/tests/e2e/prefix.spec.ts
+++ b/tests/e2e/prefix.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test'
+
+test('Switch network', async ({ page }) => {
+  await page.goto('/')
+  await page.waitForLoadState()
+  //BSX
+  await page.getByTestId('chain-select').click()
+  await page.getByTestId('chain-dropdown-bsx').click()
+  await expect(page.getByTestId('chain')).toHaveText('bsx')
+  //AHP
+  await page.getByTestId('chain-select').click()
+  await page.getByTestId('chain-dropdown-ahp').click()
+  await expect(page.getByTestId('chain')).toHaveText('ahp')
+  //AHK
+  await page.getByTestId('chain-select').click()
+  await page.getByTestId('chain-dropdown-ahk').click()
+  await expect(page.getByTestId('chain')).toHaveText('ahk')
+  //RMRK2
+  await page.getByTestId('chain-select').click()
+  await page.getByTestId('chain-dropdown-ksm').click()
+  await expect(page.getByTestId('chain')).toHaveText('rmrk2')
+  //RMRK1
+  await page.getByTestId('chain-select').click()
+  await page.getByTestId('chain-dropdown-rmrk').click()
+  await expect(page.getByTestId('chain')).toHaveText('rmrk')
+})

--- a/tests/e2e/redirect.spec.ts
+++ b/tests/e2e/redirect.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test'
+
+test('Should redirect from rmrk2 prefix to ksm', async ({ page }) => {
+  await page.goto(
+    '/rmrk2/gallery/17842583-22708b368d163c8007-CITY-LOWER_ART_DISTRICT-00000006'
+  )
+  await page.waitForLoadState()
+  // expects redirection to occur
+  expect(await page.url()).toContain(
+    '/ksm/gallery/17842583-22708b368d163c8007-CITY-LOWER_ART_DISTRICT-00000006'
+  )
+
+  await page.goto('/rmrk2/explore/items?listed=true&sort=updatedAt_DESC')
+  expect(await page.url()).toContain(
+    '/ksm/explore/items?listed=true&sort=updatedAt_DESC'
+  )
+})


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

Convert some basic old cypress tests to playwright format.
i know code could be better, will refactor as i learn more.

Also changed all the data-cy to data-testid

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Related #7051 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?


## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91d2bd1</samp>

This pull request replaces the `data-cy` attributes with the `data-testid` attributes in various components and files. This is to improve the consistency and compatibility of the testing code, as the project uses Testing Library instead of Cypress for testing. The change affects the `components` folder, the `CONTRIBUTING.md` file, and the test files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 91d2bd1</samp>

> _We are the testid warriors, we fight for quality_
> _We don't need data-cy, we have consistency_
> _We follow the best practices, we use the testing library_
> _We are the testid warriors, we make the code more reliable_