### PR TITLE
🔧 Unclickable profile dropdown (When not connected)

### DIFF
--- a/components/navbar/ProfileDropdown.vue
+++ b/components/navbar/ProfileDropdown.vue
@@ -15,7 +15,7 @@
         menu-class="mt-0"
         :triggers="['hover']">
         <template #trigger>
-          <a class="navbar-item navbar-height" role="button">
+          <a class="navbar-item my-4" role="button">
             <img :src="profileIcon" alt="profile" />
           </a>
         </template>
@@ -103,9 +103,3 @@ const toggleLanguageMenu = () => {
   languageDropdown.value?.toggle()
 }
 </script>
-
-<style lang="scss" scoped>
-.navbar-height {
-  height: 4.5rem;
-}
-</style>

--- a/components/navbar/ProfileDropdown.vue
+++ b/components/navbar/ProfileDropdown.vue
@@ -12,7 +12,7 @@
       <NeoDropdown
         position="bottom-left"
         aria-role="menu"
-        class="menu-mt-0"
+        menu-class="mt-0"
         :triggers="['hover']">
         <template #trigger>
           <a class="navbar-item navbar-height" role="button">
@@ -105,12 +105,6 @@ const toggleLanguageMenu = () => {
 </script>
 
 <style lang="scss" scoped>
-.menu-mt-0 {
-  :deep(.o-drop__menu) {
-    margin-top: 0;
-  }
-}
-
 .navbar-height {
   height: 4.5rem;
 }

--- a/components/navbar/ProfileDropdown.vue
+++ b/components/navbar/ProfileDropdown.vue
@@ -12,9 +12,10 @@
       <NeoDropdown
         position="bottom-left"
         aria-role="menu"
+        class="menu-mt-0"
         :triggers="['hover']">
         <template #trigger>
-          <a class="navbar-item" role="button">
+          <a class="navbar-item navbar-height" role="button">
             <img :src="profileIcon" alt="profile" />
           </a>
         </template>
@@ -102,3 +103,15 @@ const toggleLanguageMenu = () => {
   languageDropdown.value?.toggle()
 }
 </script>
+
+<style lang="scss" scoped>
+.menu-mt-0 {
+  :deep(.o-drop__menu) {
+    margin-top: 0;
+  }
+}
+
+.navbar-height {
+  height: 4.5rem;
+}
+</style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #7459
- [x] From #7375


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2322a1</samp>

Improved the appearance and alignment of the profile dropdown menu in the navbar. Changed some props and classes of `o-drop` and its trigger in `components/navbar/ProfileDropdown.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d2322a1</samp>

> _Oh, we're the crew of the `o-drop` component_
> _We make the profile menu fit and decent_
> _We tweak the `position` and the `class` props_
> _And we add some custom CSS on top_
