### PR TITLE
feat: Add ToS checkbox to add funds modal

### DIFF
--- a/components/shared/OnRampModal.vue
+++ b/components/shared/OnRampModal.vue
@@ -16,11 +16,26 @@
           @click.native="onClose" />
       </div>
       <div class="px-6 py-3">
+        <div class="mb-4 is-flex">
+          <NeoCheckbox
+            v-model="agreeTos"
+            class="is-align-self-flex-start pt-1" />
+          <div>
+            {{ $t('fiatOnRamp.agree') }}
+            <a
+              href="/terms-of-use"
+              target="_blank"
+              rel="nofollow noopener noreferrer"
+              class="has-text-link"
+              >{{ $t('fiatOnRamp.tos') }}</a
+            >
+          </div>
+        </div>
         <div v-for="(provider, index) in providers" :key="provider.value">
           <div
             class="provider is-clickable is-flex is-justify-content-center is-align-items-start is-flex-direction-column my-4"
             :class="{
-              provider__disabled: provider.disabled,
+              provider__disabled: provider.disabled || !agreeTos,
             }"
             @click="onSelect(provider.value)">
             <div class="is-flex is-justify-content-center">
@@ -53,7 +68,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoModal } from '@kodadot1/brick'
+import { NeoButton, NeoCheckbox, NeoModal } from '@kodadot1/brick'
 import { showNotification } from '@/utils/notification'
 
 enum Provider {
@@ -71,6 +86,7 @@ const { accountId } = useAuth()
 const { $i18n } = useNuxtApp()
 
 const isModalActive = useVModel(props, 'value')
+const agreeTos = ref<boolean>(false)
 
 const { init: initTransak } = useTransak()
 const { isDarkMode } = useTheme()
@@ -112,7 +128,7 @@ const onClose = () => {
 const onSelect = (provider: Provider) => {
   const selectedProvider = providers.value.find((p) => p.value === provider)
 
-  if (selectedProvider?.disabled) {
+  if (selectedProvider?.disabled || !agreeTos.value) {
     return
   }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -890,6 +890,10 @@
     "supports": "Supports",
     "chooseProvider": "Choose A Provider"
   },
+  "fiatOnRamp": {
+    "agree": "I agree to the",
+    "tos": "KodaDot's Terms and Conditions"
+  },
   "helper": {
     "seeMore": "See More",
     "learnMore": "Learn More",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7370
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="426" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/4cc57f51-fd61-403e-b38c-c59f54f79d10">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce9c617</samp>

This pull request enhances the user experience and compliance of the fiat on-ramp feature by adding a checkbox and a link to the terms and conditions of KodaDot in the `OnRampModal.vue` component and the corresponding localization strings in the `en.json` file.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ce9c617</samp>

> _Oh we are the coders of KodaDot_
> _We make the `OnRampModal.vue` look hot_
> _We add a checkbox and a link with a lot_
> _Of localization strings that we've got_
  