### PR TITLE
fix: consider HTTP 204 as a keywise api error

### DIFF
--- a/services/keywise.ts
+++ b/services/keywise.ts
@@ -1,4 +1,4 @@
-import { $fetch, FetchError } from 'ofetch'
+import { $fetch, FetchError, createFetchError } from 'ofetch'
 import consola from 'consola'
 import { URLS } from '../utils/constants'
 
@@ -6,6 +6,11 @@ const KEYWISE_BASE_URL = URLS.koda.keywise
 
 const keywiseApi = $fetch.create({
   baseURL: KEYWISE_BASE_URL,
+  onResponse(context) {
+    if (context.response.status === 204) {
+      throw createFetchError(context)
+    }
+  },
 })
 
 export type KeyValue = {
@@ -26,7 +31,9 @@ export const getValue = async (
     `resolve/${prefix}-${nftId}`,
   ).catch((error: FetchError<{ message: string }>) => {
     consola.error(
-      `[WORKER::KEYWISE] Unable to GET KEY for reasons ${error?.data?.message}`,
+      `[WORKER::KEYWISE] Unable to GET KEY for reasons ${
+        error?.data?.message || error?.message
+      }`,
     )
     return { url: '' }
   })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Ref #7715 
- [ ] Requires deployment <snek/rubick/worker>

1. the TypeError shown below causes the item media to appear blank until it is successfully displayed
3. Keywise api response status = 204 causes this TypeError

![CleanShot 2023-10-18-Yt9eAuRV@2x](https://github.com/kodadot/nft-gallery/assets/10708802/f0a5f561-5412-4b3c-804b-0c8a5ca82c48)


#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df551c6</samp>

Enhanced keywise service to handle API errors better. Used custom errors and console messages to provide more feedback.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at df551c6</samp>

> _No mercy for the keywise API_
> _We catch the errors and we make them cry_
> _Empty responses are a fatal sin_
> _We throw them back with `createFetchError`_
