### PR TITLE
fix: search results floor & unit continuously loading

### DIFF
--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -607,7 +607,7 @@ const updateCollectionSuggestion = async (value: string) => {
         totalCount: undefined,
         floorPrice: undefined,
       }
-      const collectionWithImages = {
+      const collectionWithImages = reactive({
         ...collections[i],
         ...meta,
         ...initialCollectionStats, // set initial stat fields to get reactivity
@@ -615,7 +615,7 @@ const updateCollectionSuggestion = async (value: string) => {
           collections[i].image || collections[i].mediaUri || '',
           'image'
         ),
-      }
+      })
       collectionWithImagesList.push(collectionWithImages)
 
       fetchCollectionStats(collectionWithImages, i)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Bugfix #7375 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

## Comments
- When searching in the search bar on collections the floor price and units is stuck in loading state.
- Make object reactive so that updates on the object are displayed on the UI.

## Screenshots
Problem:
![image](https://github.com/kodadot/nft-gallery/assets/22052693/7c0d58f2-9f93-4cd9-97a2-1523a48bd70c)

Fix:
![image](https://github.com/kodadot/nft-gallery/assets/22052693/d090ff46-7791-4e6c-8358-714f2ea72770)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64b8712</samp>

Improved the code structure and reactivity of `SearchSuggestion.vue` by using the composition API and reactive objects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 64b8712</samp>

> _To improve the code quality_
> _And the reactivity_
> _They refactored `SearchSuggestion.vue`_
> _With the composition API_
> _And used reactive objects for the view_
