### PR TITLE
feat: fixed container width on super wide screen

### DIFF
--- a/layouts/gallery-item-layout.vue
+++ b/layouts/gallery-item-layout.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="min-h-full is-flex is-flex-direction-column is-clipped">
+    <Navbar />
+    <main class="is-flex-grow-1 py-8">
+      <div class="container" :class="{ 'is-fluid': !isFullHD }">
+        <Error
+          v-if="$nuxt.isOffline"
+          :has-img="false"
+          error-subtitle="Please check your network connections"
+          error-title="Offline Detected" />
+        <NuxtPage v-else />
+      </div>
+    </main>
+    <LazyTheFooter />
+    <LazyCookieBanner />
+    <Buy />
+  </div>
+</template>
+
+<script lang="ts" setup>
+const { $config } = useNuxtApp()
+const route = useRoute()
+
+useHead({
+  link: [
+    {
+      hid: 'canonical',
+      rel: 'canonical',
+      href: $config.public.baseUrl + route.path,
+    },
+  ],
+})
+
+const { width } = useWindowSize()
+const isFullHD = computed(() => width.value >= 1440)
+</script>

--- a/pages/[prefix]/detail/[id].vue
+++ b/pages/[prefix]/detail/[id].vue
@@ -1,3 +1,9 @@
 <template>
   <GalleryItem />
 </template>
+
+<script>
+definePageMeta({
+  layout: 'gallery-item-layout',
+})
+</script>

--- a/pages/[prefix]/gallery/[id].vue
+++ b/pages/[prefix]/gallery/[id].vue
@@ -1,3 +1,9 @@
 <template>
   <GalleryItem />
 </template>
+
+<script>
+definePageMeta({
+  layout: 'gallery-item-layout',
+})
+</script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7703 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

The container width of the gallery item is fixed to 1344px when the screen width exceeds 1440px.

![CleanShot 2023-10-28-Kh582O9P@2x](https://github.com/kodadot/nft-gallery/assets/10708802/ff4331bb-26d3-4d07-906c-9644a1dbe780)


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b8ace8</samp>

This pull request introduces a new layout component `gallery-item-layout.vue` that is used for displaying gallery items (NFTs) and their collections with a consistent UI and SEO features. The pull request also applies this layout to the existing pages that show the details and the gallery of NFTs based on their prefix and id.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b8ace8</samp>

> _`gallery-item-layout`_
> _A new component for NFTs_
> _With navbar and footer_
