### PR TITLE
fix: Hover card styling and popup area

### DIFF
--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -319,6 +319,10 @@ a.has-text-grey {
   border: none !important;
 }
 
+.no-border-radius {
+  border-radius: 0 !important;
+}
+
 .card-border-color {
   @include ktheme() {
     border-color: theme('card-border-color');

--- a/components/collectionDetailsPopover/CollectionDetailsPopover.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopover.vue
@@ -1,6 +1,5 @@
 <template>
   <tippy
-    class="is-flex"
     interactive
     :animate-fill="false"
     :append-to="body"

--- a/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
@@ -60,7 +60,10 @@
           {{ $t('profile.highestSales') }}
         </h6>
         <div class="is-flex sold-items">
-          <div v-for="nftItem in soldItems" :key="nftItem.id" class="sold-item">
+          <div
+            v-for="nftItem in soldItems"
+            :key="nftItem.id"
+            class="sold-item border">
             <GalleryCard
               :id="nftItem.id"
               hide-name
@@ -162,10 +165,6 @@ const { nftEntities: soldItems } = useCollectionSoldData({
   .sold-item {
     width: 76px;
     height: 76px;
-
-    @include ktheme() {
-      border: 1px solid theme('border-color');
-    }
   }
 }
 </style>

--- a/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
@@ -160,8 +160,8 @@ const { nftEntities: soldItems } = useCollectionSoldData({
   gap: 10px;
 
   .sold-item {
-    width: 78px;
-    height: 78px;
+    width: 76px;
+    height: 76px;
 
     @include ktheme() {
       border: 1px solid theme('border-color');

--- a/components/identity/module/IdentityPopoverFooter.vue
+++ b/components/identity/module/IdentityPopoverFooter.vue
@@ -31,7 +31,7 @@
         {{ $t('profile.highestSales') }}
       </h6>
       <div class="is-flex sold-items">
-        <div v-for="nft in soldItems" :key="nft.id" class="sold-item">
+        <div v-for="nft in soldItems" :key="nft.id" class="sold-item border">
           <GalleryCard
             :id="nft.id"
             hide-name
@@ -72,12 +72,8 @@ defineProps<{
   gap: 10px;
 
   .sold-item {
-    width: 78px;
-    height: 78px;
-
-    @include ktheme() {
-      border: 1px solid theme('border-color');
-    }
+    width: 76px;
+    height: 76px;
   }
 }
 

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -7,7 +7,7 @@
     }">
     <img
       :src="src"
-      class="is-block image-media__image"
+      class="is-block image-media__image no-border-radius"
       :alt="alt"
       data-testid="type-image" />
     <!-- @error="onError" /> -->


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7650
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="278" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/6fd9aacf-aee9-4ed3-bec6-6b8ff7072b29">

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e64134</samp>

This pull request improves the appearance and layout of NFT images and collection details in the UI. It introduces a new CSS class `.no-border-radius` to remove the border radius of images, and adjusts the size and alignment of the collection details popover.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3e64134</samp>

> _`ktheme` border gone_
> _Images fit in popover_
> _Winter sharpness `img`_
  