### PR TITLE
fix: More friendly errors for drops page

### DIFF
--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -162,7 +162,7 @@ const collectionId = computed(() => props.drop?.collection)
 const { neoModal } = useProgrammatic()
 const { toast } = useToast()
 const { urlPrefix } = usePrefix()
-
+const { $i18n } = useNuxtApp()
 const imageList = ref<string[]>([])
 const resultList = ref<any[]>([])
 const selectedImage = ref('')
@@ -306,7 +306,7 @@ const handleSubmitMint = async () => {
       },
       props.drop.id,
     ).then((res) => {
-      toast('mint success', 'is-neo', 20000)
+      toast('mint success', { duration: 20000 })
       scrollToTop()
       return `${collectionId.value}-${res.result.sn}`
     })
@@ -314,11 +314,11 @@ const handleSubmitMint = async () => {
     setTimeout(() => {
       isLoading.value = false
       justMinted.value = id
-      toast('You will be redirected in few seconds', 'is-neo', 3000)
+      toast('You will be redirected in few seconds', { duration: 3000 })
       return navigateTo(`/${urlPrefix.value}/gallery/${id}`)
     }, 44000)
   } catch (error) {
-    toast('failed to mint', 'is-neo', 20000)
+    toast($i18n.t('drops.mintPerAddress'))
     isLoading.value = false
   }
 }

--- a/components/collection/voteDrop/DropContainer.vue
+++ b/components/collection/voteDrop/DropContainer.vue
@@ -307,7 +307,7 @@ const handleMint = async () => {
       return navigateTo(`/${urlPrefix.value}/gallery/${id}`)
     }, 44000)
   } catch (error) {
-    toast('failed to mint')
+    toast($i18n.t('drops.mintPerAddress'))
     isLoading.value = false
   }
 }

--- a/composables/drop/useCheckReferenDumVote.ts
+++ b/composables/drop/useCheckReferenDumVote.ts
@@ -5,6 +5,9 @@ export const useCheckReferenDumVote = (proposal?: number) => {
   const { accountId } = useAuth()
   const isEligibleUser = ref(false)
 
+  onMounted(() => {
+    checkReferenDumVote()
+  })
   watch([accountId, proposal], () => {
     checkReferenDumVote()
   })
@@ -18,12 +21,12 @@ export const useCheckReferenDumVote = (proposal?: number) => {
         query: referendumVoteByAccount,
         variables: {
           account: getss58AddressByPrefix(accountId.value, 'dot'),
-          proposal: proposal,
+          proposal: Number(proposal),
         },
         clientId: 'polkassembly',
       })
 
-      if (data.value.votes.length > 0) {
+      if (data.value?.votes.length) {
         isEligibleUser.value = true
       }
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1359,6 +1359,7 @@
     "noUpcoming": "Nothing  here yet...",
     "mintingLive": "Minting Live",
     "mintedBy": "Minted By",
+    "mintPerAddress": "Each address can mint only once",
     "recentMints": "Recent NFT Mints"
   },
   "confirmPurchase": {

--- a/queries/referendumVoteByAccount.graphql
+++ b/queries/referendumVoteByAccount.graphql
@@ -1,14 +1,12 @@
-query referendumVoteByAccount($account: String!, $proposal: Number!) {
+query referendumVoteByAccount($account: String!, $proposal: Int!) {
   votes: convictionVotes(
     where: {
-      proposal: { index_eq: proposal }
+      proposal: { index_eq: $proposal }
       decision_eq: yes
       voter_eq: $account
     }
   ) {
     id
     voter
-    votingPower
-    lockPeriod
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7624
  - [x] fix: vote drop does not work properly
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da5b621</samp>

This pull request enhances the user feedback and fixes some issues related to minting NFTs from unlockable content and voting for drops. It uses localized toast messages, fixes a query and a type mismatch, and adds a new translation. It affects the files `UnlockableContainer.vue`, `DropContainer.vue`, `useCheckReferenDumVote.ts`, `referendumVoteByAccount.graphql`, and `en.json`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at da5b621</samp>

> _We are the rebels of the drop, we mint our NFTs_
> _We vote for the proposals, we use the `Polkassembly` API_
> _We face the doom of type mismatch, we fix it with our skill_
> _We toast our success with localized messages, we rock the `DropContainer.vue`_
  