### PR TITLE
 fix: User is able to trigger a NFT creation transaction without selecting a collection

### DIFF
--- a/components/common/ChooseCollectionDropdown.vue
+++ b/components/common/ChooseCollectionDropdown.vue
@@ -1,6 +1,5 @@
 <template>
   <NeoDropdown
-    required
     :class="[
       'dropdown-width',
       {

--- a/components/create/CreateNft.vue
+++ b/components/create/CreateNft.vue
@@ -330,7 +330,7 @@ const submitHandler = () => {
   if (selectedCollection.value) {
     toggleConfirm()
   } else {
-    ;(chooseCollectionRef.value?.$el as HTMLElement).scrollIntoView({
+    ;(chooseCollectionRef.value?.$el as HTMLElement)?.scrollIntoView({
       block: 'center',
     })
   }

--- a/components/create/CreateNft.vue
+++ b/components/create/CreateNft.vue
@@ -5,7 +5,7 @@
       v-model="modalShowStatus"
       :nft-information="nftInformation"
       @confirm="createNft" />
-    <form class="is-half column" @submit.prevent="toggleConfirm">
+    <form class="is-half column" @submit.prevent="submitHandler">
       <CreateNftPreview
         :name="form.name"
         :collection="selectedCollection?.name"
@@ -56,14 +56,20 @@
       <!-- select collections -->
       <NeoField
         :key="`collection-${currentChain}`"
-        :label="`${$t('mint.nft.collection.label')} *`">
+        :label="`${$t('mint.nft.collection.label')} *`"
+        @click="startSelectedCollection = true">
         <div class="w-100">
-          <p>{{ $t('mint.nft.collection.message') }}</p>
+          <p
+            :class="{
+              'has-text-danger': startSelectedCollection && !selectedCollection,
+            }">
+            {{ $t('mint.nft.collection.message') }}
+          </p>
           <ChooseCollectionDropdown
             full-width
             no-shadow
             class="mt-3"
-            @selectedCollection="onCollectionSelected" />
+            @selected-collection="onCollectionSelected" />
         </div>
       </NeoField>
 
@@ -256,6 +262,7 @@ const form = reactive({
 
 // select collections
 const selectedCollection = ref()
+const startSelectedCollection = ref<boolean>(false)
 
 const onCollectionSelected = (collection) => {
   selectedCollection.value = collection
@@ -315,6 +322,13 @@ const transactionStatus = ref<
 >('idle')
 const createdItems = ref()
 const mintedBlockNumber = ref()
+
+const submitHandler = () => {
+  startSelectedCollection.value = true
+  if (selectedCollection.value) {
+    toggleConfirm()
+  }
+}
 
 const toggleConfirm = () => {
   modalShowStatus.value = !modalShowStatus.value

--- a/components/create/CreateNft.vue
+++ b/components/create/CreateNft.vue
@@ -56,6 +56,7 @@
       <!-- select collections -->
       <NeoField
         :key="`collection-${currentChain}`"
+        ref="chooseCollectionRef"
         :label="`${$t('mint.nft.collection.label')} *`"
         @click="startSelectedCollection = true">
         <div class="w-100">
@@ -263,6 +264,7 @@ const form = reactive({
 // select collections
 const selectedCollection = ref()
 const startSelectedCollection = ref<boolean>(false)
+const chooseCollectionRef = ref()
 
 const onCollectionSelected = (collection) => {
   selectedCollection.value = collection
@@ -327,6 +329,10 @@ const submitHandler = () => {
   startSelectedCollection.value = true
   if (selectedCollection.value) {
     toggleConfirm()
+  } else {
+    ;(chooseCollectionRef.value?.$el as HTMLElement).scrollIntoView({
+      block: 'center',
+    })
   }
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7597
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI
<img width="595" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/b6664e5f-9891-414b-8927-afc16de5ac44">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d73dad4</samp>

Improved the user experience and code quality of the NFT creation form by refactoring the submission logic, adding validation and feedback, and fixing a prop warning in `ChooseCollectionDropdown`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d73dad4</samp>

> _Oh we're the coders of the sea, and we work on the NFT_
> _We fix the bugs and warnings, and we make the code more neat_
> _We heave away on the `required` prop, and we toss it in the bin_
> _And we haul on the `CreateNft` form, and we add some validation_
  