### PR TITLE
fix: vuetippy hover card updates

### DIFF
--- a/components/collectionDetailsPopover/CollectionDetailsPopover.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopover.vue
@@ -1,17 +1,14 @@
 <template>
   <tippy
-    interactive
-    :animate-fill="false"
     :append-to="body"
     placement="bottom"
     :delay="[showDelay, hideDelay]"
-    data-testid="identity"
-    :on-show="() => (show = true)">
+    data-testid="identity">
     <slot name="content" />
 
     <template #content>
       <div class="popover-container">
-        <CollectionDetailsPopoverContent v-if="show" :nft="nft" />
+        <CollectionDetailsPopoverContent :nft="nft" />
       </div>
     </template>
   </tippy>
@@ -34,8 +31,6 @@ withDefaults(
     hideDelay: 0,
   },
 )
-
-const show = ref(false)
 </script>
 
 <style lang="scss" scoped>

--- a/components/identity/module/IdentityPopover.vue
+++ b/components/identity/module/IdentityPopover.vue
@@ -1,11 +1,8 @@
 <template>
   <tippy
     class="tippy-container"
-    interactive
-    :animate-fill="false"
     :append-to="body"
     boundary="viewport"
-    placement="bottom"
     :delay="0"
     data-testid="identity">
     <slot name="content" />

--- a/components/shared/view/BasicPopup.vue
+++ b/components/shared/view/BasicPopup.vue
@@ -1,10 +1,5 @@
 <template>
-  <tippy
-    class="tippy-container"
-    interactive
-    :animate-fill="false"
-    :placement="placement"
-    :delay="delay">
+  <tippy class="tippy-container" :placement="placement" :delay="delay">
     <slot name="content" />
 
     <template #content>

--- a/plugins/vueTippy.ts
+++ b/plugins/vueTippy.ts
@@ -1,24 +1,27 @@
-// import Vue from 'vue'
-// import VueTippy, { TippyComponent, tippy } from 'vue-tippy'
+import VueTippy, { setDefaultProps } from 'vue-tippy'
+import 'tippy.js/animations/shift-away.css'
 
-// let activeTippyInstance
-// window.addEventListener('scroll', () => {
-//   if (activeTippyInstance && activeTippyInstance.state.isVisible) {
-//     activeTippyInstance.hide()
-//     activeTippyInstance.reference.blur()
-//   }
-// })
-// tippy.setDefaults({
-//   onShow(instance) {
-//     activeTippyInstance = instance
-//   },
-// })
+let activeTippyInstance
+useEventListener('scroll', () => {
+  if (activeTippyInstance && activeTippyInstance.state.isVisible) {
+    activeTippyInstance.hide()
+    activeTippyInstance.reference.blur()
+  }
+})
 
-// Vue.use(VueTippy)
-// Vue.component('VTippy', TippyComponent)
-
-import VueTippy from 'vue-tippy'
+setDefaultProps({
+  onShow(instance) {
+    activeTippyInstance = instance
+  },
+})
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(VueTippy, {})
+  nuxtApp.vueApp.use(VueTippy, {
+    defaultProps: {
+      interactive: true,
+      animateFill: false,
+      animation: 'shift-away',
+      placement: 'bottom',
+    },
+  })
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7590 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/thnaylor)

## Screenshot 📸
- example of vuetippy hover card:
![image](https://github.com/kodadot/nft-gallery/assets/22052693/e159ea64-bdd9-4cb7-b4f8-a4319d9f4640)

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Comments
- readded animations back to vue-tippy. (from what I can remember 😆)
- readded and updated the hide on scroll behaviour. (disabled during the nuxt3 plugin migration)
- moved common props to the plugin. (can be overridden on component level)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf8b222</samp>

Updated the `tippy` component usage and configuration to simplify and standardize the popovers across the app. Removed unnecessary props from the popover components and set them as default props in the `vueTippy` plugin. Upgraded the `vue-tippy` dependency and adjusted the code accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bf8b222</samp>

> _We've simplified the `tippy` props, me hearties_
> _No need to repeat them in each popover_
> _We've moved the defaults to the `vueTippy` plugin_
> _So pull the rope and hoist the sail up over_
