### PR TITLE
🔧 round 2 collection card number

### DIFF
--- a/components/collection/CollectionDetail.vue
+++ b/components/collection/CollectionDetail.vue
@@ -27,13 +27,13 @@
         <p class="detail-item__title has-text-grey">
           {{ $t('collectionCard.volume') }}
         </p>
-        <CommonTokenMoney :value="collectionTradedVolumeNumber" />
+        <CommonTokenMoney :round="2" :value="collectionTradedVolumeNumber" />
       </div>
       <div class="detail-item has-text-centered column">
         <p class="detail-item__title has-text-grey">
           {{ $t('series.highestSale') }}
         </p>
-        <CommonTokenMoney :value="collectionHighestSalePrice" />
+        <CommonTokenMoney :round="2" :value="collectionHighestSalePrice" />
       </div>
 
       <div class="detail-item has-text-centered column">


### PR DESCRIPTION
- closes #7529

⚠️ this will round number (2 after comma) on all chains

![Screenshot 2023-10-18 at 09-25-26 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/80adde4c-4dc0-46f4-8e06-8883b5e6e806)
