### PR TITLE
style: mass list input border color

### DIFF
--- a/components/common/listingCart/shared/ListingCartPriceInput.vue
+++ b/components/common/listingCart/shared/ListingCartPriceInput.vue
@@ -45,7 +45,7 @@ watch(model, (newValue) => {
 .price-input {
   @include ktheme() {
     &:focus-within {
-      border-color: theme('border-color');
+      border-color: theme('border-color') !important;
     }
   }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).


👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7415
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="412" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/97e251fb-0ff8-4c97-947e-95b12b1af155">
<img width="401" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/146db736-f3d5-4225-8e9d-9d851ba94c37">

## Copilot Summary


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ab14dd</samp>

Fixed a UI bug with the listing cart price input border color and updated the Subsquid API URL for the `speck` endpoint. These changes improve the user experience and the data accuracy of the `ListingCartPriceInput.vue` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5ab14dd</samp>

> _`!important` fix_
> _border color harmonized_
> _autumn theme restored_

