### PR TITLE
fix: [nuxt3] show content early on landing page

### DIFF
--- a/components/landing/LandingPage.vue
+++ b/components/landing/LandingPage.vue
@@ -1,33 +1,36 @@
 <template>
   <div>
     <section class="py-8 instance section-search">
-      <LazyLandingSearchLanding />
+      <SearchLanding />
     </section>
 
     <template v-if="showCarousel">
       <!-- spotlight -->
       <section class="py-8 instance">
         <div class="container is-fluid">
-          <LazyCarouselTypeSpotlight />
+          <CarouselTypeSpotlight />
         </div>
       </section>
 
       <!-- top collections -->
       <section v-if="showTopCollections" class="py-8 instance">
         <div class="container is-fluid">
-          <LazyLandingTopCollections class="my-5" />
+          <TopCollections class="my-5" />
         </div>
       </section>
 
-      <section class="py-8 instance">
-        <div class="container is-fluid">
-          <!-- new listings -->
-          <LazyCarouselTypeNewestList />
+      <!-- at the moment lets put Carousel on Client mode only. I suspect that there is some blocked resources on Carousel component. something like async/await process -->
+      <ClientOnly>
+        <section class="py-8 instance">
+          <div class="container is-fluid">
+            <!-- new listings -->
+            <LazyCarouselTypeNewestList />
 
-          <!-- latest sales -->
-          <LazyCarouselTypeLatestSales class="mt-8" />
-        </div>
-      </section>
+            <!-- latest sales -->
+            <LazyCarouselTypeLatestSales class="mt-8" />
+          </div>
+        </section>
+      </ClientOnly>
     </template>
 
     <section class="py-8 instance instance-accent">
@@ -40,6 +43,9 @@
 
 <script lang="ts" setup>
 import type { Prefix } from '@kodadot1/static'
+import SearchLanding from './SearchLanding.vue'
+import TopCollections from './topCollections/TopCollections.vue'
+import CarouselTypeSpotlight from '@/components/carousel/CarouselTypeSpotlight.vue'
 
 const hiddenCarrouselPrefixes: Prefix[] = ['dot']
 const forbiddenPrefixesForTopCollections: Prefix[] = [


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Related #7375
- [x] Lazy load above the fold is not recommended. ref: https://web.dev/lazy-loading-best-practices/#:~:text=Anything%20resting%20above%20the%20fold,finished%20loading%20and%20begin%20execution.

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a4c106</samp>

Improved landing page performance and fixed carousel rendering. Changed some `Lazy` components to regular ones in `LandingPage.vue` and wrapped some carousels in `ClientOnly`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a4c106</samp>

> _No more lazy loading, we need speed and power_
> _`ClientOnly` wraps the carousel of fire_
> _We defy the server, we render on our own_
> _We are the masters of the landing zone_
