### PR TITLE
fix: Display normal ksm unit

### DIFF
--- a/components/common/listingCart/multipleItemsCart/ListingCartItem.vue
+++ b/components/common/listingCart/multipleItemsCart/ListingCartItem.vue
@@ -34,7 +34,7 @@
 import ListingCartPriceInput from '../shared/ListingCartPriceInput.vue'
 import { NeoButton } from '@kodadot1/brick'
 import { ListCartItem, useListingCartStore } from '@/stores/listingCart'
-import { formatBalance } from '@polkadot/util'
+import formatBalance from '@/utils/format/balance'
 import ListingCartItemDetails from '../shared/ListingCartItemDetails.vue'
 const { decimals, chainSymbol } = useChain()
 
@@ -45,9 +45,6 @@ const props = defineProps<{
 }>()
 
 const floor = computed(() =>
-  formatBalance(props.nft.collection.floor, {
-    decimals: decimals.value,
-    withUnit: chainSymbol.value,
-  })
+  formatBalance(props.nft.collection.floor, decimals.value, chainSymbol.value)
 )
 </script>

--- a/components/common/listingCart/singleItemCart/ListingCartSingleItemCart.vue
+++ b/components/common/listingCart/singleItemCart/ListingCartSingleItemCart.vue
@@ -37,7 +37,7 @@ import { useListingCartStore } from '@/stores/listingCart'
 import ListingCartItemDetails from '../shared/ListingCartItemDetails.vue'
 import ListingCartFloorPrice from '../shared/ListingCartFloorPrice.vue'
 import ListingCartPriceInput from '../shared/ListingCartPriceInput.vue'
-import { formatBalance } from '@polkadot/util'
+import formatBalance from '@/utils/format/balance'
 
 const emit = defineEmits([
   'update:fixedPrice',
@@ -73,12 +73,7 @@ const collectionPrice = computed(() =>
 )
 
 const formatWithBlank = (value: number) => {
-  return value
-    ? formatBalance(value, {
-        decimals: decimals.value,
-        withUnit: chainSymbol.value,
-      })
-    : '--'
+  return value ? formatBalance(value, decimals.value, chainSymbol.value) : '--'
 }
 
 watch(


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  
  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7320

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6795296</samp>

This pull request refactors the code for formatting balances in the listing cart components to use a custom `formatBalance` function from a new `@/utils/format/balance` module. This reduces code duplication and improves readability and consistency.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6795296</samp>

> _`formatBalance` wraps_
> _simplifying and unifying_
> _code for balances_
  