### PR TITLE
fix: stalled request on chrome

### DIFF
--- a/utils/gallery/media.ts
+++ b/utils/gallery/media.ts
@@ -15,7 +15,12 @@ export function isImageVisible(type: MediaType) {
 }
 
 export async function getMimeType(mediaUrl: string) {
-  const { headers } = await $fetch.raw(mediaUrl, { method: 'HEAD' })
+  const { headers } = await $fetch.raw(mediaUrl, {
+    method: 'HEAD',
+    headers: {
+      'cache-control': 'no-cache',
+    },
+  })
   return headers.get('content-type') || ''
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #7759

Related:
- Can be improved with this also https://github.com/kodadot/workers/issues/155

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)


## Screenshot 📸

TIL, there are still some stalled requests on Chrome

some quick test result on https://canary.kodadot.xyz/ahk/gallery/105-3283225822

| before | after |
|--------|--------|
| ![Screenshot 2023-10-23 161842](https://github.com/kodadot/nft-gallery/assets/734428/986f7524-d35e-49c4-8bc7-8084448455c1) | ![Screenshot 2023-10-23 161826](https://github.com/kodadot/nft-gallery/assets/734428/8073b269-ba11-4cce-af12-c064284ea080) | 





## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 579514e</samp>

Added `cache-control` header to `getMimeType` function to avoid caching content-type. This improves media type detection and gallery rendering.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 579514e</samp>

> _`getMimeType` changed_
> _To avoid caching issues_
> _Gallery refreshed_
