### PR TITLE
fix: search NFT tab empty on preview

### DIFF
--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -572,10 +572,10 @@ const updateNftSuggestion = async () => {
     })
     const { nFTEntities } = data.value
     const nftList = unwrapSafe(
-      nFTEntities.value.slice(0, searchSuggestionEachTypeMaxNum)
+      nFTEntities.slice(0, searchSuggestionEachTypeMaxNum)
     )
     const metadataList: string[] = nftList.map(mapNFTorCollectionMetadata)
-    const result: NFTWithMeta[] = []
+    const result: NFTWithMeta[] = reactive([])
     processMetadata<NFTWithMeta>(metadataList, (meta, i) => {
       result.push({
         ...nftList[i],

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -575,9 +575,9 @@ const updateNftSuggestion = async () => {
       nFTEntities.slice(0, searchSuggestionEachTypeMaxNum)
     )
     const metadataList: string[] = nftList.map(mapNFTorCollectionMetadata)
-    const result: NFTWithMeta[] = reactive([])
+    const result: Ref<NFTWithMeta[]> = ref([])
     processMetadata<NFTWithMeta>(metadataList, (meta, i) => {
-      result.push({
+      result.value.push({
         ...nftList[i],
         ...meta,
         image: sanitizeIpfsUrl(
@@ -586,7 +586,7 @@ const updateNftSuggestion = async () => {
         ),
       })
     })
-    nftResult.value = result
+    nftResult.value = result.value
   } catch (e) {
     logError(e, (msg) => $consola.warn('[PREFETCH] Unable fo fetch', msg))
   }

--- a/utils/cachingStrategy.ts
+++ b/utils/cachingStrategy.ts
@@ -35,7 +35,7 @@ export const processMetadata = <T>(
   const metadata = metadataList.map((meta) => meta || '')
 
   metadata.forEach(async (m, i) => {
-    const meta = await cacheOrFetchMetadata(metadataCache[m], m)
+    const meta = await processSingleMetadata(m)
     if (cb && meta !== undefined) {
       metadataCache[m] = meta
       cb(meta, i)

--- a/utils/cachingStrategy.ts
+++ b/utils/cachingStrategy.ts
@@ -34,9 +34,8 @@ export const processMetadata = <T>(
 ): void => {
   const metadata = metadataList.map((meta) => meta || '')
 
-  metadata.forEach((m, i) => {
-    const meta = cacheOrFetchMetadata(metadataCache[m], m)
-
+  metadata.forEach(async (m, i) => {
+    const meta = await cacheOrFetchMetadata(metadataCache[m], m)
     if (cb && meta !== undefined) {
       metadataCache[m] = meta
       cb(meta, i)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7453
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="657" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/182907b4-2165-424b-9782-f01c2d98b1b4">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b91fabf</samp>

This pull request improves the search suggestion component and the metadata caching strategy. It fixes a bug with reactive data in `SearchSuggestion.vue` and refactors the `processMetadata` function in `cachingStrategy.ts` to use `async/await`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b91fabf</samp>

> _Reactive arrays_
> _Simplify template logic_
> _No more `.value`_
  