### PR TITLE
feat: remove hover action on touch device

### DIFF
--- a/components/items/ItemsGrid/ItemsGrid.vue
+++ b/components/items/ItemsGrid/ItemsGrid.vue
@@ -18,6 +18,7 @@
           v-if="!isTokenEntity(entity)"
           :nft="entity"
           :hide-media-info="hideMediaInfo"
+          :hide-action="hideNFTHoverAction"
           :variant="
             slotProps.isMobileVariant || slotProps.grid === 'small'
               ? 'minimal'
@@ -27,6 +28,7 @@
           v-else
           :entity="entity"
           :hide-media-info="hideMediaInfo"
+          :hide-action="hideNFTHoverAction"
           :variant="
             slotProps.isMobileVariant || slotProps.grid === 'small'
               ? 'minimal'
@@ -88,6 +90,8 @@ const emit = defineEmits(['total', 'loading'])
 const isLoading = ref(true)
 
 const hideMediaInfo = computed(() => route.query?.art_view === 'true')
+const isTouchDevice = useMediaQuery('(hover: none)')
+const hideNFTHoverAction = computed(() => isTouchDevice.value)
 
 const gotoPage = (page: number) => {
   currentPage.value = page

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -19,7 +19,7 @@
     bind-key="to"
     :media-player-cover="mediaPlayerCover"
     media-hover-on-cover-play>
-    <template #action>
+    <template v-if="!hideAction" #action>
       <div v-if="!isOwner && Number(nft?.price)" class="is-flex">
         <NeoButton
           :label="buyLabel"
@@ -80,6 +80,7 @@ const props = defineProps<{
   nft: NFTWithMetadata
   variant?: NftCardVariant
   hideMediaInfo?: boolean
+  hideAction?: boolean
 }>()
 
 const { showCardIcon, cardIcon } = useNftCardIcon(computed(() => props.nft))

--- a/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
+++ b/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
@@ -20,7 +20,7 @@
     bind-key="to"
     :media-player-cover="mediaPlayerCover"
     media-hover-on-cover-play>
-    <template #action>
+    <template v-if="!hideAction" #action>
       <div v-if="!isOwner && isAvailableToBuy" class="is-flex">
         <NeoButton
           :label="buyLabel"
@@ -95,6 +95,7 @@ const props = defineProps<{
   entity: TokenEntity
   variant?: NftCardVariant
   hideMediaInfo?: boolean
+  hideAction?: boolean
 }>()
 
 const {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7870 
- [ ] Requires deployment <snek/rubick/worker>

Clicking on the NFT card now takes you directly to the detail page instead of the hover action buttons.

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3488b5</samp>

This pull request adds a feature to hide the buy button for NFTs on touch devices, where hovering is not possible. It uses a `hideAction` prop and a media query hook in the `ItemsGridImage` and `ItemsGridImageTokenEntity` components, which are used by the `ItemsGrid` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e3488b5</samp>

> _No buy button on the touch screen_
> _Hide the action, unleash the dream_
> _Media player, your NFT supreme_
> _`ItemsGridImage`, the component of doom_
