### PR TITLE
fix: Showing wrong number of items in collection

### DIFF
--- a/queries/subsquid/general/collectionListWithSearch.graphql
+++ b/queries/subsquid/general/collectionListWithSearch.graphql
@@ -20,7 +20,7 @@ query collectionListWithSearch(
   ) {
     ...collection
     ...collectionDetails
-    nfts {
+    nfts(where: { burned_eq: false }) {
       id
       metadata
       name


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7600
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

<img width="1194" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1500d40d-527e-4f3f-9da3-9dede3ea403e">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d97764c</samp>

Filter out burned nfts from collection list query. This improves the accuracy and usability of the `collectionListWithSearch.graphql` query by excluding nfts that are no longer valid.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d97764c</samp>

> _`nfts` in collection_
> _filter out the ones `burned_eq`_
> _autumn leaves falling_
  