### PR TITLE
feat: hidden sidebar text on mobile

### DIFF
--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -17,8 +17,11 @@
       <!-- light/dark mode -->
       <div class="is-align-items-center" @click="toggleColorMode">
         <NeoIcon icon="circle-half-stroke" size="medium" />
-        <span v-if="isDarkMode">{{ $t('profileMenu.lightMode') }}</span>
-        <span v-else>{{ $t('profileMenu.darkMode') }}</span>
+        <span class="is-hidden-mobile">
+          {{
+            $t(isDarkMode ? 'profileMenu.lightMode' : 'profileMenu.darkMode')
+          }}
+        </span>
       </div>
 
       <!-- language -->
@@ -27,7 +30,9 @@
           <template #trigger>
             <div class="is-flex is-align-items-center">
               <NeoIcon icon="globe" size="medium" class="mr-1" />
-              <span>{{ $t('profileMenu.language') }}</span>
+              <span class="is-hidden-mobile">
+                {{ $t('profileMenu.language') }}
+              </span>
             </div>
           </template>
 
@@ -51,7 +56,7 @@
         data-testid="sidebar-link-settings"
         @click="closeModal">
         <NeoIcon icon="gear" size="medium" />
-        <span>{{ $t('settings') }}</span>
+        <span class="is-hidden-mobile">{{ $t('settings') }}</span>
       </nuxt-link>
     </div>
   </div>

--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -30,7 +30,7 @@
       </div>
 
       <!-- language -->
-      <div data-testid="sidebar-language" :class="isMobileDevice ? 'mx-6' : ''">
+      <div data-testid="sidebar-language" :class="{ 'mx-6': isMobileDevice }">
         <NeoDropdown position="top-left" aria-role="menu" mobile-modal>
           <template #trigger>
             <div class="is-flex is-align-items-center">

--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -12,13 +12,7 @@
         <NeoIcon icon="angle-right" size="medium" class="has-text-grey" />
       </a>
     </div>
-    <div
-      class="wallet-asset-footer is-flex py-5 is-size-7 has-text-grey"
-      :class="
-        isMobileDevice
-          ? 'is-justify-content-center'
-          : 'is-justify-content-space-between'
-      ">
+    <div class="wallet-asset-footer is-flex py-5 is-size-7 has-text-grey">
       <!-- light/dark mode -->
       <div class="is-align-items-center" @click="toggleColorMode">
         <NeoIcon icon="circle-half-stroke" size="medium" />
@@ -30,7 +24,7 @@
       </div>
 
       <!-- language -->
-      <div data-testid="sidebar-language" :class="{ 'mx-6': isMobileDevice }">
+      <div data-testid="sidebar-language">
         <NeoDropdown position="top-left" aria-role="menu" mobile-modal>
           <template #trigger>
             <div class="is-flex is-align-items-center">
@@ -70,7 +64,6 @@
 <script setup lang="ts">
 import { NeoDropdown, NeoDropdownItem, NeoIcon } from '@kodadot1/brick'
 import { langsFlags } from '@/utils/config/i18n'
-import { isMobileDevice } from '@/utils/extension'
 
 const { urlPrefix } = usePrefix()
 const { isBasilisk } = useIsChain(urlPrefix)
@@ -134,6 +127,14 @@ const closeModal = () => {
 
 .wallet-asset-footer {
   border-top: 1px solid grey;
+  justify-content: space-between;
+  @include mobile {
+    justify-content: center;
+    // language dropdown menu
+    & > div:nth-child(2) {
+      margin: 0 2rem;
+    }
+  }
 
   & > * {
     cursor: pointer;

--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -24,7 +24,7 @@
       </div>
 
       <!-- language -->
-      <div data-testid="sidebar-language">
+      <div data-testid="sidebar-language" class="language-selector">
         <NeoDropdown position="top-left" aria-role="menu" mobile-modal>
           <template #trigger>
             <div class="is-flex is-align-items-center">
@@ -130,8 +130,7 @@ const closeModal = () => {
   justify-content: space-between;
   @include mobile {
     justify-content: center;
-    // language dropdown menu
-    & > div:nth-child(2) {
+    .language-selector {
       margin: 0 2rem;
     }
   }

--- a/components/common/ConnectWallet/WalletAssetMenu.vue
+++ b/components/common/ConnectWallet/WalletAssetMenu.vue
@@ -13,7 +13,12 @@
       </a>
     </div>
     <div
-      class="wallet-asset-footer is-flex is-justify-content-space-between py-5 is-size-7 has-text-grey">
+      class="wallet-asset-footer is-flex py-5 is-size-7 has-text-grey"
+      :class="
+        isMobileDevice
+          ? 'is-justify-content-center'
+          : 'is-justify-content-space-between'
+      ">
       <!-- light/dark mode -->
       <div class="is-align-items-center" @click="toggleColorMode">
         <NeoIcon icon="circle-half-stroke" size="medium" />
@@ -25,12 +30,12 @@
       </div>
 
       <!-- language -->
-      <div data-testid="sidebar-language">
+      <div data-testid="sidebar-language" :class="isMobileDevice ? 'mx-6' : ''">
         <NeoDropdown position="top-left" aria-role="menu" mobile-modal>
           <template #trigger>
             <div class="is-flex is-align-items-center">
-              <NeoIcon icon="globe" size="medium" class="mr-1" />
-              <span class="is-hidden-mobile">
+              <NeoIcon icon="globe" size="medium" />
+              <span class="is-hidden-mobile ml-1">
                 {{ $t('profileMenu.language') }}
               </span>
             </div>
@@ -65,6 +70,7 @@
 <script setup lang="ts">
 import { NeoDropdown, NeoDropdownItem, NeoIcon } from '@kodadot1/brick'
 import { langsFlags } from '@/utils/config/i18n'
+import { isMobileDevice } from '@/utils/extension'
 
 const { urlPrefix } = usePrefix()
 const { isBasilisk } = useIsChain(urlPrefix)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).


👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7731  
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13rv1SWoLg9Gb3tmvHPZxb7JbVy51BtMziX7k9WQGSJ7Kp3A)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


<img width="379" alt="image" src="https://github.com/kodadot/nft-gallery/assets/16473062/d8430fc4-6027-4e75-9772-d394d73f8124">




## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cec5977</samp>

Improved mobile responsiveness and readability of `WalletAssetMenu.vue` by hiding some button labels and simplifying dark mode text.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cec5977</samp>

> _Oh, we're the crew of the `wallet-asset-menu`_
> _We make it fit on any screen_
> _We hide the labels of the buttons we don't need_
> _And simplify the `dark-mode-toggle` with a ternary_


