### PR TITLE
fix: Use more updated card as mockup

### DIFF
--- a/components/create/CreateNftPreview.vue
+++ b/components/create/CreateNftPreview.vue
@@ -2,20 +2,26 @@
   <div class="preview">
     <p class="has-text-weight-bold">{{ $t('mint.nft.preview.title') }}</p>
 
-    <div class="preview-card border k-shadow theme-background-color">
-      <div class="preview-image" :style="{ backgroundImage: `url(${image})` }">
-        <p v-if="!image" class="p-4">{{ $t('mint.nft.preview.uploadArt') }}</p>
+    <div class="preview-card border theme-background-color">
+      <div
+        class="preview-image is-flex is-align-items-center"
+        :style="{ backgroundImage: `url(${image})` }">
+        <p v-if="!image" class="p-4 is-size-7 text-align-center">
+          {{ $t('mint.nft.preview.uploadArt') }}
+        </p>
       </div>
-      <div class="preview-content">
+      <div class="preview-content border-top p-3">
         <p class="has-text-weight-bold is-ellipsis">{{ name || 'Untitled' }}</p>
-        <p class="is-size-7 is-ellipsis">
+        <p class="is-size-7 is-ellipsis has-text-grey">
           {{ collection || $t('mint.nft.preview.noCollection') }}
         </p>
 
         <div
-          class="is-flex is-justify-content-space-between is-align-items-center mt-4">
-          <p class="has-text-weight-bold">{{ price || '$$$' }} {{ symbol }}</p>
-          <p class="is-size-7">{{ NAMES[chain || 'ahk'] || '--' }}</p>
+          class="is-flex is-justify-content-space-between is-align-items-center mt-2">
+          <p class="">{{ price || '$$$' }} {{ symbol }}</p>
+          <p class="is-capitalized is-size-7 has-text-grey">
+            {{ chain ? getChainNameByPrefix(chain) : '--' }}
+          </p>
         </div>
       </div>
     </div>
@@ -23,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { NAMES } from '@kodadot1/static'
+import { getChainNameByPrefix } from '@/utils/chain'
 
 defineProps<{
   name?: string
@@ -41,7 +47,12 @@ defineProps<{
 .preview {
   position: fixed;
   top: 10rem;
-  right: 2rem;
+  left: 75%;
+
+  @include until-fullhd {
+    left: unset;
+    right: 2rem;
+  }
 
   &-card {
     width: 15rem;
@@ -51,15 +62,7 @@ defineProps<{
     background-color: #d7d7d7;
     background-size: cover;
     background-position: center;
-    display: flex;
-    align-items: center;
-    height: 17.5rem;
-    text-align: center;
-    font-size: 0.75rem;
-  }
-
-  &-content {
-    padding: 0.5rem 1rem;
+    height: 15rem;
   }
 
   @include touch() {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7851
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="633" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/8f99adb5-2ae4-47ce-86b4-0caad28b7138">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a6bc8e</samp>

Improved the UI of the NFT creation page by adjusting the preview card component. Added a function to display the correct chain name by `prefix` in `CreateNftPreview.vue`.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4a6bc8e</samp>

> _Oh, we're the crew of the NFT ship, and we sail the blockchain sea_
> _We make our art and we mint our cards, with a preview component_
> _We use a function to get the chain, by the prefix that it has_
> _And we heave and haul on the style and position, on the count of three_
  