### PR TITLE
🔧 k-grey background

### DIFF
--- a/components/common/listingCart/ListingCartMini.vue
+++ b/components/common/listingCart/ListingCartMini.vue
@@ -17,7 +17,7 @@
               @click.native="listingCartStore.clear">
               {{ $t('sort.clearAll') }}
             </NeoButton>
-            <div class="mx-4 divider k-grey" />
+            <div class="mx-4 divider has-background-k-grey" />
             <NeoButton
               variant="text"
               class="has-text-grey selection-button"

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -423,7 +423,7 @@ a.has-text-grey {
   }
 }
 
-.k-grey {
+.has-background-k-grey {
   @include ktheme() {
     background-color: theme('k-grey');
   }


### PR DESCRIPTION
- closes #7353 

![Screenshot 2023-09-25 at 08-24-19 Berliner KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/d8841c27-a54f-4e1f-ab3d-50a58a4ba513)
![Screenshot 2023-09-25 at 08-24-07 NFT Artist Profile on KodaDot KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/a3616de4-dc54-4390-98f7-0e2c3229fd04)
