### PR TITLE
fix: Sidebar randomizes recent nfts on opening

### DIFF
--- a/components/common/ConnectWallet/WalletAssetNfts.vue
+++ b/components/common/ConnectWallet/WalletAssetNfts.vue
@@ -4,7 +4,7 @@
     <p class="has-text-grey is-size-7 mb-2">Recent NFTs</p>
     <div class="nfts">
       <a
-        v-for="nft in nfts.slice(0, 3)"
+        v-for="nft in nfts"
         :key="nft.id"
         v-safe-href="`/${urlPrefix}/gallery/${nft.id}`">
         <MediaItem
@@ -32,6 +32,8 @@ const { data } = useSearchNfts({
       currentOwner_eq: accountId.value,
     },
   ],
+  first: 3,
+  orderBy: 'updatedAt_DESC',
 })
 
 const nfts = ref<NFTWithMetadata[]>([])
@@ -40,14 +42,14 @@ watchEffect(() => {
   if (data.value?.nFTEntities) {
     const nftEntities = data.value.nFTEntities
 
-    nftEntities.forEach(async (nft) => {
+    nftEntities.forEach(async (nft, index) => {
       const nftMetadata = await getNftMetadata(nft, urlPrefix.value)
 
       if (nftMetadata.meta.image) {
         const mimeType = await getMimeType(
           sanitizeIpfsUrl(nftMetadata.meta.image),
         )
-        nfts.value.push({ ...nftMetadata, type: mimeType })
+        nfts.value[index] = { ...nftMetadata, type: mimeType }
       }
     })
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7847
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="346" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/8925c455-27d8-4847-a761-fdaf83d27318">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da07191</samp>

Improved `WalletAssetNfts` component to show all NFTs in a paginated view and reduce server load by fetching only recent NFTs.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at da07191</samp>

> _Sing, O Muse, of the skillful coder who enhanced_
> _The `WalletAssetNfts` component, a glorious display_
> _Of the digital tokens that the wallet address possessed,_
> _And made it easier for the user to survey._
  