### PR TITLE
Tests: More tests and some tweaks

### DIFF
--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -21,6 +21,7 @@
               variant="text"
               no-shadow
               class="has-text-weight-bold ml-3"
+              data-testid="cookie-banner-button-accept"
               @click="acceptCookies">
               {{ $t('cookies.accept') }}
             </NeoButton>

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -139,10 +139,12 @@
 
           <NotificationBoxButton
             v-if="account"
+            data-testid="navbar-button-notification"
             :show-label="isMobile"
             @closeBurgerMenu="showMobileNavbar" />
 
           <ShoppingCartButton
+            data-testid="navbar-button-cart"
             :show-label="isMobile"
             @closeBurgerMenu="showMobileNavbar" />
 
@@ -165,6 +167,7 @@
             <div v-if="!account" id="NavProfile">
               <ConnectWalletButton
                 class="button-connect-wallet"
+                data-testid="navbar-button-connect-wallet"
                 variant="connect"
                 @closeBurgerMenu="showMobileNavbar" />
             </div>
@@ -174,7 +177,7 @@
             v-if="!isMobile"
             id="NavProfile"
             :chain="urlPrefix"
-            data-testid="profileDropdown"
+            data-testid="navbar-profile-dropdown"
             @closeBurgerMenu="closeBurgerMenu" />
         </div>
         <!-- END NAV END -->

--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    class="wallet-asset-container mt-4 is-flex is-flex-direction-column is-justify-content-space-between">
+    class="wallet-asset-container mt-4 is-flex is-flex-direction-column is-justify-content-space-between"
+    data-testid="sidebar-wallet-container">
     <div>
       <a
         v-for="menu in menus"
@@ -47,6 +48,7 @@
       <nuxt-link
         to="/settings"
         class="has-text-grey is-align-items-center"
+        data-testid="sidebar-link-settings"
         @click="closeModal">
         <NeoIcon icon="gear" />
         <span>{{ $t('settings') }}</span>

--- a/components/common/NotificationBox/NotificationBoxModal.vue
+++ b/components/common/NotificationBox/NotificationBoxModal.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     v-if="isOpen"
-    class="notification-modal-container theme-background-color border-left is-flex is-flex-direction-column">
+    class="notification-modal-container theme-background-color border-left is-flex is-flex-direction-column"
+    data-testid="notification-modal-container">
     <NeoModalHead
       :title="$t('notification.notifications')"
       @close="closeModal" />

--- a/components/common/shoppingCart/ShoppingCartModal.vue
+++ b/components/common/shoppingCart/ShoppingCartModal.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
     <div
-      class="shopping-cart-modal-container theme-background-color border-left is-flex is-flex-direction-column">
+      class="shopping-cart-modal-container theme-background-color border-left is-flex is-flex-direction-column"
+      data-testid="shopping-cart-modal-container">
       <NeoModalHead
         :title="$t('shoppingCart.title')"
         @close="closeShoppingCart(ModalCloseType.BACK)" />

--- a/components/identity/module/IdentityPopover.vue
+++ b/components/identity/module/IdentityPopover.vue
@@ -7,11 +7,13 @@
     boundary="viewport"
     placement="bottom"
     :delay="0"
-    data-testid="identity">
+    data-testid="identity-tippy-link">
     <slot name="content" />
 
     <template #content>
-      <div class="popover-content-container p-5">
+      <div
+        class="popover-content-container p-5"
+        data-testid="identity-popover-container">
         <IdentityPopoverHeader />
         <IdentityPopoverFooter :sold-items="nftEntities" />
       </div>

--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -16,7 +16,7 @@
           <div class="container image is-64x64 mb-2">
             <Avatar :value="id" />
           </div>
-          <h1 class="title is-2" data-testid="user-identity">
+          <h1 class="title is-2" data-testid="profile-user-identity">
             <a
               v-if="hasBlockExplorer"
               v-safe-href="explorer"
@@ -49,7 +49,8 @@
           </NeoButton>
 
           <div
-            class="is-flex is-align-items-center is-justify-content-center is-flex-wrap-wrap">
+            class="is-flex is-align-items-center is-justify-content-center is-flex-wrap-wrap"
+            data-testid="profile-identity-buttons">
             <NeoButton
               v-safe-href="`https://subscan.io/account/${id}`"
               no-shadow
@@ -104,6 +105,7 @@
           v-for="tab in tabs"
           :key="tab"
           class="is-capitalized"
+          data-testid="profile-tabs"
           :active="activeTab === tab"
           :count="counts[tab]"
           :show-active-check="false"
@@ -138,7 +140,10 @@
         <div
           class="is-flex is-justify-content-space-between pb-4 pt-5 is-align-content-center">
           <div class="is-flex">
-            <FilterButton :label="$t('sort.listed')" url-param="buy_now" />
+            <FilterButton
+              :label="$t('sort.listed')"
+              url-param="buy_now"
+              data-testid="profile-filter-button-buynow" />
             <FilterButton
               v-if="activeTab === 'created'"
               :label="$t('activity.sold')"

--- a/components/profile/activityTab/Activity.vue
+++ b/components/profile/activityTab/Activity.vue
@@ -9,6 +9,7 @@
             <NeoButton
               no-shadow
               rounded
+              data-testid="profile-activity-button-all"
               label="All"
               variant="text"
               @click="activateAllFilter" />
@@ -16,6 +17,7 @@
               v-for="param in filters"
               :key="param"
               :label="param"
+              data-testid="profile-activity-button-filter"
               class="is-capitalized"
               :url-param="param" />
           </div>

--- a/components/profile/activityTab/History.vue
+++ b/components/profile/activityTab/History.vue
@@ -54,6 +54,7 @@
           <HistoryRow
             v-for="item in showList"
             :key="item.ID"
+            data-testid="history-item-row"
             :event="item"
             :variant="variant"
             :with-to-column="isToColumnVisible" />

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -17,6 +17,6 @@ test('Landing Elements', async ({ page }) => {
     await expect(page.getByTestId('explore').last()).toBeVisible()
     await expect(page.getByTestId('search-bar')).toBeVisible()
     await expect(page.getByTestId('footer-container')).toBeVisible()
-    await expect(page.getByTestId('profileDropdown')).toBeVisible()
+    await expect(page.getByTestId('navbar-profile-dropdown')).toBeVisible()
   }
 })

--- a/tests/e2e/custom.ts
+++ b/tests/e2e/custom.ts
@@ -6,12 +6,13 @@ export class Commands {
 
   async e2elogin() {
     await this.page.goto('/e2e-login')
-    //await Promise.all([
-    //    //this.page.waitForRequest('http://localhost:9090/_nuxt/pages/e2e-login.js')
-    //    this.page.waitForResponse(resp => resp.status() === 200)
-    //  ])
-    await this.page.waitForTimeout(10000)
-    await expect(this.page.getByTestId('mockAddress')).toHaveText('true')
+    await expect(this.page.getByTestId('navbar-profile-dropdown')).toBeVisible()
+    await expect(
+      this.page.getByTestId('navbar-button-connect-wallet'),
+    ).toBeHidden()
+    await expect(this.page.getByTestId('mockAddress')).toHaveText('true', {
+      timeout: 15000,
+    })
   }
 
   async copyText(paste: string) {
@@ -19,5 +20,19 @@ export class Commands {
       'navigator.clipboard.readText()',
     )
     expect(clipboardText1).toContain(paste)
+  }
+
+  async scrollDownSlow() {
+    await this.page.evaluate(async () => {
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+      // eslint-disable-next-line no-restricted-syntax
+      for (let i = 0; i < document.body.scrollHeight; i += 100) {
+        window.scrollTo(0, i)
+        await delay(200)
+      }
+    })
+  }
+  async acceptCookies() {
+    await this.page.getByTestId('cookie-banner-button-accept').click()
   }
 }

--- a/tests/e2e/footer.spec.ts
+++ b/tests/e2e/footer.spec.ts
@@ -66,7 +66,7 @@ const footerSocialMediaLinks = [
   //},
   {
     linkName: 'Youtube',
-    linkAddress: 'https://www.youtube.com/channel/UCEULduld5NrqOL49k1KVjoA',
+    linkAddress: 'https://www.youtube.com/channel/UCEULduld5NrqOL49k1KVjoA/',
   },
   //{
   //  linkName: 'Instagram',

--- a/tests/e2e/language.spec.ts
+++ b/tests/e2e/language.spec.ts
@@ -6,7 +6,7 @@ test('Check Language translations', async ({ page }) => {
   await expect(page.getByTestId('mockAddress')).toHaveText('true')
   await page.goto('')
   //DE
-  await page.getByTestId('profileDropdown').click()
+  await page.getByTestId('navbar-profile-dropdown').click()
   await page.getByTestId('sidebar-language').click()
   await expect(page.getByRole('menu')).toBeVisible()
   //await expect(page.getByTestId('skeleton-multiple-balances')).toHaveCount(0)

--- a/tests/e2e/prefix.spec.ts
+++ b/tests/e2e/prefix.spec.ts
@@ -24,3 +24,22 @@ test('Switch network', async ({ page }) => {
   await page.getByTestId('chain-dropdown-rmrk').click()
   await expect(page.getByTestId('chain')).toHaveText('rmrk')
 })
+
+test('Check if RMRK2 NFT URL is correct', async ({ page }) => {
+  //RMRK2
+  await page.goto('/ksm/explore/items?listed=false&search=Spirit+Key+%232112')
+  await page.locator('[class="infinite-scroll-item"]').click()
+  await expect(page).toHaveURL(
+    '/ksm/gallery/15024340-b6e98494bff52d3b1e-SPIRIT-SPIRIT2112-00002112',
+  )
+})
+
+//will not work because filtering on Assethubs still not implemented
+/*
+test('Check if Ahk NFT URL is correct', async ({ page }) => {
+  //AHK
+  await page.goto('/ahk/explore/items?listed=false&search=Susanne')
+  await page.locator('[class="infinite-scroll-item"]').click()
+  await expect(page).toHaveURL('/ahk/gallery/111-2')
+})
+*/

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from './fixtures'
+
+test('Profile Interactions', async ({ page, Commands }) => {
+  const testAddress = 'FSMdmCLv5gFZ87YerB3M8ZSQ58BGHdSnreC4J6znWpqPQK9'
+  await page.goto(`ahk/u/${testAddress}?tab=owned`)
+  await Commands.scrollDownSlow()
+  //test step - will check if buy now has items that are not listed
+  await test.step('Buy Now', async () => {
+    await Commands.acceptCookies()
+    await page.getByTestId('profile-filter-button-buynow').click()
+    await Commands.scrollDownSlow()
+    for (const li of await page.locator('[class="nft-card"]').all()) {
+      await expect(li.getByText('KSM')).toBeVisible()
+    }
+  })
+  //test step
+  await test.step('Activity Tab', async () => {
+    await page.getByTestId('profile-tabs').last().click()
+    //usually sale and buy are active when you enter the page
+    //SALE
+    await page.getByTestId('profile-activity-button-filter').nth(1).click()
+    //checks if sale tag exists
+    await expect(page.getByTestId('history-item-row').first()).toBeVisible()
+    await expect(
+      page.getByTestId('history-item-row').first().filter({ hasText: 'Sale' }),
+    ).toBeVisible()
+    await page.getByTestId('identity-tippy-link').first().hover()
+    await expect(page.getByTestId('identity-popover-container')).toBeVisible()
+    //BUY
+    await page.getByTestId('profile-activity-button-filter').nth(0).click()
+    await page.getByTestId('profile-activity-button-filter').nth(1).click()
+    await page.getByTestId('identity-tippy-link').last().hover()
+    await expect(page.getByTestId('identity-popover-container')).toBeVisible()
+    await expect(
+      page.getByTestId('history-item-row').first().filter({ hasText: 'Buy' }),
+    ).toBeVisible()
+    //TRANSFER
+    await page.getByTestId('profile-activity-button-filter').nth(1).click()
+    await page.getByTestId('profile-activity-button-filter').nth(3).click()
+    await expect(
+      page
+        .getByTestId('history-item-row')
+        .first()
+        .filter({ hasText: 'Transfer' }),
+    ).toBeVisible()
+    //LIST
+    await page.getByTestId('profile-activity-button-filter').nth(3).click()
+    await page.getByTestId('profile-activity-button-filter').nth(4).click()
+    await expect(
+      page.getByTestId('history-item-row').first().filter({ hasText: 'List' }),
+    ).toBeVisible()
+    //ALL
+    await page.getByTestId('profile-activity-button-all').click()
+  })
+  //test step
+  await test.step('Profile Links', async () => {
+    //copy address
+    await page
+      .getByTestId('profile-identity-buttons')
+      .getByText('Copy Address')
+      .click()
+    await Commands.copyText(testAddress)
+    //QR Code
+    await page
+      .getByTestId('profile-identity-buttons')
+      .getByText('QR Code')
+      .click()
+    await expect(page.locator('[class="card-header-title"]')).toBeVisible()
+    await page.keyboard.press('Escape')
+    //Transfer
+    await page
+      .getByTestId('profile-identity-buttons')
+      .getByText('Transfer')
+      .click()
+    await expect(page).toHaveURL(
+      `/ahk/transfer?target=${testAddress}&usdamount=10&donation=true`,
+    )
+  })
+})

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from './fixtures'
+
+test('Sidebar Interactions', async ({ page, Commands }) => {
+  await Commands.e2elogin()
+  await page.goto('/ahk')
+  //click on settings and check if page redirects correctly
+  await page.getByTestId('navbar-profile-dropdown').click()
+  await page.getByTestId('sidebar-link-settings').click()
+  await expect(page).toHaveURL('/settings')
+  await expect(page.getByTestId('sidebar-wallet-container')).toBeHidden()
+})

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from './fixtures'
 
-test('Sidebar Interactions', async ({ page, Commands }) => {
+test('Settings', async ({ page, Commands }) => {
   await Commands.e2elogin()
   await page.goto('/ahk')
   //click on settings and check if page redirects correctly

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from './fixtures'
+
+test('Sidebar Interactions', async ({ page, Commands }) => {
+  await Commands.e2elogin()
+  await page.goto('/ahk')
+  //checks if sidebar closes when clicking another sidebar
+  //profile
+  await page.getByTestId('navbar-profile-dropdown').click()
+  await expect(page.getByTestId('sidebar-wallet-container')).toBeVisible()
+  //cart
+  await page.getByTestId('navbar-button-cart').click()
+  await expect(page.getByTestId('sidebar-wallet-container')).toBeHidden()
+  //notification
+  await page.getByTestId('navbar-button-notification').click()
+  await expect(page.getByTestId('shopping-cart-modal-container')).toBeHidden()
+  //profile
+  await page.getByTestId('navbar-profile-dropdown').click()
+  await expect(page.getByTestId('notification-modal-container')).toBeHidden()
+})


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Test

## Context

- [ ] Related to: #7051 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e02c3b</samp>

This pull request enhances the end-to-end testing of the NFT gallery by adding or updating `data-testid` attributes to various components and elements. It also adds new test files and commands for testing the profile, settings, and sidebar features. It also updates some existing test files to reflect the changes in the components and to add a new test for the RMRK2 NFT URL.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e02c3b</samp>

> _To test the UI with more ease_
> _We added `data-testid`s_
> _To modals and buttons and rows_
> _And links and popovers that show_
> _And wrote some new tests for these_