### PR TITLE
fix: make sidebar icons size medium

### DIFF
--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -15,7 +15,7 @@
       class="wallet-asset-footer is-flex is-justify-content-space-between py-5 is-size-7 has-text-grey">
       <!-- light/dark mode -->
       <div class="is-align-items-center" @click="toggleColorMode">
-        <NeoIcon icon="circle-half-stroke" />
+        <NeoIcon icon="circle-half-stroke" size="medium" />
         <span v-if="isDarkMode">{{ $t('profileMenu.lightMode') }}</span>
         <span v-else>{{ $t('profileMenu.darkMode') }}</span>
       </div>
@@ -25,7 +25,7 @@
         <NeoDropdown position="top-left" aria-role="menu" mobile-modal>
           <template #trigger>
             <div class="is-flex is-align-items-center">
-              <NeoIcon icon="globe" class="mr-1" />
+              <NeoIcon icon="globe" size="medium" class="mr-1" />
               <span>{{ $t('profileMenu.language') }}</span>
             </div>
           </template>
@@ -48,7 +48,7 @@
         to="/settings"
         class="has-text-grey is-align-items-center"
         @click="closeModal">
-        <NeoIcon icon="gear" />
+        <NeoIcon icon="gear" size="medium" />
         <span>{{ $t('settings') }}</span>
       </nuxt-link>
     </div>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #7719 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=123PCJXhjb15i6JwVVRGd7KvN2sSNZrtPjr5doJq9oWctoTt)

## Screenshots
![image](https://github.com/kodadot/nft-gallery/assets/22052693/1c55df63-ee79-4178-ac5e-6a3ce9a0e487)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 52373d2</samp>

Improved the UI of the wallet asset menu component by resizing icons. Changed the `iconSize` prop values in `WalletAssetMenu.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 52373d2</samp>

> _We're sailing on the blockchain, me hearties, yo ho ho_
> _We need to see our wallet assets clearly as we go_
> _So grab the `iconSize` and give it a good tweak_
> _And make the UI elements look splendid and unique_
