### PR TITLE
Test: Explore test refactor and small prefix test addition

### DIFF
--- a/components/explore/ExploreTabs.vue
+++ b/components/explore/ExploreTabs.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="has-addons is-flex is-align-items-center" data-testid="tabs">
+  <div
+    class="has-addons is-flex is-align-items-center"
+    data-testid="gallery-explore-tabs">
     <TabOnCollection v-if="route.name?.includes('prefix-collection-id')" />
     <TabOnExplore v-else />
   </div>

--- a/tests/e2e/custom.ts
+++ b/tests/e2e/custom.ts
@@ -32,6 +32,16 @@ export class Commands {
       }
     })
   }
+  async scrollDownAndStop() {
+    await this.page.evaluate(async () => {
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+      // eslint-disable-next-line no-restricted-syntax
+      for (let i = 0; i < 800; i += 100) {
+        window.scrollTo(0, i)
+        await delay(200)
+      }
+    })
+  }
   async acceptCookies() {
     await this.page.getByTestId('cookie-banner-button-accept').click()
   }

--- a/tests/e2e/explore.spec.ts
+++ b/tests/e2e/explore.spec.ts
@@ -1,88 +1,67 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures'
 
-const SORT_SAMPLES = ['blockNumber_DESC', 'updatedAt_ASC']
+const collectionRoutes = [
+  '/rmrk/explore/collectibles',
+  '/ahk/explore/collectibles',
+]
 
-test.describe('Explore collections', async () => {
-  const routes = ['/rmrk/explore/collectibles', '/bsx/explore/collectibles']
-
-  for (const route of routes)
-    test(`Collections explore at ${route}`, async ({ page }) => {
-      await page.goto(route)
-      await testCollections(page)
+for (const route of collectionRoutes) {
+  test(`Collections explore at ${route}`, async ({ page, Commands }) => {
+    await page.goto(route)
+    const tabs = page.getByTestId('gallery-explore-tabs').nth(1)
+    await expect(tabs.getByText('Collections')).toBeVisible()
+    await expect(tabs.getByText('Items')).toBeVisible()
+    const sortDropdown = page.getByTestId('explore-sort-dropdown').nth(1)
+    await sortDropdown.click()
+    await sortDropdown.getByText('Newest').click()
+    await page.keyboard.press('Escape')
+    await Commands.scrollDownAndStop()
+    await page.waitForFunction(() => {
+      const images = Array.from(document.querySelectorAll('img'))
+      return images.every((img) => img.complete)
     })
-})
-
-const testCollections = async (page) => {
-  const tabs = await page.getByTestId('tabs')
-  await tabs.nth(2).waitFor()
-
-  await tabs.nth(2).getByText('Collections')
-  await tabs.nth(2).getByText('Items')
-
-  const exploreSort = await page.getByTestId('explore-sort-dropdown')
-  await exploreSort.nth(1).click()
-
-  await Promise.all(SORT_SAMPLES.map((sort) => page.$(`[value="${sort}"]`)))
-
-  await Promise.all(
-    [...Array(5).keys()].map(async (i) => {
-      const collectionIndex = await page.getByTestId(`collection-index-${i}`)
-      await collectionIndex.waitFor()
-    }),
-  )
-}
-
-test.describe('Explore items', async () => {
-  const routes = ['/rmrk/explore/items?page=1', '/bsx/explore/items?page=1']
-
-  for (const route of routes)
-    test(`Items explore at ${route}`, async ({ page }) => {
-      await page.goto(route)
-      await testItems(page)
+    await expect(page.getByTestId('collection-index-0').first()).toBeVisible({
+      timeout: 10000,
     })
-})
-
-const testItems = async (page) => {
-  const tabs = await page.getByTestId('tabs')
-  await tabs.nth(2).waitFor()
-
-  await tabs.nth(2).getByText('Collections')
-  await tabs.nth(2).getByText('Items')
-
-  const expandSearch = await page.getByTestId('expand-search')
-  await expandSearch.click()
-  const inputMin = await expandSearch.getByTestId('input-min')
-  await inputMin.type('100')
-  const btnApply = await expandSearch.getByTestId('apply').first()
-
-  await Promise.all([
-    page.waitForResponse(
-      (resp) => resp.url().includes('squid.subsquid.io') && resp.ok(),
-    ),
-    btnApply.click(),
-  ])
-
-  const exploreSort = await page.getByTestId('explore-sort-dropdown').nth(1)
-  await exploreSort.click()
-  await page.getByTestId('price_ASC').nth(1).click()
-
-  const btnAsc = await page.$('[value="price_ASC"]')
-  await btnAsc?.click()
-
-  //active and deactive buy now, since its buggy
-  await page.getByTestId('filter-checkbox-buynow').nth(1).click()
-  await page.getByTestId('filter-checkbox-buynow').nth(1).click()
-
-  await page.waitForResponse(
-    (resp) => resp.url().includes('image') && resp.status() === 200,
-  )
-  await page.waitForLoadState()
-
-  await expect(page.getByTestId('card-money').first()).toBeVisible({
-    timeout: 10000,
+    expect(
+      page.locator('[class="collection-detail__name"]').first().innerText,
+    ).not.toContain('')
   })
-  const firstItem = (await page.getByTestId('card-money')).first()
-  const moneyStr = await firstItem.innerText()
-  const money = +moneyStr.split(' ')[0]
-  expect(money).toBeGreaterThanOrEqual(100)
+}
+const routes = ['/rmrk/explore/items?page=1', '/ahk/explore/items?page=1']
+
+for (const route of routes) {
+  test(`Explore Items on ${route}`, async ({ page, Commands }) => {
+    await page.goto(route)
+    const tabs = page.getByTestId('gallery-explore-tabs').nth(1)
+    await expect(tabs.getByText('Collections')).toBeVisible()
+    await expect(tabs.getByText('Items')).toBeVisible()
+    const expandSearch = await page.getByTestId('expand-search')
+    await expandSearch.click()
+    const inputMin = await expandSearch.getByTestId('input-min')
+    await inputMin.type('100')
+    const btnApply = await expandSearch.getByTestId('apply').first()
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('squid.subsquid.io') && resp.ok(),
+      ),
+      btnApply.click(),
+    ])
+    const exploreSort = await page.getByTestId('explore-sort-dropdown').nth(1)
+    await exploreSort.click()
+    await page.getByTestId('price_ASC').nth(1).click()
+    const btnAsc = await page.$('[value="price_ASC"]')
+    await btnAsc?.click()
+    //active and deactive buy now, since its buggy
+    await page.getByTestId('filter-checkbox-buynow').nth(1).click()
+    await page.getByTestId('filter-checkbox-buynow').nth(1).click()
+    await Commands.scrollDownAndStop()
+    await expect(page.getByTestId('card-money').first()).toBeVisible({
+      timeout: 10000,
+    })
+    const firstItem = (await page.getByTestId('card-money')).first()
+    const moneyStr = await firstItem.innerText()
+    const money = +moneyStr.split(' ')[0]
+    expect(money).toBeGreaterThanOrEqual(100)
+  })
 }

--- a/tests/e2e/explore.spec.ts
+++ b/tests/e2e/explore.spec.ts
@@ -43,7 +43,7 @@ for (const route of routes) {
     const btnApply = await expandSearch.getByTestId('apply').first()
     await Promise.all([
       page.waitForResponse(
-        (resp) => resp.url().includes('squid.subsquid.io') && resp.ok(),
+        (resp) => resp.url().includes('imagedelivery.net') && resp.ok(),
       ),
       btnApply.click(),
     ])

--- a/tests/e2e/prefix.spec.ts
+++ b/tests/e2e/prefix.spec.ts
@@ -34,12 +34,9 @@ test('Check if RMRK2 NFT URL is correct', async ({ page }) => {
   )
 })
 
-//will not work because filtering on Assethubs still not implemented
-/*
 test('Check if Ahk NFT URL is correct', async ({ page }) => {
   //AHK
   await page.goto('/ahk/explore/items?listed=false&search=Susanne')
   await page.locator('[class="infinite-scroll-item"]').click()
   await expect(page).toHaveURL('/ahk/gallery/111-2')
 })
-*/


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Test

## Context

- [x] Related #7826 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd4550a</samp>

This pull request improves the code quality and functionality of the e2e tests for the explore feature. It removes unused and faulty code, fixes a potential conflict with the `data-testid` attribute, adds a new method to simulate scrolling, and refactors the tests for collections and items using fixtures and parameters.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fd4550a</samp>

> _We explore the dark collections of the web_
> _We scroll down and stop to see the horror_
> _We change the tabs and filters to escape the dread_
> _But we can't avoid the doom of `data-testid`_