### PR TITLE
fix: download

### DIFF
--- a/utils/download.ts
+++ b/utils/download.ts
@@ -5,25 +5,23 @@ export const downloadImage = async (imageSrc: string, name = 'unnamed') => {
 
   const { $consola } = useNuxtApp()
 
-  let resp
   try {
-    resp = await useFetch(imageSrc)
+    const { data } = await useFetch(imageSrc)
+    const image = data.value
+
+    if (!(image instanceof Blob)) {
+      return
+    }
+
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(image)
+    link.download = name
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    return link
   } catch (error) {
     $consola.warn('[ERR] unable to fetch image')
     return
   }
-
-  const image = resp.data.value
-  if (!(image instanceof Blob)) {
-    return
-  }
-  const imageURL = URL.createObjectURL(image)
-
-  const link = document.createElement('a')
-  link.href = imageURL
-  link.download = name
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  return link
 }

--- a/utils/download.ts
+++ b/utils/download.ts
@@ -2,9 +2,22 @@ export const downloadImage = async (imageSrc: string, name = 'unnamed') => {
   if (!imageSrc) {
     return
   }
-  const image = await fetch(imageSrc)
-  const imageBlog = await image.blob()
-  const imageURL = URL.createObjectURL(imageBlog)
+
+  const { $consola } = useNuxtApp()
+
+  let resp
+  try {
+    resp = await useFetch(imageSrc)
+  } catch (error) {
+    $consola.warn('[ERR] unable to fetch image')
+    return
+  }
+
+  const image = resp.data.value
+  if (!(image instanceof Blob)) {
+    return
+  }
+  const imageURL = URL.createObjectURL(image)
 
   const link = document.createElement('a')
   link.href = imageURL


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [X] Related to #7375
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried to respect high code quality standards
- [X] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [X] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=12ZLwasAvpdxDiiMedr11VeKUyQkY3WfneMkswBCAHVvxAqe)

#### Community participation

- [ ] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58e9055</samp>

Refactored `downloadImage` function to use `useFetch` composable and validate response data. Improved error handling and code consistency in `utils/download.ts`.
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 58e9055</samp>

> _`useFetch` instead_
> _refines `downloadImage`_
> _autumn of errors_