### PR TITLE
fix: recurring payment button on transfer not providing correct link

### DIFF
--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -45,7 +45,7 @@
           </NeoDropdownItem>
 
           <NeoDropdownItem
-            v-clipboard:copy="generateRecurringPaymentLink()"
+            v-clipboard:copy="recurringPaymentLink"
             class="no-wrap"
             data-testid="transfer-dropdown-recurring"
             @click="toast($t('toast.urlCopy'))">
@@ -830,13 +830,13 @@ const onTxError = async (dispatchError: DispatchError): Promise<void> => {
   isLoading.value = false
 }
 
-const generateRecurringPaymentLink = () => {
+const recurringPaymentLink = computed(() => {
   const addressList = targetAddresses.value
     .filter((item) => isAddress(item.address) && !item.isInvalid)
     .map((item) => item.address)
 
   return generatePaymentLink(addressList)
-}
+})
 
 const generatePaymentLink = (addressList: string[]): string => {
   const url = new URL(`${location.origin}${location.pathname}`)

--- a/plugins/vueClipboard.ts
+++ b/plugins/vueClipboard.ts
@@ -3,13 +3,21 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   nuxtApp.vueApp.directive('clipboard', {
     beforeMount(el, { value, arg }) {
+      el.dataset._clipboard_value = value
       useEventListener(el, 'click', () => {
         switch (arg) {
           case 'copy':
-            copy(value)
+            copy(el.dataset._clipboard_value)
             break
         }
       })
+    },
+    updated(el, { value, arg }) {
+      switch (arg) {
+        case 'copy':
+          el.dataset._clipboard_value = value
+          break
+      }
     },
   })
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Part of #7375 - recurring payment button on transfer not providing correct link(wrong chain and no user address)
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6f56f1</samp>

This pull request enhances the clipboard functionality for recurring payment links in the `Transfer.vue` component. It uses a computed property instead of a function call for better performance and reactivity, and updates the `clipboard` directive to handle dynamic values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d6f56f1</samp>

> _`clipboard` directive_
> _stores dynamic link value_
> _fixes bug in spring_
