### PR TITLE
fix: Make it possible to preview 3D NFTS prior to minting 

### DIFF
--- a/components/shared/DropUpload.vue
+++ b/components/shared/DropUpload.vue
@@ -86,7 +86,7 @@ const fileSizeFailed = ref(false)
 const upload = ref()
 
 const mimeType = computed(() => {
-  if (file.value) {
+  if (file.value?.type) {
     return file.value.type
   }
   //workaround for model media in chrome


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

glb file had type `""`

- [x] Closes #7253

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 
![CleanShot 2023-09-13 at 15 07 59](https://github.com/kodadot/nft-gallery/assets/44554284/37156920-ef1a-4ebb-9136-51b69975b1a7)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61695bc</samp>

Fixed a potential error in `DropUpload.vue` by using optional chaining to access `file.value.type`. Improved the DropUpload component's usability and feedback.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 61695bc</samp>

> _DropUpload fixed_
> _`file.value`?.type checks_
> _Autumn bugs swept away_


