### PR TITLE
Show image  as fallback when video is loading or fails (video poster)

### DIFF
--- a/libs/ui/src/components/MediaItem/type/VideoMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/VideoMedia.vue
@@ -8,6 +8,7 @@
       loop
       :autoplay="preview"
       :muted="preview"
+      :poster="src"
       :src="animationSrc || src"
       controlslist="nodownload"
       data-testid="type-video"
@@ -32,7 +33,7 @@ const props = withDefaults(
     preview: false,
   },
 )
-
+// console.log(123,props)
 const controls = computed(() => !props.preview)
 </script>
 

--- a/libs/ui/src/components/MediaItem/type/VideoMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/VideoMedia.vue
@@ -33,7 +33,6 @@ const props = withDefaults(
     preview: false,
   },
 )
-// console.log(123,props)
 const controls = computed(() => !props.preview)
 </script>
 

--- a/utils/gallery/media.ts
+++ b/utils/gallery/media.ts
@@ -15,13 +15,17 @@ export function isImageVisible(type: MediaType) {
 }
 
 export async function getMimeType(mediaUrl: string) {
-  const { headers } = await $fetch.raw(mediaUrl, {
-    method: 'HEAD',
-    headers: {
-      'cache-control': 'no-cache',
-    },
-  })
-  return headers.get('content-type') || ''
+  try {
+    const { headers } = await $fetch.raw(mediaUrl, {
+      method: 'HEAD',
+      headers: {
+        'cache-control': 'no-cache',
+      },
+    })
+    return headers.get('content-type') || ''
+  } catch (error) {
+    return ''
+  }
 }
 
 export async function processMedia(mediaUrl: string) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7741 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6469f9b</samp>

Improved video preview in `MediaItem` component. Added `poster` attribute to `video` element in `VideoMedia.vue` to show a preview image of the video.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6469f9b</samp>

> _`video` element_
> _shows `poster` before play_
> _a glimpse of springtime_
