### PR TITLE
fix: Make preview picture bigger

### DIFF
--- a/components/media/type/ImageMedia.vue
+++ b/components/media/type/ImageMedia.vue
@@ -17,6 +17,6 @@ defineProps<{
 
 <style scoped>
 figure > img.image-media__image {
-  object-fit: cover;
+  object-fit: contain;
 }
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7217
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="586" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/2929c2e9-9f0f-4841-984a-71ec9eb8ffbe">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb21e98</samp>

Changed the `object-fit` property of the image element in `ImageMedia.vue` to avoid cropping or distorting images. Improved the layout and responsiveness of the image media component.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eb21e98</samp>

> _Image media_
> _`object-fit` now `contain`_
> _No more cropping spring_
  