### PR TITLE
fix: [nuxt-3] Transfer page Issues 

### DIFF
--- a/components/common/itemTransfer/ItemTransferModal.vue
+++ b/components/common/itemTransfer/ItemTransferModal.vue
@@ -53,7 +53,7 @@
           </h2>
 
           <AddressInput
-            :value="address"
+            v-model="address"
             :is-invalid="isYourAddress"
             label=""
             class="is-flex-1"

--- a/components/shared/AddressInput.vue
+++ b/components/shared/AddressInput.vue
@@ -24,10 +24,10 @@ import { checkAddress, isAddress } from '@polkadot/util-crypto'
 import { NeoField, NeoInput } from '@kodadot1/brick'
 import AddressChecker from '@/components/shared/AddressChecker.vue'
 
-const emit = defineEmits(['input', 'check'])
+const emit = defineEmits(['update:modelValue', 'check'])
 const props = withDefaults(
   defineProps<{
-    value: string
+    modelValue: string
     label: string
     emptyOnError?: boolean
     strict: boolean
@@ -84,13 +84,17 @@ const inputValue = computed({
   set: (value) => handleInput(value),
 })
 
+const emitUpdate = (value: string) => {
+  emit('update:modelValue', value)
+}
+
 const clearIconClick = () => {
   inputValue.value = ''
-  emit('input', '')
+  emitUpdate('')
 }
 
 const handleInput = (value: string) => {
-  emit('input', value)
+  emitUpdate(value)
 
   if (props.disableError || props.withAddressCheck) {
     return value

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -129,7 +129,7 @@
               },
             ]">
             <AddressInput
-              :value="destinationAddress.address"
+              v-model="destinationAddress.address"
               label=""
               class="is-flex-1 is-flex-grow-2"
               :class="[

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -154,7 +154,7 @@
                 min="0"
                 icon-right-class="search"
                 @focus="onAmountFieldFocus(destinationAddress, 'token')"
-                @input="onAmountFieldChange(destinationAddress)" />
+                @update:modelValue="onAmountFieldChange(destinationAddress)" />
               <NeoInput
                 v-else
                 v-model="destinationAddress.usd"
@@ -165,7 +165,7 @@
                 icon-right="usd"
                 icon-right-class="has-text-grey"
                 @focus="onAmountFieldFocus(destinationAddress, 'usd')"
-                @input="onUsdFieldChange(destinationAddress)" />
+                @update:modelValue="onUsdFieldChange(destinationAddress)" />
               <a
                 v-if="!isMobile && targetAddresses.length > 1"
                 class="is-flex"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] ref #7375

fixes :
-   transfer is not showing address checking messages
-  transfer page total not summing values

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6173737</samp>

Refactored the `AddressInput` component to use `v-model` and a helper function for better data binding and readability. Updated the `AddressInput` usage in `ItemTransferModal.vue` and `Transfer.vue` to match the new convention.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6173737</samp>

> _We're heaving on the `v-model` line, me hearties_
> _To bind the data to the `AddressInput`_
> _We're heaving on the `v-model` line, me hearties_
> _To make the component work as we expect_


