### PR TITLE
🔧 drops watcheffect

### DIFF
--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -28,7 +28,7 @@ export function useDrops(collectionId: string, clientName?: string) {
     { clientId: clientName },
   )
 
-  watch(collectionData, () => {
+  watchEffect(() => {
     if (collectionData.value?.collectionEntity) {
       const { collectionEntity, nftEntitiesConnection } = collectionData.value
       const drops: Drop[] = []


### PR DESCRIPTION
ref #7375 

>  clicking on Drops link and then going to another page and clicking the drops link again shows no active drops

### Step to reproduce:
- click on drops in navbar
- click on any link
- click on drops in navbar again
- content empty