### PR TITLE
fix: wrong typeface on create page

### DIFF
--- a/components/create/CreateCollection.vue
+++ b/components/create/CreateCollection.vue
@@ -107,7 +107,7 @@
       <hr class="my-6" />
 
       <!-- deposit and balance -->
-      <div class="monospace">
+      <div>
         <div class="is-flex has-text-weight-medium has-text-info">
           <div>{{ $t('mint.deposit') }}:&nbsp;</div>
           <div data-testid="collection-deposit">

--- a/components/create/CreateNft.vue
+++ b/components/create/CreateNft.vue
@@ -163,7 +163,7 @@
       <hr class="my-6" />
 
       <!-- deposit and balance -->
-      <div class="monospace">
+      <div>
         <div class="is-flex has-text-weight-medium has-text-info">
           <div>{{ $t('mint.deposit') }}:&nbsp;</div>
           <div>{{ totalItemDeposit }} {{ chainSymbol }}</div>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7810
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

After fix, the fonts in the screenshot area are back to WorkSans:

![CleanShot 2023-10-26-qXlar0tf@2x](https://github.com/kodadot/nft-gallery/assets/10708802/d5f6d4fc-6fba-492c-b4e2-6aa71a37fc89)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5cc3680</samp>

Removed `monospace` font from deposit and balance elements in `CreateCollection.vue` and `CreateNft.vue`. This improved the UI readability and consistency and facilitated refactoring of common components and styles.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5cc3680</samp>

> _`monospace` gone_
> _UI more consistent_
> _refactoring done_
