### PR TITLE
🔧 clear listing store when minicart is unmounted

### DIFF
--- a/components/common/listingCart/ListingCartMini.vue
+++ b/components/common/listingCart/ListingCartMini.vue
@@ -40,6 +40,10 @@ import { useListingCartStore } from '@/stores/listingCart'
 import { usePreferencesStore } from '@/stores/preferences'
 const listingCartStore = useListingCartStore()
 const preferencesStore = usePreferencesStore()
+
+onBeforeUnmount(() => {
+  listingCartStore.clear()
+})
 </script>
 <style scoped lang="scss">
 .listing-container {

--- a/stores/listingCart.ts
+++ b/stores/listingCart.ts
@@ -84,9 +84,9 @@ export const useListingCartStore = defineStore('listingCart', {
       }
     },
     clear() {
-      this.itemsInChain.forEach((item) => {
-        this.removeItem(item.id)
-      })
+      localStorage.value = []
+      this.items = []
+      this.allUnlistedItems = []
     },
   },
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #7323
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a3a9eb</samp>

Added a hook to `ListingCartMini.vue` to clear the listing cart store on unmount. This fixes a bug where the cart items would remain after navigating away or reloading the page.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a3a9eb</samp>

> _`listing cart` clears_
> _before component leaves view_
> _a fresh start in spring_
