### PR TITLE
#7761 activity user insights tab broken

### DIFF
--- a/components/collection/activity/OwnerInsights.vue
+++ b/components/collection/activity/OwnerInsights.vue
@@ -60,7 +60,7 @@ const changeTab = (tab: Tabs) => {
 
 <style lang="scss" scoped>
 .fixed-height {
-  height: 350px;
+  height: 350px !important;
 }
 .limit-height {
   max-height: 290px;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #7761
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13Qx65nLd6SwdtjrRyuoEtp9CKXhF651xdHBPaXcvhwKm4N1)

## Screenshot 📸

- [x] My fix has changed UI

<img width="465" alt="Screen Shot 2023-10-22 at 3 23 42 PM" src="https://github.com/kodadot/nft-gallery/assets/39299315/42bf9b34-5dc1-403a-a750-15398e2c232a">





## Copilot Summary
<!--
copilot:summary
-->
