### PR TITLE
Owner-composable

### DIFF
--- a/components/collection/HeroButtons.vue
+++ b/components/collection/HeroButtons.vue
@@ -97,11 +97,10 @@ import {
   NeoDropdownItem,
   NeoModal,
 } from '@kodadot1/brick'
-import { isOwner as checkOwner } from '@/utils/account'
 import { useCollectionMinimal } from '@/components/collection/utils/useCollectionDetails'
 
 const route = useRoute()
-const { accountId } = useAuth()
+const { isCurrentOwner } = useAuth()
 const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
 const { toast } = useToast()
@@ -125,9 +124,7 @@ const openUrl = (url: string) => {
 }
 
 const displaySeperator = computed(() => twitter.value)
-const isOwner = computed(() =>
-  checkOwner(collection.value?.currentOwner, accountId.value),
-)
+const isOwner = isCurrentOwner(collection.value?.currentOwner)
 
 const QRModalActive = ref(false)
 

--- a/components/collection/HeroButtons.vue
+++ b/components/collection/HeroButtons.vue
@@ -124,7 +124,7 @@ const openUrl = (url: string) => {
 }
 
 const displaySeperator = computed(() => twitter.value)
-const isOwner = isCurrentOwner(collection.value?.currentOwner)
+const isOwner = computed(() => isCurrentOwner(collection.value?.currentOwner))
 
 const QRModalActive = ref(false)
 

--- a/components/gallery/GalleryItemAction/GalleryItemAction.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemAction.vue
@@ -28,8 +28,6 @@
 </template>
 
 <script lang="ts" setup>
-import { isOwner as checkOwner } from '@/utils/account'
-
 import GalleryItemPriceBuy from './GalleryItemActionType/GalleryItemBuy.vue'
 import GalleryItemPriceOffer from './GalleryItemActionType/GalleryItemOffer.vue'
 import GalleryItemPriceRelist from './GalleryItemActionType/GalleryItemRelist.vue'
@@ -40,11 +38,9 @@ const props = defineProps<{
   nft: NFT | undefined
 }>()
 
-const { accountId } = useAuth()
+const { isCurrentOwner } = useAuth()
 const { offersDisabled } = useChain()
-const isOwner = computed(() =>
-  checkOwner(props.nft?.currentOwner, accountId.value),
-)
+const isOwner = isCurrentOwner(props.nft?.currentOwner)
 </script>
 
 <style scoped></style>

--- a/components/gallery/GalleryItemAction/GalleryItemAction.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemAction.vue
@@ -40,7 +40,7 @@ const props = defineProps<{
 
 const { isCurrentOwner } = useAuth()
 const { offersDisabled } = useChain()
-const isOwner = isCurrentOwner(props.nft?.currentOwner)
+const isOwner = computed(() => isCurrentOwner(props.nft?.currentOwner))
 </script>
 
 <style scoped></style>

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemOffers.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemOffers.vue
@@ -104,7 +104,7 @@ const dprops = defineProps<{
   account: string
 }>()
 
-const isOwner = isCurrentOwner(dprops.account)
+const isOwner = computed(() => isCurrentOwner(dprops.account))
 
 const isActive = (row) => row.status === OfferStatusType.ACTIVE
 

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemOffers.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemOffers.vue
@@ -86,7 +86,6 @@ import type { Offer, OfferResponse } from '@/components/bsx/Offer/types'
 import type { CollectionEvents } from '@/components/rmrk/service/scheme'
 import { OfferStatusType } from '@/utils/offerStatus'
 import { notificationTypes, showNotification } from '@/utils/notification'
-import { isOwner as checkOwner } from '@/utils/account'
 import { ShoppingActions } from '@/utils/shoppingActions'
 import Loader from '@/components/shared/Loader.vue'
 
@@ -94,6 +93,7 @@ const { $i18n, $consola } = useNuxtApp()
 
 const { apiInstance } = useApi()
 const { urlPrefix } = usePrefix()
+const { isCurrentOwner } = useAuth()
 const { decimals, chainSymbol } = useChain()
 
 const { transaction, status, isLoading } = useTransaction()
@@ -104,7 +104,7 @@ const dprops = defineProps<{
   account: string
 }>()
 
-const isOwner = computed(() => checkOwner(dprops.account, accountId.value))
+const isOwner = isCurrentOwner(dprops.account)
 
 const isActive = (row) => row.status === OfferStatusType.ACTIVE
 

--- a/components/gallery/UnlockableTag.vue
+++ b/components/gallery/UnlockableTag.vue
@@ -44,7 +44,7 @@ const { isCurrentOwner } = useAuth()
 const isMobile = computed(() => useWindowSize().width.value < 768)
 const { unlockableIcon } = useUnlockableIcon()
 
-const isOwner = isCurrentOwner(props.nft?.currentOwner)
+const isOwner = computed(() => isCurrentOwner(props.nft?.currentOwner))
 </script>
 
 <style lang="scss" scoped>

--- a/components/gallery/UnlockableTag.vue
+++ b/components/gallery/UnlockableTag.vue
@@ -31,7 +31,6 @@
 
 <script lang="ts" setup>
 import { NeoTooltip } from '@kodadot1/brick'
-import { isOwner as checkOwner } from '@/utils/account'
 import { NFT } from '@/components/rmrk/service/scheme'
 import { useWindowSize } from '@vueuse/core'
 import { useUnlockableIcon } from '@/composables/useUnlockableIcon'
@@ -41,13 +40,11 @@ const props = defineProps<{
   link: string | undefined
 }>()
 
-const { accountId } = useAuth()
+const { isCurrentOwner } = useAuth()
 const isMobile = computed(() => useWindowSize().width.value < 768)
 const { unlockableIcon } = useUnlockableIcon()
 
-const isOwner = computed(() =>
-  checkOwner(props.nft?.currentOwner, accountId.value),
-)
+const isOwner = isCurrentOwner(props.nft?.currentOwner)
 </script>
 
 <style lang="scss" scoped>

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -133,7 +133,7 @@ const { cartIcon } = useShoppingCartIcon(props.nft.id)
 
 const { nft } = useNft(props.nft)
 
-const isOwner = isCurrentOwner(props.nft?.currentOwner)
+const isOwner = computed(() => isCurrentOwner(props.nft?.currentOwner))
 
 const openCompletePurcahseModal = () => {
   preferencesStore.setCompletePurchaseModal({

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -63,13 +63,11 @@ import {
   nftToListingCartItem,
   nftToShoppingCartItem,
 } from '@/components/common/shoppingCart/utils'
-import { isOwner as checkOwner } from '@/utils/account'
 import { NFTStack } from './useItemsGrid'
 import useNftMetadata, { useNftCardIcon } from '@/composables/useNft'
 
-const { urlPrefix } = usePrefix()
 const { placeholder } = useTheme()
-const { accountId, isLogIn } = useAuth()
+const { isLogIn, isCurrentOwner } = useAuth()
 const { doAfterLogin } = useDoAfterlogin(getCurrentInstance())
 const shoppingCartStore = useShoppingCartStore()
 const listingCartStore = useListingCartStore()
@@ -135,9 +133,7 @@ const { cartIcon } = useShoppingCartIcon(props.nft.id)
 
 const { nft } = useNft(props.nft)
 
-const isOwner = computed(() =>
-  checkOwner(props.nft?.currentOwner, accountId.value),
-)
+const isOwner = isCurrentOwner(props.nft?.currentOwner)
 
 const openCompletePurcahseModal = () => {
   preferencesStore.setCompletePurchaseModal({

--- a/components/items/ItemsGrid/useItemsGrid.ts
+++ b/components/items/ItemsGrid/useItemsGrid.ts
@@ -12,7 +12,6 @@ export type ItemsGridEntity = NFTWithMetadata | NFTStack
 import { NFT } from '@/components/rmrk/service/scheme'
 import { nftToListingCartItem } from '@/components/common/shoppingCart/utils'
 
-import { isOwner as checkOwner } from '@/utils/account'
 import { useListingCartStore } from '@/stores/listingCart'
 
 export function useFetchSearch({
@@ -148,11 +147,10 @@ export function useFetchSearch({
 
 export const updatePotentialNftsForListingCart = async (nfts: NFT[]) => {
   const listingCartStore = useListingCartStore()
-  const { accountId } = useAuth()
+  const { isCurrentOwner } = useAuth()
   const potentialNfts = nfts
     .filter(
-      (nft) =>
-        !Number(nft.price) && checkOwner(nft.currentOwner, accountId.value),
+      (nft) => !Number(nft.price) && isCurrentOwner(nft.currentOwner).value,
     )
     .map((nft) => {
       const floorPrice = nft.collection.floorPrice[0]?.price || '0'

--- a/components/items/ItemsGrid/useItemsGrid.ts
+++ b/components/items/ItemsGrid/useItemsGrid.ts
@@ -149,9 +149,7 @@ export const updatePotentialNftsForListingCart = async (nfts: NFT[]) => {
   const listingCartStore = useListingCartStore()
   const { isCurrentOwner } = useAuth()
   const potentialNfts = nfts
-    .filter(
-      (nft) => !Number(nft.price) && isCurrentOwner(nft.currentOwner).value,
-    )
+    .filter((nft) => !Number(nft.price) && isCurrentOwner(nft.currentOwner))
     .map((nft) => {
       const floorPrice = nft.collection.floorPrice[0]?.price || '0'
       return nftToListingCartItem(nft, floorPrice)

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -8,8 +8,16 @@ export default function () {
   const isLogIn = computed(() => Boolean(identityStore.getAuthAddress))
   const balance = computed(() => identityStore.getAuthBalance)
 
-  const isCurrentOwner = (address?: string) =>
-    computed(() => accountsAreSame(accountId.value, address))
+  const isCurrentOwner = (address?: string) => {
+    console.log('isCurrentOwner: address', address)
+    console.log('isCurrentOwner: accountid.value', accountId.value)
+    console.log(
+      'isCurrentOwner: is same?',
+      accountsAreSame(accountId.value, address),
+    )
+
+    return accountsAreSame(accountId.value, address)
+  }
 
   return {
     accountId,

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -1,4 +1,5 @@
 import { useIdentityStore } from '@/stores/identity'
+import { accountsAreSame } from '@/utils/account'
 
 export default function () {
   const identityStore = useIdentityStore()
@@ -7,9 +8,13 @@ export default function () {
   const isLogIn = computed(() => Boolean(identityStore.getAuthAddress))
   const balance = computed(() => identityStore.getAuthBalance)
 
+  const isCurrentOwner = (address?: string) =>
+    computed(() => accountsAreSame(accountId.value, address))
+
   return {
     accountId,
     isLogIn,
     balance,
+    isCurrentOwner,
   }
 }

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -8,16 +8,8 @@ export default function () {
   const isLogIn = computed(() => Boolean(identityStore.getAuthAddress))
   const balance = computed(() => identityStore.getAuthBalance)
 
-  const isCurrentOwner = (address?: string) => {
-    console.log('isCurrentOwner: address', address)
-    console.log('isCurrentOwner: accountid.value', accountId.value)
-    console.log(
-      'isCurrentOwner: is same?',
-      accountsAreSame(accountId.value, address),
-    )
-
-    return accountsAreSame(accountId.value, address)
-  }
+  const isCurrentOwner = (address?: string) =>
+    accountsAreSame(accountId.value, address)
 
   return {
     accountId,

--- a/utils/account.ts
+++ b/utils/account.ts
@@ -77,7 +77,7 @@ export const isSameAccount = (
   return addressEq(address1, address2)
 }
 
-export const isOwner = (
+export const accountsAreSame = (
   account1?: KeyringAccount | string,
   account2?: KeyringAccount | string,
 ): boolean => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #7651
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d87c15</samp>

Refactored the owner check logic in various components and composables to use a new function `isCurrentOwner` from the `useAuth` composable. This simplified the code, reduced dependencies, and improved readability. Renamed the utility function `checkOwner` to `accountsAreSame` for clarity.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d87c15</samp>

> _We're refactoring the code, me hearties, yo ho ho_
> _We're using `useAuth` to check the owner, yo ho ho_
> _We're simplifying the logic and reducing the imports, yo ho ho_
> _We're heaving on the line on the count of three, yo ho ho_
