### PR TITLE
fix: Scroll inside mass list modal

### DIFF
--- a/components/common/listingCart/ListingCartModal.vue
+++ b/components/common/listingCart/ListingCartModal.vue
@@ -19,7 +19,7 @@
             @click.native="onClose" />
         </header>
 
-        <div class="px-6 pt-4">
+        <div class="px-6 pt-4 limit-height">
           <ModalIdentityItem />
 
           <ListingCartSingleItemCart
@@ -213,6 +213,11 @@ onUnmounted(() => {
 
 .rounded {
   border-radius: 10rem;
+}
+
+.limit-height {
+  max-height: 50vh;
+  overflow-y: auto;
 }
 
 .modal-width {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7324
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="451" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1fb48366-8d4e-45a9-a160-2ff5f381b10a">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 286630a</samp>

Added scrolling to listing cart modal to improve responsiveness. Applied a CSS class to `ListingCartModal.vue` to limit the height of the modal content.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 286630a</samp>

> _`limit-height` class_
> _scrolls modal in small screens_
> _autumn leaves falling_
  