### PR TITLE
style: new neo switch design

### DIFF
--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -204,7 +204,7 @@
             ><NeoIcon icon="circle-info"
           /></NeoTooltip>
         </div>
-        <NeoSwitch v-model="sendSameAmount" :rounded="false" />
+        <NeoSwitch v-model="sendSameAmount" />
       </div>
 
       <div

--- a/libs/ui/src/components/NeoSwitch/NeoSwitch.scss
+++ b/libs/ui/src/components/NeoSwitch/NeoSwitch.scss
@@ -1,0 +1,51 @@
+@import '../../scss/_theme.scss';
+@import '@oruga-ui/oruga/src/scss/utilities/_expressions.scss';
+@import '@oruga-ui/oruga/src/scss/utilities/_variables.scss';
+@import '@oruga-ui/oruga/src/scss/utilities/_animations.scss';
+@import '@oruga-ui/oruga/src/scss/utilities/_helpers.scss';
+@import '@oruga-ui/oruga/src/scss/components/_switch.scss';
+
+$white: #fff;
+$black: #000;
+$switch-bg-light:#d9d9d9;
+$switch-bg-dark:#363234;
+
+.o-switch {
+  &__check-switch {
+    height: 1.25rem;
+    width: 1.25rem;
+    background-color: $switch-bg-light;
+    border: 1px solid $black;
+    margin-left: -1px;
+  }
+  &__check {
+    height: 1.25rem;
+    width: 2.5rem;
+    padding: 0;
+    border: 1px solid;
+    background-color: $white;
+  }
+  &__check--checked {
+    @include ktheme() {
+      background-color: theme('k-primary');
+    }
+    .o-switch__check-switch {
+      background-color: $white;
+    }
+  }
+}
+.dark-mode .o-switch {
+  &__check {
+    background-color: $black;
+  }
+  &__check-switch {
+    border-color: $white;
+    background-color: $switch-bg-dark;
+  }
+  &__check--checked {
+    background-color: $white;
+    .o-switch__check-switch {
+      background-color: $black;
+    }
+  }
+}

--- a/libs/ui/src/components/NeoSwitch/NeoSwitch.vue
+++ b/libs/ui/src/components/NeoSwitch/NeoSwitch.vue
@@ -7,18 +7,5 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../scss/_theme.scss';
-@import '@oruga-ui/oruga/src/scss/utilities/_expressions.scss';
-@import '@oruga-ui/oruga/src/scss/utilities/_variables.scss';
-@import '@oruga-ui/oruga/src/scss/utilities/_animations.scss';
-@import '@oruga-ui/oruga/src/scss/utilities/_helpers.scss';
-@import '@oruga-ui/oruga/src/scss/components/_switch.scss';
-
-.o-switch {
-  &__check--checked {
-    @include ktheme() {
-      background-color: theme('k-primary');
-    }
-  }
-}
+@import './NeoSwitch.scss';
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

is there any common fix for items in mobile?  if we know that an item is in the last col or row when use `flex-wrap: wrap` then we can get a common fix without write many specific codes like `nth-child(2n+1)`. now i can not get this way. any one have good suggestion please leave comment here

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7541 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="126" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/a1c0a022-12a2-4539-9dfc-774788859ebb">
<img width="123" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/5a72f935-bee1-4aef-9537-f49be6e714f8">
<img width="126" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/05914993-dd77-4ee3-88b1-b59d8ac47933">
<img width="123" alt="图片" src="https://github.com/kodadot/nft-gallery/assets/16473062/2e5e58e1-a21d-4ac5-ac7d-0f08cb399aac">


## Copilot Summary


copilot:summary

copilot:poem

