### PR TITLE
fix: Remove "beta" from Chain selection menu options + reorder

### DIFF
--- a/libs/static/src/chains.ts
+++ b/libs/static/src/chains.ts
@@ -42,13 +42,13 @@ export const CHAINS: Config<ChainProperties> = {
 export const DEFAULT_PREFIX: Prefix = 'ksm'
 
 export const chainPrefixes: Prefix[] = [
-  'bsx',
+  'ahp',
+  'ahk',
   'rmrk',
   'snek',
   'ksm',
-  'ahk',
   'dot',
-  'ahp',
+  'bsx',
   // 'movr',
   // 'glmr',
 ]

--- a/libs/static/src/names.ts
+++ b/libs/static/src/names.ts
@@ -5,9 +5,9 @@ export const NAMES: Record<Prefix, string> = {
   rmrk: 'Kusama',
   ksm: 'RMRK2',
   snek: 'Snek [Rococo]',
-  ahk: 'KusamaHub [Beta]',
+  ahk: 'KusamaHub',
   dot: 'Polkadot',
-  ahp: 'PolkadotHub [Beta]',
+  ahp: 'PolkadotHub',
   // glmr: 'Moonbeam [Beta]',
   // movr: 'Moonriver [Beta]',
 }

--- a/tests/e2e/createcollection.spec.ts
+++ b/tests/e2e/createcollection.spec.ts
@@ -41,7 +41,7 @@ test('Check if chain change works using the dropdown', async ({ page }) => {
   await expect(page.getByTestId('mockAddress')).toHaveText('true')
   await page.goto('/create/collection')
   expect(page.getByTestId('collection-chain')).toBeVisible()
-  await page.getByTestId('collection-chain').selectOption('KusamaHub [Beta]')
+  await page.getByTestId('collection-chain').selectOption('KusamaHub')
   //Check if balances and deposits shows
   await expect(page.getByTestId('collection-deposit')).toBeVisible({
     timeout: 30000,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7911
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="264" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/e2175721-6737-4eca-b6be-ebfa9a610081">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a13671</samp>

Updated chain names and prefixes in the UI and the tests. Removed `[Beta]` suffix from `ahk` and `ahp` chains and reordered chain prefixes in `chains.ts` to match the UI.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5a13671</samp>

> _`chain-prefix` order_
> _aligned with UI names_
> _a clear improvement_
  