### PR TITLE
fix: snek/incomingoffers page is blank

### DIFF
--- a/pages/snek/incomingOffers.vue
+++ b/pages/snek/incomingOffers.vue
@@ -1,25 +1,15 @@
 <template>
-  <MyOffer />
+  <BsxOfferMyOffer />
 </template>
 
-<script lang="ts">
-export default {
-  name: 'IncomingOffersPage',
-  components: {
-    MyOffer: () => import('@/components/bsx/Offer/MyOffer.vue'),
-  },
-  head() {
-    const title = 'Incoming Offers'
-    const metaData = {
-      title,
-      description:
-        'See all the offers you have received for your NFTs on KodaDot',
-      url: '/snek/incomingOffers',
-    }
-    return {
-      title,
-      meta: [...this.$seoMeta(metaData)],
-    }
-  },
-}
+<script lang="ts" setup>
+useHead({
+  title: 'Incoming Offers',
+  meta: [
+    {
+      name: 'description',
+      content: 'See all the offers you have received for your NFTs on KodaDot',
+    },
+  ],
+})
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Ref #7375 - snek/incomingoffers page is blank [screenshot](https://github.com/kodadot/nft-gallery/assets/10708802/d6f2d2bc-a437-4585-b9b5-2e6ca1b7ed17)
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e4a621</samp>

Refactored `incomingOffers.vue` to use `<script setup>` and `useHead`, and renamed a component for consistency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4e4a621</samp>

> _`<script setup>`: new_
> _Vue syntax for components_
> _Autumn of boilerplate_
