### PR TITLE
fix: incorrect token symbol in search suggestion

### DIFF
--- a/components/rmrk/service/scheme.ts
+++ b/components/rmrk/service/scheme.ts
@@ -6,6 +6,7 @@ import {
 import { sanitizeIpfsUrl } from '@/utils/ipfs'
 import { ItemResources } from '@/composables/useNft'
 import { Attribute } from '@kodadot1/minimark/common'
+import type { Prefix } from '@kodadot1/static'
 
 export interface CompletePack extends BasePack {
   collections: Collection[]
@@ -61,7 +62,7 @@ export interface Metadata {
   type?: string
   thumbnailUri?: string
   mediaUri?: string
-  chain?: string
+  chain?: Prefix
 }
 
 export interface NFTMetadata extends Metadata, ItemResources {

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -54,7 +54,7 @@
                     <Money
                       v-else
                       :value="item.floorPrice"
-                      :unit-symbol="chainSymbol"
+                      :prefix="item.chain"
                       inline />
                   </span>
                   <NeoSkeleton
@@ -128,10 +128,7 @@
                   <span class="name">{{ item.collection?.name }}</span>
                   <span v-if="item.price && parseFloat(item.price) > 0">
                     {{ $t('offer.price') }}:
-                    <Money
-                      :value="item.price"
-                      :unit-symbol="chainSymbol"
-                      inline />
+                    <Money :value="item.price" :prefix="item.chain" inline />
                   </span>
                 </div>
               </template>
@@ -366,7 +363,6 @@ const selectedItemListMap = computed(() => ({
   NFTs: nftSuggestion,
 }))
 
-const { chainSymbol } = useChain()
 const router = useRouter()
 const route = useRoute()
 const { $consola, $apollo } = useNuxtApp()

--- a/components/shared/format/Money.vue
+++ b/components/shared/format/Money.vue
@@ -41,7 +41,11 @@ const { decimals, unit } = useChain()
 const tokenDecimals = computed(() =>
   props.prefix ? chainPropListOf(props.prefix).tokenDecimals : decimals.value
 )
-const displayUnit = computed(() => props.unitSymbol || unit.value)
+const displayUnit = computed(() =>
+  props.unitSymbol || props.prefix
+    ? chainPropListOf(props.prefix).tokenSymbol
+    : unit.value
+)
 const finalValue = computed(() =>
   round(
     formatBalance(


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7387
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/4ea67b4c-1636-4d4e-8baf-635d4588a4f6)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e2fb01</samp>

The pull request enhances the metadata scheme and the money formatting for different chains by using the `Prefix` type and the `prefix` prop. It affects the files `scheme.ts`, `SearchSuggestion.vue`, and `Money.vue`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1e2fb01</samp>

> _To display money with flair_
> _We updated the `displayUnit` there_
> _We used the `prefix` prop_
> _And the `Prefix` type we got_
> _From a module that we import with care_
  