### PR TITLE
fix: carousel arrow

### DIFF
--- a/components/carousel/module/CarouselAgnostic.vue
+++ b/components/carousel/module/CarouselAgnostic.vue
@@ -15,15 +15,15 @@
       </div>
       <Transition name="fade">
         <div
-          v-if="sliderSettings.leftArrowValid"
+          v-if="leftArrowValid"
           class="arrow arrow-left"
-          @click="slider?.moveToIdx(sliderSettings.leftCarouselIndex)"></div>
+          @click="slider?.moveToIdx(leftCarouselIndex)"></div>
       </Transition>
       <Transition name="fade">
         <div
-          v-if="sliderSettings.rightArrowValid"
+          v-if="rightArrowValid"
           class="arrow arrow-right"
-          @click="slider?.moveToIdx(sliderSettings.rightCarouselIndex)"></div>
+          @click="slider?.moveToIdx(rightCarouselIndex)"></div>
       </Transition>
     </div>
   </div>
@@ -35,8 +35,8 @@ import CarouselInfo from './CarouselInfo.vue'
 import type { CarouselNFT } from '@/components/base/types'
 
 import 'keen-slider/keen-slider.min.css'
-import { useKeenSlider } from 'keen-slider/vue.es'
-import { wheelControls } from '../utils/useCarousel'
+import { useKeenSlider } from 'keen-slider/vue'
+import { CarouselWheelsPlugin } from '../utils/useCarousel'
 
 const slots = useSlots()
 const props = defineProps<{
@@ -49,13 +49,37 @@ const isCollection = computed(() => url.includes('collection'))
 provide('isCollection', isCollection.value)
 
 const current = ref(0)
+const leftArrowValid = ref(false)
+const rightArrowValid = ref(false)
+const leftCarouselIndex = ref(0)
+const rightCarouselIndex = ref(0)
+
+const sliderSettings = (slider) => {
+  if (slider) {
+    const { track, options, slides } = slider
+    const abs = Number(track.details.abs)
+    const perView = Number(options.slides.perView)
+
+    leftArrowValid.value = abs !== 0
+    rightArrowValid.value = abs + perView < slides.length
+    leftCarouselIndex.value = Math.max(abs - props.step, 0)
+    rightCarouselIndex.value = Math.min(
+      abs + props.step,
+      slides.length - perView,
+    )
+  }
+}
 
 const [wrapper, slider] = useKeenSlider(
   {
     initial: current.value,
     rubberband: false,
+    created: (s) => {
+      sliderSettings(s)
+    },
     slideChanged: (s) => {
       current.value = s.track.details.rel
+      sliderSettings(s)
     },
     detailsChanged: (s) => {
       s.slides.forEach((slide, index) => {
@@ -85,32 +109,8 @@ const [wrapper, slider] = useKeenSlider(
     },
     slides: { perView: 1.5, spacing: 32 },
   },
-  [wheelControls],
+  [CarouselWheelsPlugin],
 )
-
-const sliderSettings = computed(() => {
-  if (slider.value) {
-    const { track, options, slides } = slider.value
-    const abs = Number(track.details.abs)
-    const perView = Number(options.slides.perView)
-    const leftArrowValid = abs !== 0
-    const rightArrowValid = abs + perView < slides.length
-    const leftCarouselIndex = Math.max(abs - props.step, 0)
-    const rightCarouselIndex = Math.min(
-      abs + props.step,
-      slides.length - perView,
-    )
-
-    return {
-      leftArrowValid,
-      rightArrowValid,
-      leftCarouselIndex,
-      rightCarouselIndex,
-    }
-  } else {
-    return {}
-  }
-})
 </script>
 
 <style scoped lang="scss">

--- a/components/carousel/utils/useCarousel.ts
+++ b/components/carousel/utils/useCarousel.ts
@@ -144,7 +144,7 @@ function dispatch(event, name, slider) {
   )
 }
 
-export const wheelControls = (slider) => {
+export const CarouselWheelsPlugin = (slider) => {
   function eventWheel(event) {
     if (event.deltaX !== 0) {
       if (!wheelActive) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7546f15</samp>

Refactored and improved the carousel component using reactive refs and keen-slider plugins. Fixed a build error and extracted a plugin function to a separate file. Affected files: `CarouselAgnostic.vue`, `useCarousel.ts`, `CarouselWheelsPlugin.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7546f15</samp>

> _The carousel component was slow_
> _So they gave it a keen-slider glow_
> _They used reactive refs_
> _And some plugins for heft_
> _And `CarouselWheelsPlugin` stole the show_
