### PR TITLE
fix: double stroke on tabs

### DIFF
--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -267,6 +267,22 @@ watch(itemsGridSearch, (searchTerm, prevSearchTerm) => {
     flex-wrap: wrap;
     > * {
       flex: 1 0 50%;
+      &:nth-child(2) {
+        :deep(.explore-tabs-button) {
+          border-right: solid;
+        }
+      }
+      &:nth-child(1),
+      &:nth-child(2) {
+        :deep(.explore-tabs-button) {
+          border-bottom: none;
+        }
+      }
+      &:nth-child(2n + 1) {
+        :deep(.explore-tabs-button) {
+          border-right: none;
+        }
+      }
     }
     :deep(.explore-tabs-button) {
       width: 100% !important;

--- a/components/shared/TabItem.vue
+++ b/components/shared/TabItem.vue
@@ -34,6 +34,10 @@ withDefaults(
 <style scoped lang="scss">
 @import '@/styles/abstracts/variables';
 
+.control:not(:last-of-type) .explore-tabs-button {
+  border-right: none;
+}
+
 .control,
 .explore-tabs-button {
   width: 15rem;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

is there any common fix for items in mobile?  if we know that an item is in the last col or row when use `flex-wrap: wrap` then we can get a common fix without write many specific codes like `nth-child(2n+1)`. now i can not get this way. any one have good suggestion please leave comment here

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7447
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


<img width="613" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/334475fc-4840-40a7-89a6-7c4e1c3b81d1">

<img width="1281" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/30670f70-2622-4fcd-88a8-8a78959d19a4">


## Copilot Summary


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c63e17d</samp>

This pull request improves the appearance of the tabs in the profile detail page by modifying the CSS rules of `ProfileDetail.vue` and `TabItem.vue`. It removes the double border effect and adjusts the border properties of the tabs.


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c63e17d</samp>

> _`TabItem` styled well_
> _Border rules make tabs look neat_
> _Autumn leaves :deep_

