### PR TITLE
Revert "fix: mimetype text/html should be image"

### DIFF
--- a/utils/gallery/media.ts
+++ b/utils/gallery/media.ts
@@ -45,7 +45,7 @@ export function resolveMedia(mimeType?: string): MediaType {
   }
 
   if (/^text\/html/.test(mimeType)) {
-    return MediaType.IMAGE
+    return MediaType.IFRAME
   }
 
   if (/^image\/svg\+xml/.test(mimeType)) {


### PR DESCRIPTION
Reverts kodadot/nft-gallery#7280

Reasoning:
this "fix" tries to show any `text/html` as image

Is this like saying about this turtle that's clown

![-2147483648_-226704](https://github.com/kodadot/nft-gallery/assets/22471030/73e15b5a-eb6e-4415-b0a2-13aa532c4392)

Needed for:
- https://github.com/kodadot/nft-gallery/issues/7495#issuecomment-1744959543
- #7248

