### PR TITLE
fix: Some NFT's floor price feature on mass-listing cart does not work 

### DIFF
--- a/components/collection/utils/useCollectionDetails.ts
+++ b/components/collection/utils/useCollectionDetails.ts
@@ -46,12 +46,15 @@ export const useCollectionDetails = ({ collectionId }) => {
         return highestOffer
       })
 
+      const listedNfts = data.value.stats.listed
+
       stats.value = {
-        listedCount: data.value.stats.listed.length,
+        listedCount: listedNfts.length,
         collectionLength: data.value.stats.base.length,
-        collectionFloorPrice: Math.min(
-          ...data.value.stats.listed.map((item) => parseInt(item.price))
-        ),
+        collectionFloorPrice:
+          listedNfts.length > 0
+            ? Math.min(...listedNfts.map((item) => parseInt(item.price)))
+            : undefined,
         uniqueOwners: uniqueOwnerCount,
         bestOffer: maxOffer.value,
         uniqueOwnersPercent: `${(

--- a/components/common/listingCart/ListingCartModal.vue
+++ b/components/common/listingCart/ListingCartModal.vue
@@ -42,6 +42,7 @@
             <NeoButton
               class="mr-2"
               label="-5%"
+              :disabled="setFloorPriceButtonDisabled"
               rounded
               no-shadow
               @click.native="
@@ -52,6 +53,7 @@
             <NeoButton
               class="mr-2"
               :label="$t('statsOverview.floorPrice')"
+              :disabled="setFloorPriceButtonDisabled"
               rounded
               no-shadow
               @click.native="
@@ -60,6 +62,7 @@
               " />
             <NeoButton
               label="+5%"
+              :disabled="setFloorPriceButtonDisabled"
               rounded
               no-shadow
               @click.native="
@@ -139,6 +142,13 @@ const priceUSD = computed(() =>
     totalNFTsPrice.value,
     Number(fiatStore.getCurrentTokenValue(prefixToToken[urlPrefix.value]))
   )
+)
+
+const setFloorPriceButtonDisabled = computed(
+  () =>
+    !listingCartStore.itemsInChain
+      .map((item) => item.collection.floor || 0)
+      .some(Boolean)
 )
 
 const totalNFTsPrice = computed(() =>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7223

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2023-09-09 at 16 33 28@2x](https://github.com/kodadot/nft-gallery/assets/44554284/c498a404-5006-4b71-bb14-076c10f15156)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b7ebe0</samp>

This pull request adds a feature to disable listing buttons for collections without a floor price, and fixes a bug in `useCollectionDetails` that caused an error for empty collections.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5b7ebe0</samp>

> _`useCollectionDetails`_
> _Fixes bug with empty list_
> _No error in fall_


