### PR TITLE
fix: Scroll to end when wallet disconnect

### DIFF
--- a/libs/ui/src/components/NeoModalExtend/plugin.ts
+++ b/libs/ui/src/components/NeoModalExtend/plugin.ts
@@ -22,6 +22,7 @@ const ModalProgrammatic = {
 
     const defaultParam = {
       programmatic: { instances },
+      scroll: 'clip',
     }
     let slot
     if (Array.isArray(newParams.content)) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7607
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8ace03</samp>

Added scroll option to `NeoModalExtend` component to handle modal content overflow. This improves the user experience of resizing and repositioning modals.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a8ace03</samp>

> _`Modal` can scroll_
> _Overflowing content stays_
> _Winter snow contained_
  