### PR TITLE
fix: auto imports broken

### DIFF
--- a/components/landing/LandingPage.vue
+++ b/components/landing/LandingPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <section class="py-8 instance section-search">
-      <LazyLandingSearchLanding />
+      <LazySearchLanding />
     </section>
 
     <template v-if="showCarousel">
@@ -15,7 +15,7 @@
       <!-- top collections -->
       <section v-if="showTopCollections" class="py-8 instance">
         <div class="container is-fluid">
-          <LazyLandingTopCollections class="my-5" />
+          <LazyTopCollections class="my-5" />
         </div>
       </section>
 
@@ -32,7 +32,7 @@
 
     <section class="py-8 instance instance-accent">
       <div class="container is-fluid footer-landing-container">
-        <LazyLandingFeaturedArticles />
+        <LazyFeaturedArticles />
       </div>
     </section>
   </div>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -180,54 +180,52 @@ export default defineNuxtConfig({
   },
 
   // Auto import components: https://go.nuxtjs.dev/config-components
-  components: {
-    dirs: [
-      {
-        path: '~/components',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/common',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/landing',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/metadata',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/rmrk',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/series',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/settings',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/shared',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/spotlight',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/transfer',
-        extensions: ['vue'],
-      },
-      {
-        path: '~/components/unique',
-        extensions: ['vue'],
-      },
-    ],
-  },
+  components: [
+    {
+      path: '~/components/common',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/landing',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/metadata',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/rmrk',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/series',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/settings',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/shared',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/spotlight',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/transfer',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components/unique',
+      extensions: ['vue'],
+    },
+    {
+      path: '~/components',
+      extensions: ['vue'],
+    },
+  ],
 
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: [


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Bugfix #7375 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

## Comments
- Leaving in draft to test on deploy-preview for side effects as I'm not sure about this yet.

- Some components are not being auto-import from the nuxt config settings. I cannot find any reference to the `components.dirs` property being used in such a way with Nuxt 3 or if this was just passed on from Nuxt2 and now is broken?

Should fix:
- QrCode, NoResults, Settings/Metadata, etc... and other components that were not manually imported, however there are still bugs in some of those components that will now appear as they are loaded in such a MassList.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2cc16f</samp>

This pull request refactors some component names and paths in the `LandingPage.vue` component and the `nuxt.config.js` file. The goal is to simplify the code structure and avoid potential naming conflicts. No changes to the functionality or appearance of the app are expected.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a2cc16f</samp>

> _We simplify the config, we avoid the conflicts_
> _We `nuxt/components` module, we don't need its tricks_
> _We rename the components, we make them clear and strong_
> _We `LandingPage.vue`, we rock it all night long_
