### PR TITLE
chore: fix warning on money and dropdown

### DIFF
--- a/components/bsx/format/TokenMoney.vue
+++ b/components/bsx/format/TokenMoney.vue
@@ -1,8 +1,6 @@
 <template>
   <BasicMoney
     :value="value"
-    :unit="unit"
-    :decimals="decimals"
     :inline="inline"
     :hide-unit="hideUnit"
     :round="round" />
@@ -10,26 +8,17 @@
 
 <script lang="ts" setup>
 import BasicMoney from '@/components/shared/format/BasicMoney.vue'
-import { useAssetsStore } from '@/stores/assets'
 
-const assetsStore = useAssetsStore()
-const assetIdOf = (id: string | number) => assetsStore.getAssetById(String(id))
-const props = withDefaults(
+withDefaults(
   defineProps<{
     value: number | string | undefined
-    tokenId: string
     inline: boolean
     hideUnit?: boolean
     round?: number
   }>(),
   {
     value: '0',
-    tokenId: '5',
     round: 4,
   }
 )
-
-const asset = computed(() => assetIdOf(props.tokenId))
-const unit = computed(() => asset.symbol)
-const decimals = computed(() => asset.decimals)
 </script>

--- a/components/shared/CommonTokenMoney.vue
+++ b/components/shared/CommonTokenMoney.vue
@@ -2,7 +2,6 @@
   <TokenMoney
     v-if="tokenId"
     :value="value"
-    :token-id="tokenId"
     :data-testid="dataCy"
     :round="round"
     inline />

--- a/components/shared/CommonTokenMoney.vue
+++ b/components/shared/CommonTokenMoney.vue
@@ -3,17 +3,15 @@
     v-if="tokenId"
     :value="value"
     :token-id="tokenId"
-    :prefix="urlPrefix"
-    data-testid="money"
+    :data-testid="dataCy"
     :round="round"
     inline />
-  <Money v-else :value="value" data-testid="money" inline :round="round" />
+  <Money v-else :value="value" :data-testid="dataCy" inline :round="round" />
 </template>
 
 <script lang="ts" setup>
 import Money from '@/components/shared/format/Money.vue'
 import TokenMoney from '@/components/bsx/format/TokenMoney.vue'
-import { getKusamaAssetId } from '@/utils/api/bsx/query'
 
 defineProps({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -33,6 +31,5 @@ defineProps({
   },
 })
 
-const { urlPrefix } = usePrefix()
-const tokenId = computed(() => getKusamaAssetId(urlPrefix.value))
+const { tokenId } = usePrefix()
 </script>

--- a/components/shared/CommonTokenMoney.vue
+++ b/components/shared/CommonTokenMoney.vue
@@ -4,10 +4,10 @@
     :value="value"
     :token-id="tokenId"
     :prefix="urlPrefix"
-    :data-testid="money"
+    data-testid="money"
     :round="round"
     inline />
-  <Money v-else :value="value" :data-testid="money" inline :round="round" />
+  <Money v-else :value="value" data-testid="money" inline :round="round" />
 </template>
 
 <script lang="ts" setup>

--- a/components/shared/format/Money.vue
+++ b/components/shared/format/Money.vue
@@ -17,24 +17,35 @@ import {
   roundTo,
 } from '@/utils/format/balance'
 import { chainPropListOf } from '@/utils/config/chain.config'
-import type { Prefix } from '@kodadot1/static'
 
-const props = withDefaults(
-  defineProps<{
-    value?: number | string
-    inline: boolean
-    hideUnit?: boolean
-    unitSymbol?: string
-    prefix?: Prefix
-    round?: number
-  }>(),
-  {
-    value: 0,
-    round: 4,
-    unitSymbol: '',
-    prefix: undefined,
-  }
-)
+const props = defineProps({
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  value: {
+    type: [Number, String, BigInt],
+    default: '0',
+  },
+  inline: {
+    type: Boolean,
+    default: false,
+  },
+  hideUnit: {
+    type: Boolean,
+    default: false,
+  },
+  unitSymbol: {
+    type: String,
+    default: '',
+  },
+  prefix: {
+    type: String,
+    default: undefined,
+  },
+  round: {
+    type: Number,
+    default: 4,
+  },
+})
 
 const { decimals, unit } = useChain()
 

--- a/libs/ui/src/components/NeoDropdown/NeoDropdown.vue
+++ b/libs/ui/src/components/NeoDropdown/NeoDropdown.vue
@@ -8,6 +8,21 @@ export default {
       type: Boolean,
       default: false,
     },
+    // eslint-disable-next-line vue/require-default-prop
+    position: {
+      type: String,
+      validator(value) {
+        return (
+          [
+            'top-right',
+            'top-left',
+            'bottom-left',
+            'bottom-right',
+            'bottom-auto',
+          ].indexOf(value) > -1
+        )
+      },
+    },
   },
   data() {
     return {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] chore: fix warning on money and dropdown

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d220f1</samp>

Removed unnecessary attributes from `CommonTokenMoney.vue`, refactored props definition in `Money.vue`, and added `position` prop to `NeoDropdown.vue`. These changes improve the code quality, fix TypeScript errors, and enhance the UI flexibility of the components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9d220f1</samp>

> _`data-testid` gone_
> _`props` and `position` changed_
> _Autumn of refactor_