### PR TITLE
add: add top collection to sidebar on polkadothub

### DIFF
--- a/components/shared/filters/modules/PopularCollections.vue
+++ b/components/shared/filters/modules/PopularCollections.vue
@@ -21,13 +21,14 @@
         class="mb-2">
         <NeoCheckbox
           :model-value="checkedCollections.includes(collection.id)"
+          class="w-full"
           label-class="is-flex-grow-1"
           @update:modelValue="toggleCollection(collection)">
           <div
             class="is-flex is-align-items-center filter-container pl-2 is-flex-grow-1 min-width-0">
             <img
               :src="sanitizeIpfsUrl(collection.meta.image)"
-              class="image is-32x32 border mr-2"
+              class="image is-32x32 is-flex-shrink-0 border mr-2"
               :alt="collection.meta.name || collection.id" />
             <div
               class="is-flex is-flex-direction-column is-flex-grow-1 min-width-0">

--- a/components/shared/filters/modules/constants.ts
+++ b/components/shared/filters/modules/constants.ts
@@ -53,4 +53,9 @@ export const POPULAR_COLLECTIONS = {
     'u-2022', // Polkadot Decoded 2022 POAPs
     'u-31848', // Ajuna Network Promo Collection
   ],
+  ahp: [
+    '10', // Kodachain - Berlin Onchain Exhibition
+    '11', // Kodachain - Sub0 Opening Party 2023
+    '13', // The sub0 2023 Biodiversity Collection
+  ],
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7441

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2023-10-02 at 14 03 58@2x](https://github.com/kodadot/nft-gallery/assets/44554284/99f2a43b-5567-4000-ae24-b6d19cddc425)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ceb784</samp>

Added new Kodachain collections to the popular filter. This change supports the feature of displaying Kodachain NFTs on the gallery page.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1ceb784</samp>

> _`POPULAR_COLLECTIONS`_
> _Kodachain NFTs join them_
> _Autumn of art blooms_


