### PR TITLE
fix: Change polkadothub (beta) on cards to ahp

### DIFF
--- a/components/carousel/module/CarouselInfo.vue
+++ b/components/carousel/module/CarouselInfo.vue
@@ -41,7 +41,7 @@
         inline
         :prefix="item.chain"
         :unit-symbol="unitSymbol" />
-      <p class="is-size-7 chain-name">{{ chainName }}</p>
+      <p class="is-size-7 chain-name is-capitalized">{{ chainName }}</p>
     </div>
   </div>
 </template>
@@ -49,9 +49,8 @@
 <script lang="ts" setup>
 import Money from '@/components/shared/format/Money.vue'
 import type { CarouselNFT } from '@/components/base/types'
-
+import { getChainNameByPrefix } from '@/utils/chain'
 import { useCarouselUrl } from '../utils/useCarousel'
-import { NAMES } from '@/libs/static/src/names'
 import { prefixToToken } from '@/components/common/shoppingCart/utils'
 
 const CollectionDetailsPopover = defineAsyncComponent(
@@ -69,7 +68,7 @@ const { urlOf } = useCarouselUrl()
 const url = inject('itemUrl', 'gallery') as string
 const isCollection = inject<boolean>('isCollection', false)
 const chainName = computed(() => {
-  return NAMES[props.item.chain || urlPrefix.value]
+  return getChainNameByPrefix(props.item.chain || urlPrefix.value)
 })
 
 const showPrice = computed((): boolean => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7809
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/0bbf72fd-523d-4378-aaa6-dd9f5b6f8001)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33e5650</samp>

Improved chain name display in `CarouselInfo.vue` component. Used existing class and function to capitalize and format the chain name based on its prefix.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 33e5650</samp>

> _We're sailing on the blockchain, me hearties, yo ho ho_
> _We need to show the chain name, in the carousel info_
> _We use the `is-capitalized` class and the `getChainNameByPrefix` function_
> _To make it nice and readable, on the count of three, heave-ho!_
  