### PR TITLE
fix: Mint phase time is off for generative drop

### DIFF
--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="unlockable-container">
     <CollectionUnlockableLoader v-model="isLoading" :minted="justMinted" />
-    <CountdownTimer />
-    <div class="container is-fluid">
+    <div class="container is-fluid border-top">
       <div class="columns is-desktop">
         <div class="column is-half-desktop mobile-padding">
           <UnlockableCollectionInfo
@@ -91,7 +90,6 @@
 </template>
 
 <script setup lang="ts">
-import CountdownTimer from '@/components/collection/unlockable/CountdownTimer.vue'
 import UnlockableCollectionInfo from '@/components/collection/unlockable/UnlockableCollectionInfo.vue'
 import UnlockableSlider from '@/components/collection/unlockable/UnlockableSlider.vue'
 import UnlockableTag from '@/components/collection/unlockable/UnlockableTag.vue'


### PR DESCRIPTION

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7884 

  ## Screenshot 📸

  - [x] My fix has changed UI
<img width="1229" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/2e7b6453-3a50-49e4-8b1e-387692793c13">
