### PR TITLE
fix: Error on stick indexer on explorer items with ticked collection

### DIFF
--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -284,6 +284,10 @@ const props = defineProps({
       return {} as SearchQuery
     },
   },
+  showDefaultSuggestions: {
+    type: Boolean,
+    required: false,
+  },
 })
 
 const query = toRef(props, 'query', {})
@@ -301,7 +305,6 @@ const nftResult = ref([] as NFTWithMeta[])
 const collectionResult = ref([] as CollectionWithMeta[])
 const searched = ref([] as NFTWithMeta[])
 const searchString = ref('')
-const showDefaultSuggestions = ref(true)
 
 onMounted(async () => {
   getSearchHistory()
@@ -519,7 +522,7 @@ const goToExploreResults = (item) => {
 }
 
 const fetchSuggestions = async () => {
-  if (showDefaultSuggestions.value) {
+  if (props.showDefaultSuggestions) {
     try {
       const result = await $apollo.query({
         query: seriesInsightList,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7379
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57a67dd</samp>

Refactored `SearchSuggestion` component to use a prop for default suggestions. This improves the component's reusability and responsiveness.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 57a67dd</samp>

> _There once was a component `SearchSuggestion`_
> _That used a local variable for default completion_
> _But to make it more flexible_
> _And parent state reflexible_
> _It switched to a prop for better adaptation_
  