### PR TITLE
Test: Footer link change and flakiness

### DIFF
--- a/tests/e2e/footer.spec.ts
+++ b/tests/e2e/footer.spec.ts
@@ -53,12 +53,12 @@ const footerSocialMediaLinks = [
     linkAddress: 'https://twitter.com/KodaDot',
   },
   {
-    linkName: 'Discord',
-    linkAddress: 'https://discord.com/invite/u6ymnbz4PR',
+    linkName: 'Beehiiv',
+    linkAddress: 'https://kodadotweeklyroundup.beehiiv.com',
   },
   {
-    linkName: 'Substack',
-    linkAddress: 'https://kodadot.substack.com',
+    linkName: 'Linkedin',
+    linkAddress: 'https://www.linkedin.com/company/kodadot',
   },
   //{
   //  linkName: 'Medium',
@@ -68,10 +68,10 @@ const footerSocialMediaLinks = [
     linkName: 'Youtube',
     linkAddress: 'https://www.youtube.com/channel/UCEULduld5NrqOL49k1KVjoA/',
   },
-  //{
-  //  linkName: 'Instagram',
-  //  linkAddress: 'https://instagram.com/kodadot.xyz',
-  // },
+  {
+    linkName: 'Instagram',
+    linkAddress: 'https://www.instagram.com/kodadot.xyz/',
+  },
   {
     linkName: 'Reddit',
     linkAddress: 'https://www.reddit.com/r/KodaDot/',
@@ -81,7 +81,7 @@ const footerSocialMediaLinks = [
 test('Check Footer Subscription', async ({ page }) => {
   await page.goto('/')
   const footerSubscribe = page.getByTestId('footer-subscribe')
-  await page.getByPlaceholder('jane.doe@kodadot.xyz').fill('a')
+  await footerSubscribe.getByPlaceholder('jane.doe@kodadot.xyz').fill('a')
   await footerSubscribe.locator('button').click()
   await expect(footerSubscribe.locator('.error')).toBeVisible()
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] test

## Context

- [ ] Related #7803 
- [ ] Requires deployment <snek/rubick/worker>


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f8050a</samp>

This pull request updates and fixes the footer and its test. It changes the `tests/e2e/footer.spec.ts` file to reflect the new social media links and the correct subscribe behavior.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f8050a</samp>

> _The footer had links that were old_
> _They did not match the platforms we hold_
> _So we changed them with care_
> _And fixed a test there_
> _Now the footer is shiny and bold_