### PR TITLE
fix: Profile not full width

### DIFF
--- a/layouts/full-width-no-footer.vue
+++ b/layouts/full-width-no-footer.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="min-h-full is-flex is-flex-direction-column is-clipped">
+    <Navbar />
+    <main class="is-flex-grow-1 py-8">
+      <Error
+        v-if="$nuxt.isOffline"
+        :has-img="false"
+        error-subtitle="Please check your network connections"
+        error-title="Offline Detected" />
+      <NuxtPage v-else />
+    </main>
+    <LazyCookieBanner />
+    <Buy />
+  </div>
+</template>
+
+<script lang="ts" setup>
+const { $config } = useNuxtApp()
+const route = useRoute()
+
+useHead({
+  link: [
+    {
+      hid: 'canonical',
+      rel: 'canonical',
+      href: $config.public.baseUrl + route.path,
+    },
+  ],
+})
+</script>

--- a/pages/[prefix]/u/[id].vue
+++ b/pages/[prefix]/u/[id].vue
@@ -10,7 +10,7 @@
 const route = useRoute()
 
 definePageMeta({
-  layout: 'no-footer',
+  layout: 'full-width-no-footer',
 })
 
 useSeoMeta({


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7947
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1119" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/7721aca9-b4fe-4a66-af34-dc2734f78f7c">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90df3f8</samp>

The pull request introduces a new layout component `full-width-no-footer.vue` that excludes the footer from the page and adds some other features. The pull request also applies this layout to the user profile page `pages/[prefix]/u/[id].vue` to improve its appearance and functionality.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 90df3f8</samp>

> _New layout added_
> _`full-width-no-footer.vue`_
> _No footer, more space_
  