### PR TITLE
fix: Some images not loading properly on Kusama

### DIFF
--- a/utils/gallery/media.ts
+++ b/utils/gallery/media.ts
@@ -15,7 +15,7 @@ export function isImageVisible(type: MediaType) {
 }
 
 export async function getMimeType(mediaUrl: string) {
-  const { headers } = await $fetch.raw(mediaUrl, { method: 'HEAD' })
+  const { headers } = await $fetch.raw(mediaUrl)
   return headers.get('content-type') || ''
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7596
  - [x] fix: nft is not loading properly on gallery list  https://kodadot.xyz/rmrk/collection/6c380dc2e061d72103-CV8888
  - [x] fix: nft is not loading properly on gallery details

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1195" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/548415ff-8adf-4e62-b5e0-0123f3906920">


<img width="1195" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/65bdd50b-f385-4e69-bf6f-098c78ef05b8">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 222b33f</samp>

Simplified `getMimeType` function in `utils/gallery/media.ts` to avoid CORS errors when fetching media from IPFS.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 222b33f</samp>

> _`getMimeType` changed_
> _No more `method: 'HEAD'` woes_
> _CORS errors gone - spring_
  