### PR TITLE
fix: reactive network fee on create nft

### DIFF
--- a/components/create/Confirm/MintConfirmModal.vue
+++ b/components/create/Confirm/MintConfirmModal.vue
@@ -120,6 +120,7 @@ const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
 const fiatStore = useFiatStore()
 const preferencesStore = usePreferencesStore()
+const { isBasilisk } = useIsChain(urlPrefix)
 
 const {
   balance,
@@ -223,21 +224,14 @@ const confirm = () => {
   emit('confirm')
 }
 
-const calculateNetworkFee = async () => {
+watchEffect(async () => {
   networkFee.value = 0
-  const fee = await getTransitionFee(accountId.value, [''], decimals.value)
-  networkFee.value = Number(fee)
-}
 
-watch(
-  () => chainSymbol.value,
-  () => {
-    calculateNetworkFee()
-  },
-  {
-    immediate: true,
-  },
-)
+  if (!isBasilisk.value) {
+    const fee = await getTransitionFee(accountId.value, [''], decimals.value)
+    networkFee.value = Number(fee)
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/composables/useDeposit.ts
+++ b/composables/useDeposit.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef } from 'vue/types'
+import type { ComputedRef } from 'vue'
 import type { PalletBalancesAccountData } from '@polkadot/types/lookup'
 
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] fix: reactive network fee on create nft
- [x] I don't think network fee on bsx/snek was correct. at the moment I disable on that network

#### Had issue bounty label?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Copilot Summary
copilot:summary

copilot:poem