### PR TITLE
fix: Wrong validation of polkadot address at transfer? 

### DIFF
--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -65,6 +65,7 @@ import {
   isEthereumAddress,
 } from '@polkadot/util-crypto'
 import correctFormat from '@/utils/ss58Format'
+import { isValidAddress } from '@/utils/account'
 import { CHAINS } from '@/libs/static/src/chains'
 import InfoBox from '@/components/shared/view/InfoBox.vue'
 import { NeoButton } from '@kodadot1/brick'
@@ -107,15 +108,6 @@ const checkAddressByss58Format = (value: string, ss58: number) => {
   return isValid
 }
 
-const isValidUnsupportedPolkadotAddress = (address: string) => {
-  try {
-    encodeAddress(decodeAddress(address))
-    return true
-  } catch (error) {
-    return false
-  }
-}
-
 const getAddressCheck = (value: string): AddressCheck => {
   if (isEthereumAddress(value)) {
     return { valid: false, type: AddressType.ETHEREUM }
@@ -152,7 +144,7 @@ const getAddressCheck = (value: string): AddressCheck => {
     }
   }
 
-  const isValid = isValidUnsupportedPolkadotAddress(value)
+  const isValid = isValidAddress(value)
 
   if (isValid) {
     return {

--- a/components/shared/AddressChecker.vue
+++ b/components/shared/AddressChecker.vue
@@ -89,6 +89,7 @@ const props = defineProps<{
   address: string
 }>()
 
+const { $i18n } = useNuxtApp()
 const { chainProperties } = useChain()
 const { urlPrefix } = usePrefix()
 const currentChainName = computed(() => chainNames[urlPrefix.value])
@@ -104,6 +105,15 @@ const isWrongNetworkAddress = computed(
 const checkAddressByss58Format = (value: string, ss58: number) => {
   const [isValid] = checkAddress(value, correctFormat(ss58))
   return isValid
+}
+
+const isValidUnsupportedPolkadotAddress = (address: string) => {
+  try {
+    encodeAddress(decodeAddress(address))
+    return true
+  } catch (error) {
+    return false
+  }
 }
 
 const getAddressCheck = (value: string): AddressCheck => {
@@ -139,6 +149,16 @@ const getAddressCheck = (value: string): AddressCheck => {
       valid: false,
       type: AddressType.WRONG_NETWORK_ADDRESS,
       value: chainNames[validAddressesChain],
+    }
+  }
+
+  const isValid = isValidUnsupportedPolkadotAddress(value)
+
+  if (isValid) {
+    return {
+      valid: false,
+      type: AddressType.WRONG_NETWORK_ADDRESS,
+      value: $i18n.t('transfers.invalidAddress.wrongNetwork'),
     }
   }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -107,6 +107,7 @@
     "transferable": "Transferable",
     "networkFee": "Network fee",
     "invalidAddress": {
+      "wrongNetwork": "wrong network",
       "changeToChainAddress": "Change to {selectedChain} address",
       "addressChanged": {
         "title": "Changed to {selectedChain} address",

--- a/utils/account.ts
+++ b/utils/account.ts
@@ -100,4 +100,13 @@ export function accountToPublicKey(account: string): `0x${string}` {
   return u8aToHex(decoded)
 }
 
+export const isValidAddress = (address: string): boolean => {
+  try {
+    encodeAddress(decodeAddress(address))
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
 export default passwordRequired


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7405

Test: address 3p9ErbP5rmDnzu7PU7YFzJ6ih1J3DNE248rEJdkYLFShP6FY

https://polkadot.subscan.io/tools/format_transform?input=3p9ErbP5rmDnzu7PU7YFzJ6ih1J3DNE248rEJdkYLFShP6FY&type=All

it's a Subsocial address 

![CleanShot 2023-09-29 at 07 54 14@2x](https://github.com/kodadot/nft-gallery/assets/44554284/e28c4b3c-1b73-4261-8ecb-9756a6de5546)

valid polkadot ecosystem address but not one that we support atm

now you can transform from any valid polakdot ecosystem address to the current network

using this pr from Subsocial to Kusama returns -> Dg68oJbsCUtwNbKvGfeAsBftPaPnbrV9gSpJs2iJ1z24iJz 


<img width="769" alt="CleanShot 2023-09-29 at 08 04 01@2x" src="https://github.com/kodadot/nft-gallery/assets/44554284/aa51c254-5322-4388-a01a-5c7240652492">


#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

![CleanShot 2023-09-29 at 07 58 43](https://github.com/kodadot/nft-gallery/assets/44554284/0f22f4e7-4b30-4efc-8f1a-834fd6a8334d)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da86358</samp>

The code adds a feature to check the validity of Polkadot addresses and display an error message in the user's language if the address is from an unsupported network. The code modifies `AddressChecker.vue` and `locales/en.json` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at da86358</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A way to check the Polkadot addresses and prevent_
> _The grievous error of sending funds to the wrong network_
> _By adding `transfers.invalidAddress.wrongNetwork` to the `locales/en.json` file._


