### PR TITLE
fix: Remove Paybis from fiat-on ramp modal

### DIFF
--- a/components/shared/OnRampModal.vue
+++ b/components/shared/OnRampModal.vue
@@ -73,7 +73,6 @@ import { showNotification } from '@/utils/notification'
 
 enum Provider {
   TRANSAK,
-  PAYBIS,
   RAMP,
 }
 
@@ -112,12 +111,6 @@ const providers = computed(() => [
     disabled: true,
     supports: ['DOT', 'KSM'],
     value: Provider.RAMP,
-  },
-  {
-    image: getImage('paybis'),
-    disabled: true,
-    supports: ['DOT'],
-    value: Provider.PAYBIS,
   },
 ])
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Context

  - [x] Closes #7466
  - [ ] Requires deployment <snek/rubick/worker>

<img width="476" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1443ba74-74ce-4b93-9d4e-500a9093f52b">


  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 812ecc4</samp>

Removed Paybis from the on-ramp modal component. This component allows users to choose a service to buy crypto with fiat currency.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 812ecc4</samp>

> _Oh, we're the coders of the sea, and we work with vim and git_
> _We push and pull and merge and branch, and we never quit_
> _But sometimes we have to say goodbye to a feature or a fix_
> _So farewell to Paybis, we've removed it from the `providers` list_
  