### PR TITLE
fix: Cycling trough examples not working properly on drops

### DIFF
--- a/components/collection/unlockable/ImageSlider.vue
+++ b/components/collection/unlockable/ImageSlider.vue
@@ -15,12 +15,12 @@
       <Transition name="fade">
         <div
           class="arrow arrow-left arrow-small-size"
-          @click="slider?.moveToIdx(sliderSettings.leftCarouselIndex)" />
+          @click="slider?.prev()" />
       </Transition>
       <Transition name="fade">
         <div
           class="arrow arrow-right arrow-small-size"
-          @click="slider?.moveToIdx(sliderSettings.rightCarouselIndex)" />
+          @click="slider?.next()" />
       </Transition>
       <div ref="thumbnail" class="keen-slider thumbnail">
         <div v-for="image in imageList" :key="image" class="keen-slider__slide">
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { useKeenSlider } from 'keen-slider/vue.es'
+import { useKeenSlider } from 'keen-slider/vue'
 import 'keen-slider/keen-slider.min.css'
 const emit = defineEmits(['select'])
 
@@ -87,27 +87,6 @@ const [thumbnail] = useKeenSlider(
   },
   [ThumbnailPlugin(slider)],
 )
-
-const sliderSettings = computed(() => {
-  if (slider.value) {
-    const { track, slides } = slider.value
-    const abs = Number(track.details.abs)
-    const perView = Number(4)
-    const leftArrowValid = abs !== 0
-    const rightArrowValid = abs + perView < slides.length
-    const leftCarouselIndex = (abs - 1 + perView) % perView
-    const rightCarouselIndex = (abs + 1) % perView
-
-    return {
-      leftArrowValid,
-      rightArrowValid,
-      leftCarouselIndex,
-      rightCarouselIndex,
-    }
-  } else {
-    return {}
-  }
-})
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7593
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f10b81</samp>

Improved the functionality and code quality of the image slider component for unlockable collections. Refactored the component to use the `useKeenSlider` hook and the `slider` methods from `keen-slider`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2f10b81</samp>

> _Oh we're the keenest crew on the web, me hearties_
> _We use the `useKeenSlider` hook with ease_
> _We simplify the code and we fix the bugs_
> _And we navigate the `slider` as we please_
  