### PR TITLE
fix: collection search no result

### DIFF
--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -599,7 +599,7 @@ const updateCollectionSuggestion = async (value: string) => {
       searchSuggestionEachTypeMaxNum,
     )
     const metadataList: string[] = collections.map(mapNFTorCollectionMetadata)
-    const collectionWithImagesList: CollectionWithMeta[] = []
+    const collectionWithImagesList = ref<CollectionWithMeta[]>([])
 
     processMetadata<CollectionWithMeta>(metadataList, (meta, i) => {
       const initialCollectionStats = {
@@ -615,11 +615,11 @@ const updateCollectionSuggestion = async (value: string) => {
           'image',
         ),
       })
-      collectionWithImagesList.push(collectionWithImages)
+      collectionWithImagesList.value.push(collectionWithImages)
 
       fetchCollectionStats(collectionWithImages, i)
     })
-    collectionResult.value = collectionWithImagesList
+    collectionResult.value = collectionWithImagesList.value
   } catch (e) {
     logError(e, (msg) => $consola.warn('[PREFETCH] Unable fo fetch', msg))
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Ref #7375 - search providing NFT results, but not collections
- [ ] Requires deployment <snek/rubick/worker>

After fix:

https://github.com/kodadot/nft-gallery/assets/10708802/926c28e8-955f-4c54-8859-c0ba91397885

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d5199f</samp>

Refactored search suggestion component to use Vue 3 refs for better reactivity. Fixed ref value access and modification in `SearchSuggestion.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4d5199f</samp>

> _To make search suggestions more snappy_
> _The coder refactored some `ref`s_
> _But they had to be careful_
> _Not to mess with the `value`_
> _Or else the rendering would be messy_
