### PR TITLE
fix: Explorer audio NFTs stopped playing on hover 

### DIFF
--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="media-object" style="height: fit-content">
+  <div ref="mediaItem" class="media-object" style="height: fit-content">
     <component
       :is="resolveComponent"
       :src="properSrc"
@@ -11,7 +11,8 @@
       :is-detail="isDetail"
       :disable-operation="disableOperation"
       :player-cover="audioPlayerCover"
-      :hover-on-cover-play="audioHoverOnCoverPlay" />
+      :hover-on-cover-play="audioHoverOnCoverPlay"
+      :parent-hovering="isMediaItemHovering" />
     <div
       v-if="isLewd && isLewdBlurredLayer"
       class="nsfw-blur is-capitalized is-flex is-align-items-center is-justify-content-center is-flex-direction-column">
@@ -56,6 +57,7 @@ import JsonMedia from './type/JsonMedia.vue'
 import IFrameMedia from './type/IFrameMedia.vue'
 import ObjectMedia from './type/ObjectMedia.vue'
 import Media from './type/UnknownMedia.vue'
+import { useElementHover } from '@vueuse/core'
 
 const SUFFIX = 'Media'
 const props = withDefaults(
@@ -129,6 +131,9 @@ watch(
 const toggleContent = () => {
   isLewdBlurredLayer.value = !isLewdBlurredLayer.value
 }
+
+const mediaItem = ref()
+const isMediaItemHovering = useElementHover(mediaItem)
 
 defineExpose({ isLewdBlurredLayer })
 </script>

--- a/libs/ui/src/components/MediaItem/type/AudioMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/AudioMedia.vue
@@ -21,33 +21,49 @@
 <script lang="ts" setup>
 import { NeoAudioPlayer } from '@kodadot1/brick'
 import ImageMedia from './ImageMedia.vue'
-import { useElementHover } from '@vueuse/core'
+import { useElementHover, watchDebounced } from '@vueuse/core'
 
-const props = defineProps<{
-  animationSrc?: string
-  playerCover?: string
-  hoverOnCoverPlay?: boolean
+const props = withDefaults(
+  defineProps<{
+    animationSrc?: string
+    playerCover?: string
+    hoverOnCoverPlay?: boolean
+    parentHovering?: boolean
 
-  // image media props
-  alt?: string
-  original: boolean
-  placeholder: string
-  isDetail?: boolean
-  isDarkMode?: boolean
-}>()
+    // image media props
+    alt?: string
+    original: boolean
+    placeholder: string
+    isDetail?: boolean
+    isDarkMode?: boolean
+  }>(),
+  {
+    parentHovering: undefined,
+  },
+)
 
 const cover = ref()
 const audioPlayer = ref()
 
-const coverHovering = useElementHover(cover, { delayEnter: 1000 })
+const debounceDelay = 1000
+
+const coverHovering = useElementHover(cover, { delayEnter: debounceDelay })
 
 if (props.hoverOnCoverPlay) {
-  watch(coverHovering, () => handleCoverHover())
+  if (props.parentHovering !== undefined) {
+    watchDebounced(
+      () => props.parentHovering,
+      (hovering) => handleCoverHover(hovering),
+      { debounce: computed(() => (props.parentHovering ? debounceDelay : 0)) },
+    )
+  } else {
+    watch(coverHovering, (hovering) => handleCoverHover(hovering))
+  }
 }
 
-const handleCoverHover = async () => {
+const handleCoverHover = async (hovering: boolean) => {
   try {
-    if (coverHovering.value) {
+    if (hovering) {
       await audioPlayer.value.play()
     } else {
       await audioPlayer.value.pause()

--- a/libs/ui/src/components/MediaItem/type/AudioMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/AudioMedia.vue
@@ -45,16 +45,16 @@ const props = withDefaults(
 const cover = ref()
 const audioPlayer = ref()
 
-const debounceDelay = 1000
+const hoverDelay = 1000
 
-const coverHovering = useElementHover(cover, { delayEnter: debounceDelay })
+const coverHovering = useElementHover(cover, { delayEnter: hoverDelay })
 
 if (props.hoverOnCoverPlay) {
   if (props.parentHovering !== undefined) {
     watchDebounced(
       () => props.parentHovering,
       (hovering) => handleCoverHover(hovering),
-      { debounce: computed(() => (props.parentHovering ? debounceDelay : 0)) },
+      { debounce: computed(() => (props.parentHovering ? hoverDelay : 0)) },
     )
   } else {
     watch(coverHovering, (hovering) => handleCoverHover(hovering))


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7668


issue 

nft card's hover effect got changed 
![CleanShot 2023-10-16 at 14 32 52@2x](https://github.com/kodadot/nft-gallery/assets/44554284/35e2da7c-c25a-482a-a010-e070e22b3ffc)

@kodadot/qa-guild 

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33607aa</samp>

Added hover-based audio playback control to `MediaItem` and `AudioMedia` components. Used `useElementHover`, `watchDebounced`, and `withDefaults` functions from `@vueuse/core` library to implement the logic and handle props. Improved the user experience of interacting with audio media items in the gallery.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 33607aa</samp>

> _To make audio media play nice_
> _We added some hover device_
> _With `useElementHover`_
> _And `watchDebounced` cover_
> _We can pause or resume in a trice_


