### PR TITLE
fix: Zero balance on transfer when address has DOTs

### DIFF
--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -372,6 +372,7 @@ import { toDefaultAddress } from '@/utils/account'
 import AddressChecker from '@/components/shared/AddressChecker.vue'
 import TabItem from '@/components/shared/TabItem.vue'
 import Auth from '@/components/shared/Auth.vue'
+import { useIdentityStore } from '@/stores/identity'
 
 const Money = defineAsyncComponent(
   () => import('@/components/shared/format/Money.vue'),
@@ -383,6 +384,7 @@ const { $consola } = useNuxtApp()
 const { unit, decimals } = useChain()
 const { apiInstance } = useApi()
 const { urlPrefix } = usePrefix()
+const identityStore = useIdentityStore()
 const { isLogIn, accountId } = useAuth()
 const { getBalance } = useBalance()
 const { fetchFiatPrice, getCurrentTokenValue } = useFiatStore()
@@ -699,7 +701,16 @@ const calculateTransactionFee = async () => {
   txFee.value = Number((Number(fee) / Math.pow(10, decimals.value)).toFixed(4))
 }
 
-onMounted(() => calculateTransactionFee())
+const updateAuthBalance = () => {
+  accountId.value && identityStore.fetchBalance({ address: accountId.value })
+}
+
+watch(urlPrefix, updateAuthBalance)
+
+onMounted(() => {
+  calculateTransactionFee()
+  updateAuthBalance()
+})
 
 watchDebounced(
   [urlPrefix, () => targetAddresses.value.length],


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7674
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="644" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/30c6d39c-f78b-4c3e-8014-e699b01ac149">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efb061f</samp>

Added identity and balance management to `Transfer.vue` component. The component now uses `useIdentityStore` to access and update the user's identity and balance on different networks and accounts.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at efb061f</samp>

> _`useIdentityStore`_
> _Manages user balance_
> _On KodaDot platform_
  