### PR TITLE
fix: mass mint persistent while chain changed

### DIFF
--- a/components/navbar/ChainSelectDropdown.vue
+++ b/components/navbar/ChainSelectDropdown.vue
@@ -24,17 +24,20 @@
 <script lang="ts" setup>
 import { NeoDropdown, NeoDropdownItem } from '@kodadot1/brick'
 import { usePreferencesStore } from '@/stores/preferences'
+import { useListingCartStore } from '@/stores/listingCart'
 import { getChainNameByPrefix } from '@/utils/chain'
 
 const { availableChains } = useChain()
 const { redirectAfterChainChange } = useChainRedirect()
 const { urlPrefix, setUrlPrefix } = usePrefix()
 const prefrencesStore = usePreferencesStore()
+const listingCartStore = useListingCartStore()
 
 const selected = computed({
   get: () => urlPrefix.value,
   set: (newChain) => {
     prefrencesStore.setNotificationBoxCollapse(false)
+    listingCartStore.clear()
     setUrlPrefix(newChain)
     redirectAfterChainChange(newChain)
   },


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).


👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7346 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


## Copilot Summary


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95f7170</samp>

Clear listing cart when switching chains in `ChainSelectDropdown.vue`. This avoids invalid listings and enhances UX.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 95f7170</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to clear the `listingCart` of old_
> _And incompatible chains, when the user switched_
> _To a different network, avoiding errors bold._


