### PR TITLE
fix: collection name card truncation

### DIFF
--- a/components/carousel/module/CarouselInfo.vue
+++ b/components/carousel/module/CarouselInfo.vue
@@ -21,7 +21,7 @@
               chain: item.chain,
             })
           "
-          class="is-size-7 carousel-info-collection-name">
+          class="is-size-7 carousel-info-collection-name is-ellipsis">
           {{ item.collectionName || '--' }}
         </nuxt-link>
       </template>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7649
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="252" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/6d48742b-dda0-4957-99a5-69630d586a95">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cd3a92</samp>

Added `is-ellipsis` class to collection name element in `CarouselInfo.vue` to truncate long text with an ellipsis. This improves the layout and readability of the carousel component.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8cd3a92</samp>

> _`is-ellipsis` class_
> _truncates long collection names_
> _autumn leaves falling_
  