### PR TITLE
fix: ransfer: estimated waiting time - add seconds

### DIFF
--- a/components/shared/TransactionLoader.vue
+++ b/components/shared/TransactionLoader.vue
@@ -58,7 +58,7 @@
           </NeoStepItem>
         </NeoSteps>
         <div v-if="activeStep === 2" class="text-align-center has-text-grey">
-          {{ `Est. waiting time ~ ${estmiatedTimeLeft}` }}
+          {{ `Est. waiting time ~ ${estimatedTimeLeft} seconds` }}
         </div>
         <div v-if="isFinalStep" class="is-flex is-justify-content-center mb-4">
           <NeoButton
@@ -106,17 +106,17 @@ const props = withDefaults(
 const emit = defineEmits(['close', 'update:modelValue'])
 const { $i18n } = useNuxtApp()
 const { urlPrefix } = usePrefix()
-const { blocktime } = useBlockTime()
+const { blockTime } = useBlockTime()
 const { toast } = useToast()
 
-const estmiatedTimeLeft = computed(() => {
+const estimatedTimeLeft = computed(() => {
   switch (props.status) {
     case TransactionStatus.Broadcast:
-      return 3 * blocktime.value
+      return 3 * blockTime.value
     case TransactionStatus.Block:
-      return 2 * blocktime.value
+      return 2 * blockTime.value
     default:
-      return 0
+      return 'few'
   }
 })
 

--- a/composables/useBlockTime.ts
+++ b/composables/useBlockTime.ts
@@ -12,10 +12,10 @@ export default function () {
     rmrk: relayChainBlockTime,
   }
 
-  const blocktime = computed(
+  const blockTime = computed(
     () => chainBlockTimes[urlPrefix.value] ?? paraChainBlockTime,
   )
   return {
-    blocktime,
+    blockTime,
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7788

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/e08960f0-ce30-4bd6-9d47-ffca07394506)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d92274</samp>

Improved the user feedback and consistency of transaction loading messages in the `TransactionLoader` component. Renamed a variable in the `useBlockTime` composable to match the camelCase convention and the component.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7d92274</samp>

> _We are the TransactionLoader, we defy the doom_
> _We useBlockTime to estimate our fate_
> _We fix the typos, we improve the readability_
> _We change the variables, we set the default state_
  