### PR TITLE
fix: Remove upcoming section when empty

### DIFF
--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -12,13 +12,6 @@
         <DropCard :drop="drop" />
       </div>
     </div>
-    <div class="title is-2 my-7">
-      {{ $i18n.t('drops.upcoming') }}
-    </div>
-
-    <div class="title is-4 has-text-grey has-text-centered">
-      {{ $i18n.t('drops.noUpcoming') }}
-    </div>
     <hr />
     <div>
       <CreateDropCard />

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -12,7 +12,7 @@
         <DropCard :drop="drop" />
       </div>
     </div>
-    <hr />
+    <hr class="my-7" />
     <div>
       <CreateDropCard />
     </div>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7848
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1304" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/cfd4496d-ccce-4932-8b29-13fe0a2bc57e">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e48f93e</samp>

Removed unused code from `components/drops/Drops.vue`. Simplified the drops page UI by relying on existing components.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e48f93e</samp>

> _No more title, message_
> _`upcomingDrops` code removed_
> _Winter of empty state_
  