### PR TITLE
fix: reduce video payload

### DIFF
--- a/components/carousel/CarouselTypeRelated.vue
+++ b/components/carousel/CarouselTypeRelated.vue
@@ -1,5 +1,9 @@
 <template>
-  <CarouselIndex v-if="nfts" :title="`${$t('nft.related')}`" :nfts="nfts" />
+  <div ref="target"></div>
+  <CarouselIndex
+    v-if="nfts && targetIsVisible"
+    :title="`${$t('nft.related')}`"
+    :nfts="nfts" />
 </template>
 
 <script lang="ts" setup>
@@ -10,4 +14,14 @@ const props = defineProps<{
 }>()
 
 const { nfts } = await useCarouselRelated({ collectionId: props.collectionId })
+
+const target = ref(null)
+const targetIsVisible = ref(false)
+
+useIntersectionObserver(target, ([{ isIntersecting }]) => {
+  // set visible only once
+  if (!targetIsVisible.value && isIntersecting) {
+    targetIsVisible.value = isIntersecting
+  }
+})
 </script>

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -12,7 +12,8 @@
       :disable-operation="disableOperation"
       :player-cover="audioPlayerCover"
       :hover-on-cover-play="audioHoverOnCoverPlay"
-      :parent-hovering="isMediaItemHovering" />
+      :parent-hovering="isMediaItemHovering"
+      :preview="preview" />
     <div
       v-if="isLewd && isLewdBlurredLayer"
       class="nsfw-blur is-capitalized is-flex is-align-items-center is-justify-content-center is-flex-direction-column">
@@ -75,6 +76,7 @@ const props = withDefaults(
     disableOperation?: boolean
     audioPlayerCover?: string
     audioHoverOnCoverPlay?: boolean
+    preview?: boolean // props for video component
   }>(),
   {
     src: '',
@@ -86,6 +88,7 @@ const props = withDefaults(
     isDetail: false,
     placeholder: '',
     disableOperation: undefined,
+    audioPlayerCover: '',
   },
 )
 

--- a/libs/ui/src/components/MediaItem/type/VideoMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/VideoMedia.vue
@@ -6,7 +6,7 @@
       :controls="controls"
       playsinline
       loop
-      autoplay
+      :autoplay="preview"
       :muted="preview"
       :src="animationSrc || src"
       controlslist="nodownload"
@@ -29,7 +29,7 @@ const props = withDefaults(
     animationSrc: '',
     src: '',
     alt: '',
-    preview: true,
+    preview: false,
   },
 )
 

--- a/utils/gallery/media.ts
+++ b/utils/gallery/media.ts
@@ -15,7 +15,7 @@ export function isImageVisible(type: MediaType) {
 }
 
 export async function getMimeType(mediaUrl: string) {
-  const { headers } = await $fetch.raw(mediaUrl)
+  const { headers } = await $fetch.raw(mediaUrl, { method: 'HEAD' })
   return headers.get('content-type') || ''
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Fix #7715
- [x] Fix https://github.com/kodadot/workers/issues/185

three contexts in this PR:
1. readd back the `HEAD` request to mime type. because the `GET` request will take more response size compared to the `HEAD` request
2. disable autoplay video by default. because autoplay video takes more resources compared to non-autoplay video
3. hide the `More From This Collection` section until the user scrolls to the below area. because, if all of the items in the collection are a video and the video is autoplay. total resources will be `video size * n (total items on the carousel)`

IMO, we need an `autoplay` setting on our setting page. This is what it looks like on `x.com`, you can find the settings under accessibility

![Screenshot 2023-10-20 075852](https://github.com/kodadot/nft-gallery/assets/734428/39ccc6a1-c773-4baf-98fa-4a6a4281d041)

and this is on the app store setting

![photo_2023-10-20_10-19-53](https://github.com/kodadot/nft-gallery/assets/734428/b58db5c4-400b-481a-abad-e45358507fca)



#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5223c6</samp>

Improved the performance and user experience of the carousel and media components. Used an intersection observer to render the carousel only when visible, added a `preview` prop to enable video autoplay and mute options, and changed the `getMimeType` function to use the `HEAD` method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f5223c6</samp>

> _To optimize media display_
> _The `getMimeType` function changed its way_
> _It uses `HEAD` instead of `GET`_
> _To fetch the header and not the content_
> _And save some bandwidth along the way_
