### PR TITLE
Go back to main menu after selecting chain

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -96,8 +96,13 @@
             </div>
           </nuxt-link>
 
-          <MobileExpandableSection v-if="isMobile" :title="$t('explore')">
-            <NavbarExploreOptions @closeMobileNavbar="showMobileNavbar" />
+          <MobileExpandableSection
+            v-if="isMobile"
+            v-slot="{ onCloseMobileSubMenu }"
+            :title="$t('explore')">
+            <NavbarExploreOptions
+              @closeMobileNavbar="showMobileNavbar"
+              @closeMobileSubMenu="onCloseMobileSubMenu" />
           </MobileExpandableSection>
           <ExploreDropdown
             v-else
@@ -129,9 +134,12 @@
 
           <MobileExpandableSection
             v-if="isMobile"
+            v-slot="{ onCloseMobileSubMenu }"
             no-padding
             :title="$t('chainSelect', [chainName])">
-            <NavbarChainOptions @select="handleMobileChainSelect" />
+            <NavbarChainOptions
+              @select="handleMobileChainSelect"
+              @closeMobileSubMenu="onCloseMobileSubMenu" />
           </MobileExpandableSection>
 
           <ChainSelectDropdown
@@ -153,7 +161,16 @@
 
           <template v-if="isMobile">
             <template v-if="!account">
-              <MobileLanguageOption @closeLanguageOption="showMobileNavbar" />
+              <MobileExpandableSection
+                v-slot="{ onCloseMobileSubMenu }"
+                class="mobile-language"
+                :no-padding="true"
+                :title="$t('profileMenu.language')"
+                icon="globe">
+                <MobileLanguageOption
+                  @closeLanguageOption="showMobileNavbar"
+                  @closeMobileSubMenu="onCloseMobileSubMenu" />
+              </MobileExpandableSection>
               <ColorModeButton class="navbar-item" />
             </template>
             <div

--- a/components/navbar/MobileExpandableSection.vue
+++ b/components/navbar/MobileExpandableSection.vue
@@ -20,6 +20,8 @@
 <script lang="ts" setup>
 import { NeoIcon } from '@kodadot1/brick'
 
+const route = useRoute()
+
 defineProps({
   title: {
     type: String,
@@ -44,4 +46,10 @@ const isOpened = ref(false)
 const close = (): void => {
   isOpened.value = false
 }
+watch(
+  () => route.path,
+  () => {
+    isOpened.value = false
+  },
+)
 </script>

--- a/components/navbar/MobileExpandableSection.vue
+++ b/components/navbar/MobileExpandableSection.vue
@@ -12,15 +12,13 @@
       {{ title }}
     </div>
     <div :class="{ 'navbar-item': !noPadding }" class="navbar-item-body">
-      <slot />
+      <slot @closeMobileSubMenu="close" />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { NeoIcon } from '@kodadot1/brick'
-
-const route = useRoute()
 
 defineProps({
   title: {
@@ -46,10 +44,4 @@ const isOpened = ref(false)
 const close = (): void => {
   isOpened.value = false
 }
-watch(
-  () => route.path,
-  () => {
-    isOpened.value = false
-  },
-)
 </script>

--- a/components/navbar/MobileLanguageOption.vue
+++ b/components/navbar/MobileLanguageOption.vue
@@ -1,32 +1,26 @@
 <template>
-  <MobileExpandableSection
-    class="mobile-language"
-    :no-padding="true"
-    :title="$t('profileMenu.language')"
-    icon="globe">
-    <a
-      v-for="lang in langsFlags"
-      :key="lang.value"
-      :value="lang.value"
-      aria-role="listitem"
-      has-link
-      class="navbar-item"
-      :class="{ 'is-active': $i18n.locale === lang.value }"
-      @click="setUserLang(lang.value)">
-      <div>{{ lang.flag }} {{ lang.label }}</div>
-    </a>
-  </MobileExpandableSection>
+  <a
+    v-for="lang in langsFlags"
+    :key="lang.value"
+    :value="lang.value"
+    aria-role="listitem"
+    has-link
+    class="navbar-item"
+    :class="{ 'is-active': $i18n.locale === lang.value }"
+    @click="setUserLang(lang.value)">
+    <div>{{ lang.flag }} {{ lang.label }}</div>
+  </a>
 </template>
 
 <script lang="ts" setup>
 import { langsFlags } from '@/utils/config/i18n'
-import MobileExpandableSection from '@/components/navbar/MobileExpandableSection.vue'
 
 const { $i18n } = useNuxtApp()
-const emit = defineEmits(['closeLanguageOption'])
+const emit = defineEmits(['closeLanguageOption', 'closeMobileSubMenu'])
 
 const setUserLang = (value: string) => {
   $i18n.locale.value = value
   emit('closeLanguageOption')
+  emit('closeMobileSubMenu')
 }
 </script>

--- a/components/navbar/NavbarChainOptions.vue
+++ b/components/navbar/NavbarChainOptions.vue
@@ -20,12 +20,13 @@ const { setUrlPrefix } = usePrefix()
 const { redirectAfterChainChange } = useChainRedirect()
 const preferencesStore = usePreferencesStore()
 
-const emits = defineEmits(['select'])
+const emits = defineEmits(['select', 'closeMobileSubMenu'])
 
 const changeChain = (newChain) => {
   preferencesStore.setNotificationBoxCollapse(false)
   setUrlPrefix(newChain)
   redirectAfterChainChange(newChain)
   emits('select')
+  emits('closeMobileSubMenu')
 }
 </script>

--- a/components/navbar/NavbarExploreOptions.vue
+++ b/components/navbar/NavbarExploreOptions.vue
@@ -5,13 +5,13 @@
         :to="`/${urlPrefix}/explore/items`"
         class="menu-item mr-6"
         data-testid="explore-items"
-        @click="emit('closeMobileNavbar')">
+        @click="emitClose">
         {{ $t('items') }}
       </nuxt-link>
       <nuxt-link
         :to="`/${urlPrefix}/explore/collectibles`"
         class="menu-item mr-6"
-        @click="emit('closeMobileNavbar')">
+        @click="emitClose">
         {{ $t('collections') }}
       </nuxt-link>
       <span class="menu-item is-disabled has-text-k-shade">
@@ -45,7 +45,7 @@
 const { urlPrefix, setUrlPrefix } = usePrefix()
 const { availableChains } = useChain()
 
-const emit = defineEmits(['closeMobileNavbar'])
+const emit = defineEmits(['closeMobileNavbar', 'closeMobileSubMenu'])
 
 const prefixToExploreOptionName = {
   ahk: 'KusamaHub',
@@ -66,9 +66,13 @@ const filteredChains = computed(() => {
     }))
 })
 
+const emitClose = () => {
+  emit('closeMobileNavbar')
+  emit('closeMobileSubMenu')
+}
 const setSelectedChain = (value) => {
   setUrlPrefix(value)
-  emit('closeMobileNavbar')
+  emitClose()
   navigateTo(`/${value}/explore/collectibles`)
 }
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #7883 
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca99f20</samp>

Improved mobile navigation by closing the expandable section on page change. Added a `route` constant and a `watch` function to `MobileExpandableSection.vue`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca99f20</samp>

> _`Route` to the dark abyss_
> _`Watch` for the demons' kiss_
> _Close the gate of mobile hell_
> _Escape the expandable spell_
