### PR TITLE
Fix graphql

### DIFF
--- a/components/bsx/Offer/MasterOfferTable.vue
+++ b/components/bsx/Offer/MasterOfferTable.vue
@@ -157,9 +157,10 @@ const fetchCreatedOffers = async () => {
     if (!skipUserOffer.value) {
       variables.id = destinationAddress.value || accountId.value
     }
-    const { data } = await useAsyncQuery(offerListUser, variables)
-    if (data?.offers?.length) {
-      createdOffers.value = data.offers
+    const { client } = usePrefix()
+    const { data } = await useAsyncQuery(offerListUser, client.value)
+    if (data.value?.offers?.length) {
+      createdOffers.value = data.value?.offers
       if (!skipUserOffer.value) {
         incomingOffers.value = []
       }

--- a/components/bsx/Offer/OfferStats.vue
+++ b/components/bsx/Offer/OfferStats.vue
@@ -33,7 +33,7 @@ const { pending } = useLazyAsyncData('data', async () => {
   try {
     const { data } = await useAsyncQuery(offerList, {})
 
-    offers.value = data.offers
+    offers.value = data.value?.offers
   } catch (e) {
     $consola.error(e)
   }

--- a/components/bsx/Offer/StatsOverview.vue
+++ b/components/bsx/Offer/StatsOverview.vue
@@ -66,8 +66,8 @@ watchEffect(() => {
     )
 
     statsResponse.value = data.value
-    offerStats.value = data.value.offerStats
-    keysObject.value = Object.keys(data.value).filter(
+    offerStats.value = data.value?.offerStats
+    keysObject.value = Object.keys(data.value as object).filter(
       (key) => key !== 'offerStats'
     )
   } catch (e) {

--- a/components/carousel/utils/useCarousel.ts
+++ b/components/carousel/utils/useCarousel.ts
@@ -17,9 +17,12 @@ export const useCarouselUrl = () => {
   }
 }
 
+const { client } = usePrefix()
+
 const popularCollectionsGraphql = {
   queryPrefix: 'subsquid',
   queryName: 'popularCollectionList',
+  clientName: client.value,
   variables: {
     orderDirection: 'ASC',
     limit: 10,

--- a/components/collection/drop/DropContainer.vue
+++ b/components/collection/drop/DropContainer.vue
@@ -207,6 +207,7 @@ const leftTime = computed(() => {
 
 const { data: collectionData, refetch: tryAgain } = useGraphql({
   queryName: 'dropCollectionById',
+  clientName: urlPrefix.value,
   variables: {
     id: collectionId,
     price: pricePerMint,

--- a/components/collection/voteDrop/DropContainer.vue
+++ b/components/collection/voteDrop/DropContainer.vue
@@ -209,8 +209,11 @@ const leftTime = computed(() => {
   return isFinish ? 'Finished' : `${hoursLeft}${minutesLeft}Left`
 })
 
+const { client } = usePrefix()
+
 const { data: collectionData, refetch } = useGraphql({
   queryName: 'dropCollectionById',
+  clientName: client.value,
   variables: {
     id: collectionId.value,
     account: accountId.value,

--- a/components/common/NotificationBox/useNotification.ts
+++ b/components/common/NotificationBox/useNotification.ts
@@ -42,8 +42,11 @@ export const useNotification = () => {
     return block.number.toNumber()
   }
 
+  const { client } = usePrefix()
+
   const { data: collectionData } = useGraphql({
     queryName: 'collectionByAccount',
+    clientName: client.value,
     variables: {
       account: accountId.value,
     },
@@ -54,6 +57,7 @@ export const useNotification = () => {
         ? 'chain-bsx'
         : 'subsquid',
     queryName: 'notificationsByAccount',
+    clientName: client.value,
     variables: {
       account: accountId.value,
     },

--- a/components/gallery/useGalleryItem.ts
+++ b/components/gallery/useGalleryItem.ts
@@ -64,9 +64,9 @@ export const useGalleryItem = async (nftId?: string): Promise<GalleryItem> => {
   const { urlPrefix, client } = usePrefix()
   const { prefix } = useQueryParams({
     queryPrefix: queryPath[urlPrefix.value],
-    clientName: '',
+    clientName: client.value,
   })
-  console.log(prefix)
+
   const query = await resolveQueryPath(prefix, 'nftById')
   // const { result: nftEntity, refetch } = useQuery(query.default, { id })
 

--- a/components/identity/utils/useIdentity.ts
+++ b/components/identity/utils/useIdentity.ts
@@ -19,8 +19,11 @@ export function useIdentitySoldData({ address }, collectionId?) {
     }
   }
 
+  const { client } = usePrefix()
+
   const { data } = useGraphql({
     queryName: 'nftListSold',
+    clientName: client.value,
     variables: {
       account: address,
       limit: 3,

--- a/components/profile/ProfileActivitySummery.vue
+++ b/components/profile/ProfileActivitySummery.vue
@@ -114,7 +114,7 @@ useLazyAsyncData('stats', async () => {
     clientId: client.value,
   })
 
-  if (!data) {
+  if (!data.value) {
     $consola.log('stats is null')
     return
   }

--- a/components/rmrk/Gallery/Holding.vue
+++ b/components/rmrk/Gallery/Holding.vue
@@ -29,7 +29,11 @@ const { refresh } = useLazyAsyncData('ownerEventsOfNft', async () => {
     const { data } = await useAsyncQuery(allNftSaleEventsByAccountId, {
       id: props.accountId,
     })
-    if (data && data.nftEntities && data.nftEntities.length) {
+    if (
+      data.value &&
+      data.value?.nftEntities &&
+      data.value?.nftEntities.length
+    ) {
       const events: NftHolderEvent[] = []
       data.nftEntities.forEach((item) => {
         const nftEvents = item.events.map((event: Interaction) => ({

--- a/components/rmrk/Gallery/UserGainHistory.vue
+++ b/components/rmrk/Gallery/UserGainHistory.vue
@@ -28,8 +28,8 @@ const { refresh } = useLazyAsyncData('ownerEventsOfNft', async () => {
       clientId: client.value,
     })
 
-    if (data && data.value.events && data.value.events.length) {
-      ownerEventsOfNft.value = sortedEventByDate(data.value.events, 'ASC')
+    if (data.value && data.value?.events && data.value?.events.length) {
+      ownerEventsOfNft.value = sortedEventByDate(data.value?.events, 'ASC')
     }
   } catch (e) {
     showNotification(`${e}`, notificationTypes.warn)

--- a/components/series/SeriesTable.vue
+++ b/components/series/SeriesTable.vue
@@ -360,7 +360,7 @@ const fetchCollectionEvents = async (ids: string[]) => {
         gte: lastmonthDate,
       },
     })
-    return data.value.events
+    return data.value?.events
   } catch (e) {
     $consola.error(e)
     return []

--- a/components/stmn/Create/CreateToken.vue
+++ b/components/stmn/Create/CreateToken.vue
@@ -122,8 +122,11 @@ const balanceNotEnoughMessage = computed(() => {
   return balanceNotEnough.value ? $i18n.t('tooltip.notEnoughBalance') : ''
 })
 
+const { client } = usePrefix()
+
 const { data: collectionsData, refetch: refetchCollections } = useGraphql({
   queryName: 'collectionForMint',
+  clientName: client.value,
   variables: { account: accountId.value },
 })
 

--- a/composables/transaction/mintCollection/useNewCollectionId.ts
+++ b/composables/transaction/mintCollection/useNewCollectionId.ts
@@ -5,9 +5,11 @@ import { unwrapSafe } from '@/utils/uniquery'
 export function useNewCollectionId() {
   const newCollectionId = ref<number>()
   const randomNumbers = getRandomValues(10).map(String)
+  const { client } = usePrefix()
 
   const { data, error, loading, refetch } = useGraphql({
     queryName: 'existingCollectionList',
+    clientName: client.value,
     variables: {
       ids: randomNumbers,
     },

--- a/composables/transaction/transactionBurn.ts
+++ b/composables/transaction/transactionBurn.ts
@@ -43,8 +43,10 @@ export function execBurnTx(item: ActionConsume, api, executeTransaction) {
       ''
     )
     const hasOffers = ref(false)
+    const { client } = usePrefix()
     const { data } = useGraphql({
       queryName: 'acceptableOfferListByNftId',
+      clientName: client.value,
       queryPrefix: 'chain-bsx',
       variables: {
         id: item.nftId,

--- a/composables/useIdentity.ts
+++ b/composables/useIdentity.ts
@@ -27,7 +27,7 @@ export default function useIdentity({
   )
 
   const { data, refetch, loading } = useGraphql({
-    clientName: computed(() => (isDotAddress.value ? 'pid' : 'kid')),
+    clientName: computed(() => (isDotAddress.value ? 'pid' : 'kid')).value,
     queryName: 'identityById',
     variables: {
       id: id.value,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring

## Context

- [X] Related to #7225
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried to respect high code quality standards
- [X] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [X] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?usdamount=20&target=12ZLwasAvpdxDiiMedr11VeKUyQkY3WfneMkswBCAHVvxAqe)

#### Community participation

- [ ] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5776ac9</samp>

Refactored several components and composables to use a common `usePrefix` function to get the `clientName` parameter for GraphQL queries based on the URL prefix. This improves code consistency and readability, and makes the `clientName` parameter reactive. Wrapped some `data` properties in `value` properties and added optional chaining to make them reactive and avoid errors.
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5776ac9</samp>

> _Oh we're the coders of the sea, and we love to refactor_
> _We use the `usePrefix` function to make our code much neater_
> _We wrap our `data` in a `value` and we pass the `clientName`_
> _And we heave away, me hearties, on the count of three_
