### PR TITLE
⏩ stop fetching collection stats for every single item

### DIFF
--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -62,7 +62,6 @@ import {
   nftToShoppingCardItem,
 } from '@/components/common/shoppingCart/utils'
 import { isOwner as checkOwner } from '@/utils/account'
-import { useCollectionDetails } from '@/components/collection/utils/useCollectionDetails'
 import { ItemsGridEntity, NFTStack } from './useItemsGrid'
 import useNftMetadata, { useNftCardIcon } from '@/composables/useNft'
 
@@ -82,9 +81,6 @@ const props = defineProps<{
 
 const { showCardIcon, cardIcon } = useNftCardIcon(computed(() => props.nft))
 
-const { stats } = useCollectionDetails({
-  collectionId: props.nft?.collection?.id || props.nft?.collectionId,
-})
 const isStack = computed(() => (props.nft as NFTStack).count > 1)
 
 const variant = computed(() =>
@@ -177,12 +173,8 @@ const onClickListingCart = () => {
     if (listingCartStore.isItemInCart(nft.id)) {
       listingCartStore.removeItem(nft.id)
     } else {
-      listingCartStore.setItem(
-        nftToListingCartItem(
-          nft,
-          String(stats.value.collectionFloorPrice ?? '')
-        )
-      )
+      const floorPrice = nft.collection.floorPrice[0]?.price || '0'
+      listingCartStore.setItem(nftToListingCartItem(nft, floorPrice))
     }
   })
 }

--- a/components/items/ItemsGrid/useItemsGrid.ts
+++ b/components/items/ItemsGrid/useItemsGrid.ts
@@ -10,8 +10,6 @@ export type NFTStack = NFTWithMetadata & Stack
 
 export type ItemsGridEntity = NFTWithMetadata | NFTStack
 import { NFT } from '@/components/rmrk/service/scheme'
-import { Stats } from '@/components/collection/utils/types'
-import { useCollectionDetails } from '@/components/collection/utils/useCollectionDetails'
 import { nftToListingCartItem } from '@/components/common/shoppingCart/utils'
 
 import { isOwner as checkOwner } from '@/utils/account'
@@ -182,49 +180,14 @@ export function useFetchSearch({
 export const updatePotentialNftsForListingCart = async (nfts: NFT[]) => {
   const listingCartStore = useListingCartStore()
   const { accountId } = useAuth()
-
-  //  Get unique collection IDs
-  const uniqueCollectionIds = Array.from(
-    new Set(nfts.map((nft) => nft.collection?.id || nft.collectionId))
-  )
-
-  // Wrap useCollectionDetails in a promise to watch for the stats
-  const fetchStatsForCollection = (
-    collectionId
-  ): Promise<{ id: string; stats: Stats }> =>
-    new Promise((resolve) => {
-      const { stats } = useCollectionDetails({ collectionId })
-      watch(stats, (newStats) => {
-        if (newStats && Object.keys(newStats).length) {
-          resolve({ id: collectionId, stats: newStats })
-        }
-      })
-    })
-
-  // Fetch stats for all unique collection IDs.
-  const allStats = await Promise.all(
-    uniqueCollectionIds.map(fetchStatsForCollection)
-  )
-
-  const statsById = allStats.reduce(
-    (acc, { id, stats }) => ({
-      ...acc,
-      [id]: stats,
-    }),
-    {}
-  )
-
   const potentialNfts = nfts
     .filter(
       (nft) =>
         !Number(nft.price) && checkOwner(nft.currentOwner, accountId.value)
     )
     .map((nft) => {
-      const collectionId = nft.collection?.id ?? nft.collectionId ?? ''
-      return nftToListingCartItem(
-        nft,
-        String(statsById[collectionId]?.collectionFloorPrice ?? '')
-      )
+      const floorPrice = nft.collection.floorPrice[0]?.price || '0'
+      return nftToListingCartItem(nft, floorPrice)
     })
 
   listingCartStore.setUnlistedItems(potentialNfts)

--- a/components/rmrk/service/scheme.ts
+++ b/components/rmrk/service/scheme.ts
@@ -167,7 +167,7 @@ export interface NFT extends ItemResources {
   name: string
   instance: string
   transferable: number
-  collection: EntityWithId
+  collection: EntityWithId & { floorPrice: { price: string }[] }
   collectionId?: string
   sn: string
   _id: string

--- a/queries/subsquid/general/nftListWithSearch.graphql
+++ b/queries/subsquid/general/nftListWithSearch.graphql
@@ -27,6 +27,17 @@ query nftListWithSearch(
     collection {
       id
       name
+      floorPrice: nfts (
+        where: {
+          burned_eq: false,
+           price_gt: "0"
+          },
+        orderBy: price_ASC,
+        limit: 1
+      ) 
+      {
+        price
+      }
     }
     meta {
       ...baseMeta

--- a/queries/subsquid/ksm/nftListWithSearch.graphql
+++ b/queries/subsquid/ksm/nftListWithSearch.graphql
@@ -27,6 +27,17 @@ query nftListWithSearch(
     collection {
       id
       name
+      floorPrice: nfts (
+        where: {
+          burned_eq: false,
+           price_gt: "0"
+          },
+        orderBy: price_ASC,
+        limit: 1
+      ) 
+      {
+        price
+      }
     }
     meta {
       ...baseMeta

--- a/queries/subsquid/rmrk/nftListWithSearch.graphql
+++ b/queries/subsquid/rmrk/nftListWithSearch.graphql
@@ -26,6 +26,17 @@ query nftListWithSearch(
     collection {
       id
       name
+      floorPrice: nfts (
+        where: {
+          burned_eq: false,
+           price_gt: "0"
+          },
+        orderBy: price_ASC,
+        limit: 1
+      ) 
+      {
+        price
+      }
     }
     meta {
       ...baseMeta


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type


- [x] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

Performance improvement
stop fetching collection stats for every single nft


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d2758f</samp>

Added `floorPrice` field to NFT collections to show the lowest price of the NFTs in the collection. Simplified listing cart item mapping by using `floorPrice` from GraphQL queries. Removed unused code and imports from `ItemsGridImage.vue` and `useItemsGrid.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7d2758f</samp>

> _To show the lowest price of NFTs_
> _We added `floorPrice` to queries_
> _For each subsquid endpoint_
> _We used the same logic to implement_
> _And cleaned up some code redundancies_
