### PR TITLE
update ParaSpell XCM SDK -> v3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@kodadot1/sub-api": "0.2.0-rc.0",
     "@nuxtjs/apollo": "5.0.0-alpha.6",
     "@nuxtjs/i18n": "8.0.0-rc.3",
-    "@paraspell/sdk": "^3.0.1",
+    "@paraspell/sdk": "^3.0.4",
     "@pinia/nuxt": "^0.5.1",
     "@polkadot/api": "^10.9.1",
     "@polkadot/api-base": "^10.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: 8.0.0-rc.3
         version: 8.0.0-rc.3(rollup@2.79.1)(vue@3.3.6)
       '@paraspell/sdk':
-        specifier: ^3.0.1
-        version: 3.0.1(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.130.1)(@polkadot/types@10.9.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.130.1)(@polkadot/types@10.9.1)
       '@pinia/nuxt':
         specifier: ^0.5.1
         version: 0.5.1(rollup@2.79.1)(typescript@4.9.5)(vue@3.3.6)
@@ -4172,8 +4172,8 @@ packages:
       '@open-web3/orml-type-definitions': 2.0.1
     dev: false
 
-  /@paraspell/sdk@3.0.1(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.130.1)(@polkadot/types@10.9.1):
-    resolution: {integrity: sha512-IK2XyAY+L1KnIvarfXgxx9EVFZxQGxrvf4PHcMbafy834ApQ21jECJLM866sS4/WykGALxtXmS3g6S4namh9lA==}
+  /@paraspell/sdk@3.0.4(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.130.1)(@polkadot/types@10.9.1):
+    resolution: {integrity: sha512-Fzli++1NBuBKwppeZpJuMILs4TpNtu+TZ7YdzyAKETyZHCws7Og/pRauyRtxmFDnY9rwkvdtLBSkd6pXbxI7BA==}
     peerDependencies:
       '@polkadot/api': ^10.6.1
       '@polkadot/api-base': ^10.6.1


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- PR bumps ParaSpell XCM SDK version. The update does not contain any breaking changes. It fixes transfers for Parachains with Large IDs. For example Moonbeam can now be used without an issue.
- Our original issue: https://github.com/paraspell/xcm-sdk/issues/36

This can be useful if KodaDot plans to expand teleport feature to new Parachains.

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] tested on main net in localhost mode (With KodaDot app) 

#### Did your issue had any of the "$" label on it?

- Not relevant

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- Not relevant

## Copilot Summary
copilot:summary

copilot:poem
