### PR TITLE
fix: preview item for nuxt3

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -19,7 +19,7 @@
               !hasAnimatedResources
             "
             class="fullscreen-button is-justify-content-center is-align-items-center"
-            @click="isFullscreen = true">
+            @click="toggleFullscreen()">
             <NeoIcon icon="expand" />
           </a>
 
@@ -153,9 +153,8 @@
     <CarouselTypeVisited class="mt-8" />
 
     <GalleryItemPreviewer
-      v-model="isFullscreen"
-      :item-src="previewItemSrc"
-      :gallery-item="galleryItem" />
+      :fullscreen="isFullscreen"
+      :toggle-fullscreen="toggleFullscreen" />
   </section>
 </template>
 
@@ -197,6 +196,10 @@ const preferencesStore = usePreferencesStore()
 const galleryItem = useGalleryItem()
 const { nft, nftMetadata, nftImage, nftAnimation, nftMimeType, nftResources } =
   galleryItem
+provide('nft', readonly(nft))
+provide('nftMimeType', readonly(nftMimeType))
+provide('nftAnimation', readonly(nftAnimation))
+
 const collection = computed(() => nft.value?.collection)
 
 const triggerBuySuccess = computed(() => preferencesStore.triggerBuySuccess)
@@ -213,6 +216,9 @@ const activeTab = ref(tabs.offers)
 const showCongratsMessage = ref(false)
 
 const isFullscreen = ref(false)
+const toggleFullscreen = () => {
+  isFullscreen.value = !isFullscreen.value
+}
 const canPreview = computed(() =>
   [MediaType.VIDEO, MediaType.IMAGE, MediaType.OBJECT].includes(
     resolveMedia(nftMimeType.value)
@@ -239,6 +245,7 @@ const previewItemSrc = computed(() => {
     (hasResources.value && activeCarouselImage.value) || nftImage.value
   return baseUrl ? toOriginalContentUrl(baseUrl) : baseUrl
 })
+provide('previewItemSrc', readonly(previewItemSrc))
 
 const onNFTBought = () => {
   activeTab.value = tabs.activity

--- a/components/gallery/GalleryItemPreviewer.vue
+++ b/components/gallery/GalleryItemPreviewer.vue
@@ -1,13 +1,12 @@
 <template>
-  <NeoModal
-    v-model="isFullscreen"
+  <NeoModalExtend
+    :active="fullscreen"
     :destroy-on-hide="false"
     :can-cancel="false"
     full-screen
-    root-class="gallery-item-modal"
-    content-class="gallery-item-modal-content"
-    @close="isFullscreen = false">
-    <NeoButton class="back-button" @click.native="emit('input', false)">
+    root-class="neo-modal gallery-item-modal"
+    content-class="gallery-item-modal-content">
+    <NeoButton class="back-button" @click.native="toggleFullscreen()">
       <NeoIcon icon="chevron-left" />
       {{ $t('go back') }}
     </NeoButton>
@@ -15,34 +14,30 @@
     <div class="gallery-item-modal-container">
       <MediaItem
         class="gallery-item-media"
-        :src="itemSrc"
+        :src="previewItemSrc"
         :placeholder="placeholder"
         :animation-src="nftAnimation"
         :mime-type="nftMimeType"
         :title="nft?.name || nft?.id"
         original />
     </div>
-  </NeoModal>
+  </NeoModalExtend>
 </template>
 
 <script setup lang="ts">
-import { useVModel } from '@vueuse/core'
-import { MediaItem, NeoButton, NeoIcon, NeoModal } from '@kodadot1/brick'
-import { GalleryItem } from './useGalleryItem'
+import type { NFT } from '@/components/rmrk/service/scheme'
+import { MediaItem, NeoButton, NeoIcon, NeoModalExtend } from '@kodadot1/brick'
 const { placeholder } = useTheme()
 
-const props = defineProps<{
-  value: boolean
-  itemSrc: string
-  galleryItem: GalleryItem
+defineProps<{
+  fullscreen: boolean
+  toggleFullscreen: () => void
 }>()
 
-const nft = computed(() => props.galleryItem.nft.value)
-const nftMimeType = computed(() => props.galleryItem.nftMimeType.value)
-const nftAnimation = computed(() => props.galleryItem.nftAnimation.value)
-
-const emit = defineEmits(['input'])
-const isFullscreen = useVModel(props, 'value', emit)
+const nft = inject<NFT>('nft')
+const nftMimeType = inject<string>('nftMimeType')
+const nftAnimation = inject<string>('nftAnimation')
+const previewItemSrc = inject<string>('previewItemSrc')
 </script>
 
 <style lang="scss" scoped>
@@ -51,11 +46,12 @@ const isFullscreen = useVModel(props, 'value', emit)
 .gallery-item-modal {
   position: fixed;
 
-  :deep(&-content) {
+  :deep(.gallery-item-modal-content) {
     height: calc(100% - $navbar-desktop-min-height + 1px) !important;
     margin-top: calc($navbar-desktop-min-height - 1px) !important;
-    border: none !important;
     width: 100%;
+    max-height: 80vh;
+
     @include mobile {
       height: calc(100% - $navbar-mobile-min-height + 1px) !important;
       margin-top: calc($navbar-mobile-min-height - 1px) !important;
@@ -71,6 +67,7 @@ const isFullscreen = useVModel(props, 'value', emit)
       left: $fluid-container-padding;
     }
   }
+
   &-container {
     @include ktheme() {
       background-color: theme('background-color');


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Currently preview media not works on nuxt3. this is an attempt to fix that

![Screenshot 2023-09-25 200239](https://github.com/kodadot/nft-gallery/assets/734428/03668575-da07-4820-ac4d-04073ec8e749)


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a9d265</samp>

Refactored `GalleryItem` and `GalleryItemPreviewer` components to enhance fullscreen mode and code quality. Used `provide` function and `NeoModalExtend` component from external library. Improved media item and modal appearance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a9d265</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who reshaped the `GalleryItem` component_
> _And made it more reusable and readable_
> _With `provide` function and props as helpers._
