### PR TITLE
fix: Status of Minting when collection is minted out

### DIFF
--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -18,7 +18,9 @@
                 custom-class="avatar-image" />
             </div>
 
-            <TimeTag :drop-start-time="drop.dropStartTime" />
+            <TimeTag
+              :drop-start-time="drop.dropStartTime"
+              :ended="availableCount === 0" />
           </div>
         </section>
       </div>
@@ -45,10 +47,7 @@
             <div class="is-flex is-flex-direction-column">
               <div class="has-text-grey">Available</div>
 
-              <div v-if="isFreeDrop">
-                {{ drop.max - drop.minted }}/{{ drop.max }}
-              </div>
-              <div v-else>{{ drop.minted }}/{{ drop.max }}</div>
+              <div>{{ availableCount }}/{{ drop.max }}</div>
             </div>
             <div class="is-flex is-flex-direction-column">
               <span class="has-text-grey">{{ $t('price') }}</span>
@@ -119,6 +118,14 @@ const correctUrlPrefix = computed(() => {
 
 const isFreeDrop = computed(() => {
   return !Number(props.drop?.price)
+})
+
+const availableCount = computed(() => {
+  if (isFreeDrop.value) {
+    return props.drop.max - props.drop.minted
+  } else {
+    return props.drop.minted
+  }
 })
 
 onMounted(async () => {

--- a/components/drops/TimeTag.vue
+++ b/components/drops/TimeTag.vue
@@ -1,12 +1,11 @@
 <template>
   <div
     class="tag-container is-flex border py-1 px-2 is-justify-content-space-between is-align-items-center">
-    <div class="image is-24x24 has-text-centered">
+    <div v-if="!ended" class="image is-24x24 has-text-centered">
       <img v-if="isMintingLive" src="/drop/unlockable-pulse.svg" />
       <NeoIcon v-else icon="calendar-day" variant="k-grey" />
     </div>
-
-    <span class="pr-1">{{ displayText }}</span>
+    {{ displayText }}
   </div>
 </template>
 
@@ -15,6 +14,7 @@ import { NeoIcon } from '@kodadot1/brick'
 const { $i18n } = useNuxtApp()
 const props = defineProps<{
   dropStartTime: Date
+  ended: boolean
 }>()
 
 const isMintingLive = computed(() => {
@@ -23,7 +23,9 @@ const isMintingLive = computed(() => {
 })
 
 const displayText = computed(() => {
-  if (isMintingLive.value) {
+  if (props.ended) {
+    return $i18n.t('drops.mintingEnded')
+  } else if (isMintingLive.value) {
     return $i18n.t('drops.mintingLive')
   } else {
     const options = {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1379,6 +1379,7 @@
     "upcoming": "Upcoming",
     "noUpcoming": "Nothing  here yet...",
     "mintingLive": "Minting Live",
+    "mintingEnded": "Ended",
     "mintedBy": "Minted By",
     "mintPerAddress": "Each address can mint only once",
     "recentMints": "Recent NFT Mints"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7925
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1220" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/47688bf8-fc0e-4409-be92-598395b686a5">

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e993ea3</samp>

Improved the `DropCard` and `TimeTag` components to show the drop status and the number of NFTs left in a drop. Added a new translation for the `TimeTag` component.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e993ea3</samp>

> _The drops are ending, time is running out_
> _`TimeTag` shows the status with a shout_
> _No more NFTs left, the `DropCard` is clear_
> _Refactored logic, code is easier to hear_
  