### PR TITLE
🔧 highest offer

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionSection.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionSection.vue
@@ -42,10 +42,12 @@ const priceChain = ref('0')
 const priceUsd = ref('0')
 
 watchEffect(async () => {
-  const tokenPrice = await getApproximatePriceOf(chainSymbol.value)
-  const price = roundTo(format(props.price || '0', decimals.value, ''), 4)
-  priceChain.value = `${price} ${chainSymbol.value}`
-  priceUsd.value = `${Math.round(parseInt(price) * tokenPrice)}`
+  if (props.price) {
+    const tokenPrice = await getApproximatePriceOf(chainSymbol.value)
+    const price = roundTo(format(props.price || '0', decimals.value, ''), 4)
+    priceChain.value = `${price} ${chainSymbol.value}`
+    priceUsd.value = `${Math.round(parseInt(price) * tokenPrice)}`
+  }
 })
 </script>
 


### PR DESCRIPTION
TESTED on `/bsx/gallery/282897835-6`

**before**
![Screenshot 2023-10-08 at 15-47-17 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/f4f1e21e-8aed-41d4-a774-79a5974f7ccb)



**after**
![Screenshot 2023-10-08 at 15-37-49 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/6c143769-3107-40e5-996b-36dc0f5508d5)
