### PR TITLE
feat: new teleport page

### DIFF
--- a/components/teleport/NetworkDropdown.vue
+++ b/components/teleport/NetworkDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full">
+  <div>
     <NeoDropdown class="w-full">
       <template #trigger="{ active }">
         <NeoButton

--- a/components/teleport/NetworkDropdown.vue
+++ b/components/teleport/NetworkDropdown.vue
@@ -2,24 +2,22 @@
   <div class="w-full">
     <NeoDropdown class="w-full">
       <template #trigger="{ active }">
-        <div class="is-flex is-flex-items-center">
-          <NeoButton
-            no-shadow
-            expanded
-            rounded
-            class="black-border"
-            :icon="active ? 'chevron-up' : 'chevron-down'">
-            <div class="is-flex is-flex-items-center">
-              <img
-                class="mr-2"
-                width="24"
-                height="24"
-                :src="selectedNetwork?.icon"
-                alt="icon" />
-              <span>{{ selectedNetwork?.label }}</span>
-            </div>
-          </NeoButton>
-        </div>
+        <NeoButton
+          no-shadow
+          expanded
+          rounded
+          class="dropdown-trigger"
+          :icon="active ? 'chevron-up' : 'chevron-down'">
+          <div class="is-flex is-flex-items-center">
+            <img
+              class="mr-2"
+              width="24"
+              height="24"
+              :src="selectedNetwork?.icon"
+              alt="icon" />
+            <span>{{ selectedNetwork?.label }}</span>
+          </div>
+        </NeoButton>
       </template>
       <NeoDropdownItem
         v-for="opt in options"
@@ -49,6 +47,7 @@ const props = defineProps<{
   options: NetworkOption[]
   value: string
 }>()
+
 const emit = defineEmits(['select'])
 
 const selectedNetwork = computed<NetworkOption | undefined>(() => {
@@ -59,9 +58,11 @@ const selectedNetwork = computed<NetworkOption | undefined>(() => {
 <style lang="scss" scoped>
 @import '@/assets/styles/abstracts/variables';
 
-.black-border {
+.dropdown-trigger {
+  height: 2.5rem;
+
   @include ktheme() {
-    border: 1px solid theme('black');
+    border: 1px solid theme('border-color');
   }
 }
 </style>

--- a/components/teleport/NetworkDropdown.vue
+++ b/components/teleport/NetworkDropdown.vue
@@ -20,7 +20,7 @@
         </NeoButton>
       </template>
       <NeoDropdownItem
-        v-for="opt in options"
+        v-for="opt in validateOptions"
         :key="opt.value"
         :active="value === opt.value"
         @click="emit('select', opt.value)">
@@ -52,6 +52,9 @@ const emit = defineEmits(['select'])
 
 const selectedNetwork = computed<NetworkOption | undefined>(() => {
   return props.options.find((opt) => opt.value === props.value)
+})
+const validateOptions = computed(() => {
+  return props.options.filter((opt) => !opt.disabled?.value)
 })
 </script>
 

--- a/components/teleport/NetworkDropdown.vue
+++ b/components/teleport/NetworkDropdown.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="w-full">
+    <NeoDropdown class="w-full">
+      <template #trigger="{ active }">
+        <div class="is-flex is-flex-items-center">
+          <NeoButton
+            no-shadow
+            expanded
+            rounded
+            class="black-border"
+            :icon="active ? 'chevron-up' : 'chevron-down'">
+            <div class="is-flex is-flex-items-center">
+              <img
+                class="mr-2"
+                width="24"
+                height="24"
+                :src="selectedNetwork?.icon"
+                alt="icon" />
+              <span>{{ selectedNetwork?.label }}</span>
+            </div>
+          </NeoButton>
+        </div>
+      </template>
+      <NeoDropdownItem
+        v-for="opt in options"
+        :key="opt.value"
+        :active="value === opt.value"
+        @click="emit('select', opt.value)">
+        <div class="is-flex is-flex-items-center">
+          <img class="mr-2" width="24" height="24" :src="opt.icon" alt="icon" />
+          <span>{{ opt.label }}</span>
+        </div>
+      </NeoDropdownItem>
+    </NeoDropdown>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { NeoButton, NeoDropdown, NeoDropdownItem } from '@kodadot1/brick'
+import { Chain } from '@/utils/teleport'
+
+type NetworkOption = {
+  label: string
+  value: Chain
+  disabled?: ComputedRef<boolean>
+  icon: string
+}
+const props = defineProps<{
+  options: NetworkOption[]
+  value: string
+}>()
+const emit = defineEmits(['select'])
+
+const selectedNetwork = computed<NetworkOption | undefined>(() => {
+  return props.options.find((opt) => opt.value === props.value)
+})
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/styles/abstracts/variables';
+
+.black-border {
+  @include ktheme() {
+    border: 1px solid theme('black');
+  }
+}
+</style>

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -475,6 +475,10 @@ const sendXCM = async () => {
   @include ktheme() {
     background: theme('k-shade');
   }
+
+  @include mobile {
+    width: 254px;
+  }
 }
 
 .networks {

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -61,6 +61,7 @@
         <NeoInput
           v-model="amount"
           root-class="w-full"
+          input-class="pr-2"
           step="0.01"
           type="number"
           placeholder="Enter Amount"

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="mt-6 mb-7 mx-auto teleport-container">
+  <section class="mx-auto teleport-container">
     <Loader v-model="isLoading" />
     <h1 class="is-size-3 has-text-weight-bold">
       {{ $t('teleport.page') }}
@@ -24,11 +24,24 @@
           @select="onChainChange" />
       </div>
 
-      <img
-        src="/teleport/arrow.svg"
-        class="network-arrow"
-        alt="arrow"
-        width="32px" />
+      <div class="network-arrow is-flex has-text-color">
+        <svg viewBox="0 0 39 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <line y1="5.5" x2="35" y2="5.5" stroke="currentColor" />
+          <line y1="11.5" x2="35" y2="11.5" stroke="currentColor" />
+          <line
+            x1="30.3536"
+            y1="1.14645"
+            x2="38.3536"
+            y2="9.14645"
+            stroke="currentColor" />
+          <line
+            x1="38.3293"
+            y1="8.87629"
+            x2="30.3293"
+            y2="15.8763"
+            stroke="currentColor" />
+        </svg>
+      </div>
 
       <div class="w-full is-relative">
         <div class="network-title">{{ $t('teleport.destination') }}</div>
@@ -98,7 +111,7 @@
         v-safe-href="explorerUrl"
         target="_blank"
         rel="nofollow noopener noreferrer"
-        class="short-address">
+        class="has-text-k-blue">
         {{ shortAddress(toAddress) }}
       </a>
     </div>
@@ -433,61 +446,18 @@ const sendXCM = async () => {
 }
 </script>
 <style lang="scss" scoped>
-@import '@/assets/styles/abstracts/variables.scss';
+@import '@/assets/styles/abstracts/variables';
 
 .teleport-container {
   @include tablet {
     width: 454px;
+    margin-top: 80px;
+    margin-bottom: 94px;
   }
 
-  .short-address,
-  .max-button {
-    @include ktheme() {
-      color: theme('k-blue');
-    }
-  }
-}
-
-.input-wrapper {
-  @include ktheme() {
-    border: 1px solid theme('border-color');
-  }
-
-  .token {
-    width: 16rem;
-    position: relative;
-
-    .token-value {
-      position: absolute;
-      left: 0;
-      transform: translateX(-110%);
-
-      @include ktheme() {
-        color: theme('k-grey');
-      }
-    }
-  }
-
-  .transfer-amount {
-    border: none;
-
-    @include ktheme() {
-      color: theme('text-color');
-      border-right: 1px solid theme('border-color');
-      background: theme('background-color');
-    }
-
-    background: transparent;
-    padding: 0 0.5rem;
-    height: 54px;
-    outline: none;
-    width: 100%;
-
-    &::-webkit-outer-spin-button,
-    &::-webkit-inner-spin-button {
-      -webkit-appearance: none !important;
-    }
-    -moz-appearance: textfield;
+  @include mobile {
+    padding-top: 40px;
+    padding-bottom: 40px;
   }
 }
 
@@ -527,16 +497,35 @@ const sendXCM = async () => {
 }
 
 .network-arrow {
-  width: 32px;
-  flex-basis: 32px;
+  min-width: 32px;
+  line-height: 1;
 
   @include tablet {
     margin: 0 1rem;
   }
 
   @include mobile {
+    position: relative;
     transform: rotate(90deg);
-    margin: 10px 0;
+    height: 32px;
+    margin-top: 2px;
+    margin-bottom: 40px;
+
+    &:before {
+      content: '';
+      position: absolute;
+      top: 12px;
+      left: 0;
+      width: 8px;
+      height: 8px;
+      background: $white;
+    }
+  }
+}
+
+.dark-mode {
+  .network-arrow:before {
+    background: $background-dark;
   }
 }
 </style>

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="mx-auto teleport-container">
+  <form class="mx-auto teleport-container" @submit.prevent="sendXCM">
     <Loader v-model="isLoading" />
     <h1 class="is-size-3 has-text-weight-bold">
       {{ $t('teleport.page') }}
@@ -105,8 +105,8 @@
       expanded
       :loading="isLoading"
       :disabled="isDisabledButton"
-      variant="k-accent"
-      @click="sendXCM" />
+      native-type="submit"
+      variant="k-accent" />
 
     <div>
       {{ $t('teleport.receiveValue', [amount || 0, currency, toChainLabel]) }}
@@ -118,7 +118,7 @@
         {{ shortAddress(toAddress) }}
       </a>
     </div>
-  </section>
+  </form>
 </template>
 
 <script setup lang="ts">

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -54,7 +54,7 @@
 
     <NeoField class="mt-5">
       <template #label>
-        <div class="font-normal">{{ $t('teleport.amount') }}</div>
+        <div class="has-text-weight-normal">{{ $t('teleport.amount') }}</div>
       </template>
 
       <div class="is-relative w-full">
@@ -101,7 +101,8 @@
           : 'Proceed To Confirmation'
       "
       size="large"
-      class="is-size-6 submit-button my-5 w-full"
+      class="is-size-6 my-5"
+      expanded
       :loading="isLoading"
       :disabled="isDisabledButton"
       variant="k-accent"
@@ -529,9 +530,5 @@ const sendXCM = async () => {
   .network-arrow:before {
     background: $background-dark;
   }
-}
-
-.font-normal {
-  font-weight: normal;
 }
 </style>

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -78,7 +78,7 @@
         v-if="myBalance !== undefined"
         class="is-size-7 is-flex is-justify-content-end is-align-items-center">
         <span class="is-flex is-align-items-center">
-          <span class="mr-2">{{ $t('balance') }}:</span
+          <span class="mr-2">{{ $t('general.balance') }}:</span
           >{{ myBalanceWithoutDivision.toFixed(4) }}{{ currency }}
         </span>
         <NeoButton

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -58,7 +58,6 @@
       <div class="is-relative amount-input">
         <NeoInput
           v-model="amount"
-          class=""
           step="0.01"
           type="number"
           placeholder="Enter Amount"

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -12,7 +12,7 @@
       >{{ $t('teleport.howItWorks') }}
     </a>
 
-    <hr class="divider my-5" />
+    <hr class="my-5" />
 
     <div
       class="is-flex is-align-items-center is-justify-content-space-between networks">
@@ -468,16 +468,6 @@ const sendXCM = async () => {
   position: absolute;
   right: 2rem;
   top: 0.75rem;
-}
-
-.divider {
-  @include ktheme() {
-    background: theme('k-shade');
-  }
-
-  @include mobile {
-    width: 254px;
-  }
 }
 
 .networks {

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -52,17 +52,19 @@
       </div>
     </div>
 
-    <div class="is-flex is-flex-direction-column">
-      <div class="mb-3 mt-5">{{ $t('teleport.amount') }}</div>
+    <NeoField class="mt-5">
+      <template #label>
+        <div class="font-normal">{{ $t('teleport.amount') }}</div>
+      </template>
 
-      <div class="is-relative amount-input">
+      <div class="is-relative w-full">
         <NeoInput
           v-model="amount"
+          root-class="w-full"
           step="0.01"
           type="number"
           placeholder="Enter Amount"
           :min="0" />
-
         <div class="is-absolute-right">
           <span
             v-if="totalFiatValue"
@@ -72,23 +74,23 @@
           {{ currency }}
         </div>
       </div>
+    </NeoField>
 
-      <div
-        v-if="myBalance !== undefined"
-        class="is-size-7 is-flex is-justify-content-end is-align-items-center">
-        <span class="is-flex is-align-items-center">
-          <span class="mr-2">{{ $t('general.balance') }}:</span
-          >{{ myBalanceWithoutDivision.toFixed(4) }}{{ currency }}
-        </span>
-        <NeoButton
-          no-shadow
-          rounded
-          size="small"
-          class="ml-2"
-          @click="handleMaxClick"
-          >{{ $t('teleport.max') }}</NeoButton
-        >
-      </div>
+    <div
+      v-if="myBalance !== undefined"
+      class="is-size-7 is-flex is-justify-content-end is-align-items-center">
+      <span class="is-flex is-align-items-center">
+        <span class="mr-2">{{ $t('general.balance') }}:</span
+        >{{ myBalanceWithoutDivision.toFixed(4) }}{{ currency }}
+      </span>
+      <NeoButton
+        no-shadow
+        rounded
+        size="small"
+        class="ml-2"
+        @click="handleMaxClick"
+        >{{ $t('teleport.max') }}</NeoButton
+      >
     </div>
 
     <NeoButton
@@ -142,7 +144,7 @@ import {
 import { txCb } from '@/utils/transactionExecutor'
 import NeoInput from '~/libs/ui/src/components/NeoInput/NeoInput.vue'
 import NetworkDropdown from './NetworkDropdown.vue'
-import { NeoButton } from '@kodadot1/brick'
+import { NeoButton, NeoField } from '@kodadot1/brick'
 import { blockExplorerOf } from '@/utils/config/chain.config'
 import { simpleDivision } from '@/utils/balance'
 import { useFiatStore } from '@/stores/fiat'
@@ -466,10 +468,6 @@ const sendXCM = async () => {
   top: 0.75rem;
 }
 
-.amount-input {
-  margin-bottom: 10px;
-}
-
 .divider {
   @include ktheme() {
     background: theme('k-shade');
@@ -530,5 +528,9 @@ const sendXCM = async () => {
   .network-arrow:before {
     background: $background-dark;
   }
+}
+
+.font-normal {
+  font-weight: normal;
 }
 </style>

--- a/layouts/teleport-layout.vue
+++ b/layouts/teleport-layout.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="min-h-full is-flex is-flex-direction-column is-clipped">
+    <Navbar />
+    <main class="is-flex-grow-1">
+      <div class="container is-fluid">
+        <Error
+          v-if="$nuxt.isOffline"
+          :has-img="false"
+          error-subtitle="Please check your network connections"
+          error-title="Offline Detected" />
+        <NuxtPage v-else />
+      </div>
+    </main>
+    <LazyTheFooter />
+    <LazyCookieBanner />
+    <Buy />
+  </div>
+</template>
+
+<script lang="ts" setup>
+const { $config } = useNuxtApp()
+const route = useRoute()
+
+useHead({
+  link: [
+    {
+      hid: 'canonical',
+      rel: 'canonical',
+      href: $config.public.baseUrl + route.path,
+    },
+  ],
+})
+</script>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1038,6 +1038,11 @@
   },
   "teleport": {
     "page": "Teleport",
+    "subtitle": "Easy Asset Teleportation from One Network to Another",
+    "howItWorks": "How It Works?",
+    "source": "Source chain",
+    "destination": "Destination",
+    "amount": "Asset Amount",
     "from": "From",
     "to": "To",
     "max": "Max",

--- a/pages/[prefix]/teleport.vue
+++ b/pages/[prefix]/teleport.vue
@@ -1,3 +1,9 @@
 <template>
   <LazyTeleport />
 </template>
+
+<script lang="ts" setup>
+definePageMeta({
+  layout: 'teleport-layout',
+})
+</script>

--- a/public/teleport/arrow.svg
+++ b/public/teleport/arrow.svg
@@ -1,6 +1,0 @@
-<svg width="39" height="17" viewBox="0 0 39 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <line y1="5.5" x2="35" y2="5.5" stroke="black"/>
-    <line y1="11.5" x2="35" y2="11.5" stroke="black"/>
-    <line x1="30.3536" y1="1.14645" x2="38.3536" y2="9.14645" stroke="black"/>
-    <line x1="38.3293" y1="8.87629" x2="30.3293" y2="15.8763" stroke="black"/>
-</svg>

--- a/public/teleport/arrow.svg
+++ b/public/teleport/arrow.svg
@@ -1,0 +1,6 @@
+<svg width="39" height="17" viewBox="0 0 39 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <line y1="5.5" x2="35" y2="5.5" stroke="black"/>
+    <line y1="11.5" x2="35" y2="11.5" stroke="black"/>
+    <line x1="30.3536" y1="1.14645" x2="38.3536" y2="9.14645" stroke="black"/>
+    <line x1="38.3293" y1="8.87629" x2="30.3293" y2="15.8763" stroke="black"/>
+</svg>

--- a/utils/chain.ts
+++ b/utils/chain.ts
@@ -43,20 +43,21 @@ export const getAvailablePrefix = (prefix: string): string => {
     : ''
 }
 
-export const availablePrefixWithIcon = () => {
-  const menus = {
-    ahk: '/token/kusama_asset_hub.svg',
-    ahp: '/token/polkadot_asset_hub.svg',
-    bsx: '/token/bsx.svg',
-    snek: '/token/bsx.svg',
-    ksm: '/token/ksm.svg',
-    rmrk: '/token/ksm.svg',
-  }
+export const chainIcons = {
+  ahk: '/token/kusama_asset_hub.svg',
+  ahp: '/token/polkadot_asset_hub.svg',
+  bsx: '/token/bsx.svg',
+  snek: '/token/bsx.svg',
+  ksm: '/token/ksm.svg',
+  rmrk: '/token/ksm.svg',
+  dot: '/token/dot.svg',
+}
 
+export const availablePrefixWithIcon = () => {
   return availablePrefixes().map((chain) => {
     return {
       ...chain,
-      icon: menus[chain.value] || '',
+      icon: chainIcons[chain.value] || '',
     }
   })
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7363 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![CleanShot 2023-11-05-D5WCxjMR@2x](https://github.com/kodadot/nft-gallery/assets/10708802/80da4d41-a80f-4889-90a9-02cf19359ba4)


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44b9d94</samp>

This pull request enhances the teleport feature by adding new components, icons, input fields and localization strings. It modifies the `Teleport.vue` component and its related files, such as `NetworkDropdown.vue`, `locales/en.json` and `utils/chain.ts`. The goal is to improve the user interface and experience of teleporting assets across networks.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 44b9d94</samp>

> _To teleport assets with ease_
> _We added some dropdowns and keys_
> _`NetworkDropdown.vue`_
> _And `locales/en.json` too_
> _And some icons for networks like `dot` and `kusama`_
