### PR TITLE
fix: minting Settings not persistent after page refresh or navigating around the page

### DIFF
--- a/components/settings/Minting.vue
+++ b/components/settings/Minting.vue
@@ -4,14 +4,14 @@
       {{ $t('Minting Settings') }}
     </div>
     <div class="py-2 is-flex">
-      <Support :value="hasSupport" :show-price="false" />
+      <Support v-model="hasSupport" :show-price="false" />
       <NeoTooltip :label="$t('support.tooltip')" position="bottom" multiline>
         <NeoIcon icon="info-circle" />
       </NeoTooltip>
     </div>
     <div class="py-2 is-flex">
       <Support
-        :value="hasCarbonOffset"
+        v-model="hasCarbonOffset"
         :price="1"
         :active-message="$t('carbonOffset.carbonOffsetYes')"
         :passive-message="$t('carbonOffset.carbonOffsetNo')" />

--- a/components/shared/Support.vue
+++ b/components/shared/Support.vue
@@ -2,7 +2,9 @@
   <NeoSwitch v-model="model" :type="type" :rounded="false">
     <div class="is-flex is-align-items-center">
       <span class="mr-2">
-        {{ value ? `${$t(activeMessage)}${priceString}` : $t(passiveMessage) }}
+        {{
+          modelValue ? `${$t(activeMessage)}${priceString}` : $t(passiveMessage)
+        }}
       </span>
       <slot name="tooltip" />
     </div>
@@ -15,12 +17,12 @@ import { NeoSwitch } from '@kodadot1/brick'
 
 const props = withDefaults(
   defineProps<{
-    value: boolean
+    modelValue: boolean
     showPrice?: boolean
     price?: number
-    activeMessage: string
-    passiveMessage: string
-    type: string
+    activeMessage?: string
+    passiveMessage?: string
+    type?: string
   }>(),
   {
     showPrice: true,
@@ -30,10 +32,7 @@ const props = withDefaults(
     type: '',
   },
 )
-const emit = defineEmits(['input'])
+
+const model = useVModel(props, 'modelValue')
 const priceString = ref(props.showPrice ? ` ($ ${round(props.price)})` : '')
-const model = computed({
-  get: () => props.value,
-  set: (value: boolean) => emit('input', value),
-})
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Ref #7375
-  minting Settings not persistent after page refresh or navigating around the page


#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2074dbe</samp>

Refactored `Minting.vue` and `Support.vue` components to use `v-model` and Vue 3 features. This improves the data binding, reactivity, and reusability of the components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2074dbe</samp>

> _`Minting.vue` changed_
> _`v-model` for `Support`_
> _Simpler and reactive_


