### PR TITLE
fix: Put Tos and PP into footer

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -226,6 +226,16 @@ const menuKodadot: Menu[] = [
     url: '/blog',
     external: false,
   },
+  {
+    name: $i18n.t('footer.privacyPolicy'),
+    url: '/privacy-policy',
+    external: false,
+  },
+  {
+    name: $i18n.t('footer.toc'),
+    url: '/terms-of-use',
+    external: false,
+  },
 ]
 
 const socials = [

--- a/locales/en.json
+++ b/locales/en.json
@@ -1100,7 +1100,9 @@
   "footer": {
     "subscribe": "Get The Latest KodaDot Updates",
     "join": "Join Our Community",
-    "subscribeLabel": "Subscribe"
+    "subscribeLabel": "Subscribe",
+    "toc": "Terms of Use",
+    "privacyPolicy": "Privacy Policy"
   },
   "share": {
     "copyLink": "Copy Link",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7465
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="664" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/66076101-1f71-4243-9049-888f58b790ff">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22ebee3</samp>

Added Privacy Policy and Terms of Use links to the footer menu. Updated the English locale file with the names of the new pages.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 22ebee3</samp>

> _Footer menu grows_
> _`$i18n.t` translates_
> _Winter of consent_
  