### PR TITLE
fix: fullscreen button not working for videos

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -42,7 +42,7 @@
             v-else
             :key="nftImage"
             ref="mediaItemRef"
-            class="gallery-item-media"
+            class="gallery-item-media is-relative"
             :src="nftImage"
             :animation-src="nftAnimation"
             :mime-type="nftMimeType"
@@ -320,7 +320,7 @@ $break-point-width: 930px;
   position: absolute;
   right: 2.75rem;
   top: 2rem;
-  z-index: 1;
+  z-index: 2;
   display: none;
   width: 35px;
   height: 35px;

--- a/components/gallery/GalleryItemPreviewer.vue
+++ b/components/gallery/GalleryItemPreviewer.vue
@@ -4,6 +4,8 @@
     :destroy-on-hide="false"
     :can-cancel="false"
     full-screen
+    append-to-body
+    max-height="100vh"
     root-class="gallery-item-modal"
     content-class="gallery-item-modal-content"
     @close="isFullscreen = false">
@@ -70,6 +72,9 @@ const isFullscreen = useVModel(props, 'value', emit)
     @include desktop {
       left: $fluid-container-padding;
     }
+  }
+  :deep(.gallery-item-modal-content) {
+    width: 100% !important;
   }
   &-container {
     @include ktheme() {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).


👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7744  
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


https://github.com/kodadot/nft-gallery/assets/16473062/0ab9af9e-c6fa-4e90-857d-5e7b36a3edfc



## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8b726c</samp>

Improved the layout and responsiveness of the gallery item modal on different screen sizes. Fixed a bug where the modal close button was hidden by the media.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e8b726c</samp>

> _Sing, O Muse, of the skillful coder who refined the gallery_
> _And made the modal window fit the screens of every size_
> _He added `append-to-body` and `max-height` to `b-modal`_
> _And gave `gallery-item-modal-content` full width to please the eyes_


