### PR TITLE
feat: Generative drop page UI V1

### DIFF
--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -45,21 +45,32 @@
           </div>
           <div class="my-5">
             <div
-              class="is-flex is-justify-content-space-between is-align-items-center">
-              <div v-if="!hasUserMinted">
+              class="is-flex is-justify-content-flex-end is-align-items-center">
+              <div v-if="hasUserMinted" class="is-flex is-align-items-center">
+                <div class="mr-2">
+                  {{ $t('mint.unlockable.nftAlreadyMinted') }}
+                </div>
+                <NeoIcon
+                  icon="circle-check has-text-success"
+                  pack="fass"
+                  class="mr-4" />
+                <NeoButton
+                  class="mb-2 mt-4 mint-button"
+                  :tag="NuxtLink"
+                  :label="$t('mint.unlockable.seeYourNft')"
+                  :to="`/${urlPrefix}/gallery/${hasUserMinted}`"
+                  @click="handleSubmitMint" />
+              </div>
+
+              <div v-else>
                 <NeoButton
                   ref="root"
                   class="mb-2 mt-4 mint-button"
                   variant="k-accent"
                   :disabled="mintButtonDisabled"
-                  label="Mint"
+                  :label="$t('mint.unlockable.mintThisNft')"
                   @click="handleSubmitMint" />
               </div>
-              <nuxt-link v-else :to="`/${urlPrefix}/gallery/${hasUserMinted}`">
-                <p class="title is-size-4">
-                  [{{ $t('mint.unlockable.alreadyMinted') }}]
-                </p>
-              </nuxt-link>
             </div>
           </div>
         </div>
@@ -123,6 +134,7 @@ import { createUnlockableMetadata } from '../unlockable/utils'
 import GenerativePreview from '@/components/collection/drop/GenerativePreview.vue'
 import { DropItem } from '@/params/types'
 import { doWaifu } from '@/services/waifu'
+const NuxtLink = resolveComponent('NuxtLink')
 
 const Loader = defineAsyncComponent(
   () => import('@/components/collection/unlockable/UnlockableLoader.vue'),
@@ -257,7 +269,6 @@ const handleSubmitMint = async () => {
 
   isLoading.value = true
 
-  // return
   try {
     const id = await doWaifu(
       {

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -55,7 +55,7 @@
                   pack="fass"
                   class="mr-4" />
                 <NeoButton
-                  class="mb-2 mt-4 mint-button"
+                  class="my-2 mint-button"
                   :tag="NuxtLink"
                   :label="$t('mint.unlockable.seeYourNft')"
                   :to="`/${urlPrefix}/gallery/${hasUserMinted}`"
@@ -65,7 +65,7 @@
               <div v-else>
                 <NeoButton
                   ref="root"
-                  class="mb-2 mt-4 mint-button"
+                  class="my-2 mint-button"
                   variant="k-accent"
                   :disabled="mintButtonDisabled"
                   :label="$t('mint.unlockable.mintThisNft')"

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="unlockable-container">
-    <Loader v-model="isLoading" :minted="justMinted" />
+    <CollectionUnlockableLoader v-model="isLoading" :minted="justMinted" />
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid">
@@ -136,10 +136,6 @@ import { DropItem } from '@/params/types'
 import { doWaifu } from '@/services/waifu'
 const NuxtLink = resolveComponent('NuxtLink')
 
-const Loader = defineAsyncComponent(
-  () => import('@/components/collection/unlockable/UnlockableLoader.vue'),
-)
-
 const props = defineProps({
   drop: {
     type: Object,
@@ -182,7 +178,7 @@ const totalAvailableMintCount = computed(
 )
 
 watch(accountId, () => {
-  tryAgain({
+  refetchCollectionStats({
     account: accountId.value,
   })
 })
@@ -190,7 +186,7 @@ watch(accountId, () => {
 const {
   data: stats,
   loading: currentMintedLoading,
-  refetch: tryAgain,
+  refetch: refetchCollectionStats,
 } = useGraphql({
   queryName: 'firstNftOwnedByAccountAndCollectionId',
   variables: {
@@ -210,7 +206,7 @@ useSubscriptionGraphql({
     ) {
       id
   }`,
-  onChange: tryAgain,
+  onChange: refetchCollectionStats,
 })
 
 const mintedCount = computed(

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -58,8 +58,7 @@
                   class="my-2 mint-button"
                   :tag="NuxtLink"
                   :label="$t('mint.unlockable.seeYourNft')"
-                  :to="`/${urlPrefix}/gallery/${hasUserMinted}`"
-                  @click="handleSubmitMint" />
+                  :to="`/${urlPrefix}/gallery/${hasUserMinted}`" />
               </div>
 
               <div v-else>

--- a/components/collection/drop/GenerativePreview.vue
+++ b/components/collection/drop/GenerativePreview.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="fixed-size mt-6">
+  <div class="fixed-size mt-6 border">
     <div
       class="fixed-top-left border px-4 py-2 theme-background-color has-z-index-1 no-wrap">
-      {{ $t('mint.unlockable.onlyOneExample') }}
+      {{ $t('mint.unlockable.yourVariation') }}
     </div>
 
     <MediaItem
@@ -10,22 +10,34 @@
       :mime-type="generativeImageUrl ? 'text/html' : ''"
       preview
       is-detail
-      class="border" />
-    <div class="is-flex is-flex-direction-column is-align-items-center">
+      class="border-bottom" />
+    <div class="is-flex is-justify-content-center is-align-items-center py-6">
       <NeoButton
-        class="mt-4"
+        class="rounded border-k-grey hover-button"
         :loading="isLoading"
         no-shadow
+        loading-with-label
         :disabled="!accountId"
         @click="generateNft">
         {{ $t('mint.unlockable.variations') }}
+        <NeoIcon v-if="!isLoading" icon="arrow-rotate-left" pack="fasr" />
       </NeoButton>
+
+      <a
+        v-safe-href="sanitizeIpfsUrl(displayUrl)"
+        class="is-flex is-align-items-center has-text-link fixed-right"
+        rel="nofollow noopener noreferrer"
+        target="_blank"
+        role="link">
+        {{ $t('Img') }}
+        <NeoIcon icon="arrow-up-right" class="ml-1 has-text-link" />
+      </a>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { MediaItem, NeoButton } from '@kodadot1/brick'
+import { MediaItem, NeoButton, NeoIcon } from '@kodadot1/brick'
 import { sanitizeIpfsUrl } from '@/utils/ipfs'
 import { getRandomInt } from '../unlockable/utils'
 import { encodeAddress } from '@polkadot/util-crypto'
@@ -77,16 +89,16 @@ const generateNft = async () => {
 @import '@/assets/styles/abstracts/variables';
 
 .fixed-size {
-  width: 580px;
+  width: 36rem;
   position: relative;
 
   @include mobile {
     width: 100% !important;
     height: 100% !important;
-    max-width: 560px;
+    max-width: 35rem;
   }
   @include tablet-only {
-    width: 768px;
+    width: 48rem;
   }
 }
 
@@ -99,5 +111,21 @@ const generateNft = async () => {
     left: 50%;
     transform: translateX(-50%);
   }
+}
+
+.hover-button:hover {
+  background: unset;
+  @include ktheme() {
+    border-color: theme('border-color') !important;
+  }
+}
+
+.rounded {
+  border-radius: 6rem;
+}
+
+.fixed-right {
+  position: absolute;
+  right: 2rem;
 }
 </style>

--- a/components/collection/drop/GenerativePreview.vue
+++ b/components/collection/drop/GenerativePreview.vue
@@ -13,13 +13,19 @@
       class="border-bottom" />
     <div class="is-flex is-justify-content-center is-align-items-center py-6">
       <NeoButton
-        class="rounded border-k-grey hover-button"
+        class="rounded border-k-grey hover-button fixed-width"
         :loading="isLoading"
         no-shadow
         loading-with-label
         :disabled="!accountId"
         @click="generateNft">
-        {{ $t('mint.unlockable.variations') }}
+        {{
+          $t(
+            isLoading
+              ? 'mint.unlockable.generating'
+              : 'mint.unlockable.variations',
+          )
+        }}
         <NeoIcon v-if="!isLoading" icon="arrow-rotate-left" pack="fasr" />
       </NeoButton>
 
@@ -127,5 +133,9 @@ const generateNft = async () => {
 .fixed-right {
   position: absolute;
   right: 2rem;
+}
+
+.fixed-width {
+  width: 10rem;
 }
 </style>

--- a/locales/en.json
+++ b/locales/en.json
@@ -597,8 +597,12 @@
       "preparing": "Preparing Your Item...",
       "alreadyMinted": "🎉 You already have this NFT, check it here",
       "imageTip": "Examples Of Possible Drop",
-      "variations": "Variations",
+      "variations": "Generate New",
       "onlyOneExample": "Example Of Drop",
+      "mintThisNft": "Mint This NFT",
+      "seeYourNft": "See Your NFT",
+      "nftAlreadyMinted": "NFT Already Minted",
+      "yourVariation": "Your Unique Variation",
       "loader": {
         "shareSuccess": "Share your success",
         "onTwitter": "on Twitter",

--- a/locales/en.json
+++ b/locales/en.json
@@ -598,6 +598,7 @@
       "alreadyMinted": "🎉 You already have this NFT, check it here",
       "imageTip": "Examples Of Possible Drop",
       "variations": "Generate New",
+      "generating": "Generating",
       "onlyOneExample": "Example Of Drop",
       "mintThisNft": "Mint This NFT",
       "seeYourNft": "See Your NFT",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature


  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7838
  - [x] solved some review comments from @roiLeo   https://github.com/kodadot/nft-gallery/pull/7745 

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1310" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/55397d71-aaeb-4bab-a55f-ff05b3bf73c1">

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a3b345</samp>

The pull request enhances the generative NFT minting page by updating the UI, fixing a bug, and adding translations. It renames and redesigns the `GenerativePreview` component, moves and modifies the `mint` button, and adds links to the NFT and IPFS pages. It also changes some keys and values in the `en.json` file.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a3b345</samp>

> _To mint a generative NFT_
> _Some changes were made to the UI_
> _The `GenerativePreview` got a new look_
> _And a link to the IPFS nook_
> _And some keys were added to en.json for free_
  