### PR TITLE
🔧 invalid orderBy in `useSearchNfts`

### DIFF
--- a/composables/useSearchNfts.ts
+++ b/composables/useSearchNfts.ts
@@ -2,7 +2,7 @@ export default function useSearchNfts({
   search,
   first = 10,
   prefix = '',
-  orderBy = '',
+  orderBy = 'blockNumber_DESC',
 }) {
   const { client } = usePrefix()
   const chainPrefix = prefix || client.value


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Context

- [x] query `nftListWithSearch` fired from `useSearchNfts` had invalid default value `orderBy=''`
changed  that to be `blockNumber_DESC`

![image](https://github.com/kodadot/nft-gallery/assets/22791238/2706e371-e8ff-4802-a044-9a012b1a3492)


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6296b80</samp>

Changed the default sorting order of NFTs to show the most recent ones first. Updated the `useSearchNfts` composable and the `orderBy` parameter in `composables/useSearchNfts.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6296b80</samp>

> _`orderBy` changed_
> _NFTs sorted by block_
> _Freshness for users_
