### PR TITLE
fix:Remove discord, substack and add beehiiv, linkedin in footer

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -123,7 +123,7 @@
               </svg>
               <NeoIcon
                 v-else
-                :pack="item.name == 'Swag' ? 'fasr' : 'fab'"
+                :pack="item.pack || item.name == 'Swag' ? 'fasr' : 'fab'"
                 :icon="item.icon" />
             </a>
           </li>
@@ -229,14 +229,15 @@ const socials = [
     icon: 'x-twitter',
   },
   {
-    name: 'Discord',
-    url: 'https://discord.gg/u6ymnbz4PR',
-    icon: 'discord',
+    name: 'Beehiiv',
+    url: 'https://kodadotweeklyroundup.beehiiv.com',
+    icon: 'newspaper',
+    pack: 'fal',
   },
   {
-    name: 'Substack',
-    url: 'https://kodadot.substack.com',
-    icon: 'substack',
+    name: 'Linkedin',
+    url: 'https://www.linkedin.com/company/kodadot',
+    icon: 'linkedin',
   },
   {
     name: 'Medium',


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7801
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/581ae26b-0bfd-47e9-9386-c382e6d32349)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d8634e</samp>

Enhanced the footer menu with more icons and links. Added a `pack` prop to the `NeoIcon` component to support different icon libraries. Added links to the newsletter and Linkedin page, and reordered the menu items in `TheFooter.vue`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0d8634e</samp>

> _Sing, O Muse, of the skillful coder who enhanced the footer menu_
> _With a clever prop for the `NeoIcon` component, a shining adornment_
> _And who added and reordered items, like a wise and orderly ruler_
> _Linking to the newsletter and the Linkedin page, sources of renown and contentment_
  