### PR TITLE
feat: Create picture for Generative art collection

### DIFF
--- a/services/capture.ts
+++ b/services/capture.ts
@@ -1,0 +1,19 @@
+import { $fetch, FetchError } from 'ofetch'
+const CAPTURE_BASE_URL = 'https://capture.kodadot.workers.dev'
+
+const api = $fetch.create({
+  baseURL: CAPTURE_BASE_URL,
+})
+
+export const makeScreenshot = async (url: string) => {
+  const value = await api<any>('/screenshot', {
+    method: 'POST',
+    body: {
+      url,
+    },
+  }).catch((error: FetchError) => {
+    throw new Error(`[Capture::makeScreenshot] failed ${error.message}`)
+  })
+
+  return value
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7844
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="930" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/02ff1b86-62c5-4fd4-8375-b5eb8bfb7871">

<img width="1127" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/8efcca39-24d8-4155-b1e6-ea470a50eba1">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4b57c8</samp>

This pull request adds a feature to capture and upload generative art to IPFS from the drop page. It uses a new service module `capture.ts` that makes use of a Cloudflare worker to take screenshots of URLs. It also updates the `Generative.vue` component to handle the image fetching and display.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4b57c8</samp>

> _We capture the web in a flash of light_
> _We pin the image to the IPFS_
> _We face the doom of the centralized might_
> _We mint our drops with the VImage finesse_
  