### PR TITLE
fix: missing icon on NeoButtons

### DIFF
--- a/libs/ui/src/components/NeoButton/NeoButton.vue
+++ b/libs/ui/src/components/NeoButton/NeoButton.vue
@@ -11,7 +11,7 @@
     :variant="variant"
     :disabled="disabled"
     :expanded="expanded"
-    :icon-pack="iconPack || 'fasr'"
+    :icon-pack="iconPack"
     :label="label"
     class="is-neo"
     :rounded="rounded"
@@ -27,21 +27,26 @@
 import { OButton } from '@oruga-ui/oruga-next'
 import { NeoButtonVariant } from '@kodadot1/brick'
 
-defineProps<{
-  size?: 'small' | 'medium' | 'large'
-  disabled?: boolean
-  expanded?: boolean
-  icon?: string
-  iconPack?: string
-  label?: string
-  active?: boolean
-  fixedWidth?: boolean
-  noShadow?: boolean
-  variant?: NeoButtonVariant
-  rounded?: boolean
-  tag?: string
-  loadingWithLabel?: boolean
-}>()
+withDefaults(
+  defineProps<{
+    size?: 'small' | 'medium' | 'large'
+    disabled?: boolean
+    expanded?: boolean
+    icon?: string
+    iconPack?: string
+    label?: string
+    active?: boolean
+    fixedWidth?: boolean
+    noShadow?: boolean
+    variant?: NeoButtonVariant
+    rounded?: boolean
+    tag?: string
+    loadingWithLabel?: boolean
+  }>(),
+  {
+    iconPack: 'fasr',
+  }
+)
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Bugfix #7375
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

# Comments
- Icons missing as 'fasr' icon pack default on prop overriden when binding $props on component. (Could change order?)
- Seems to be introduced in #7461 but I'm not sure why we bind $props here 🤷‍♂️ (maybe some compatibility?)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f0b36d</samp>

Simplified `NeoButton` component by removing unnecessary prop binding and setting default icon pack.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f0b36d</samp>

> _We're sailing with the `NeoButton` on our deck_
> _We don't need no `iconPack` to make it look its best_
> _We've set a default value with the `withDefaults` function_
> _And now our template is simpler and our icons are in unison_
