### PR TITLE
fix: Transfer URI link w/ usd amount after address

### DIFF
--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -798,12 +798,14 @@ const generateRecurringPaymentLink = () => {
 
 const generatePaymentLink = (addressList: string[]): string => {
   const url = new URL(`${location.origin}${location.pathname}`)
-
-  url.searchParams.set('usdamount', String(targetAddresses.value[0]?.usd || 0))
-
   addressList.forEach((addr, i) => {
     url.searchParams.append(`target${i == 0 ? '' : i}`, addr)
   })
+  url.searchParams.append(
+    'usdamount',
+    String(targetAddresses.value[0]?.usd || 0)
+  )
+
   return url.toString()
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7356
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a6b5fe</samp>

Fixed a bug in the payment link generation by changing the order of the url search parameters in `Transfer.vue`. This prevents the `usdamount` parameter from being confused with the `target` address.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a6b5fe</samp>

> _`usdamount` last_
> _avoids conflicts with target_
> _a winter bug fixed_
  