### PR TITLE
fix: Holders at collection view doesnot have data

### DIFF
--- a/components/collection/activity/ownerInsightsTabs/HolderTab.vue
+++ b/components/collection/activity/ownerInsightsTabs/HolderTab.vue
@@ -81,6 +81,10 @@ import { NeoIcon } from '@kodadot1/brick'
 import NFTsDetaislDropdown from './NFTsDetaislDropdown.vue'
 import { timeAgo } from '@/components/collection/utils/timeAgo'
 
+const props = defineProps<{
+  owners?: Owners
+}>()
+
 const toggleNFTDetails = (holderId: string) => {
   const isOpen = isNFTDetailsOpen.value[holderId]
   isNFTDetailsOpen.value = {
@@ -118,10 +122,6 @@ const isNFTDetailsOpen = ref(
     {},
   ),
 )
-
-const props = defineProps<{
-  owners?: Owners
-}>()
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7808
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/2e0b5174-6b54-40c0-88c2-995d93a77c2f)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2691ac2</samp>

Refactored `HolderTab.vue` component to use `defineProps` for props validation and type safety.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2691ac2</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who made the HolderTab component shine_
> _With defineProps, a gift from Apollo_
> _The god of code and prophecy divine_
  