### PR TITLE
fix: Spacing between sections in gallery item

### DIFF
--- a/assets/styles/abstracts/_variables.scss
+++ b/assets/styles/abstracts/_variables.scss
@@ -183,5 +183,6 @@ $spacing-values: (
   "6": 2rem,
   "7": 2.5rem,
   "8": 3rem,
+  "10": 4rem,
   "auto": auto
 ) !default;

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -538,3 +538,8 @@ a.has-text-grey {
 .w-half {
   width: 50%;
 }
+
+
+.mt-10 {
+  margin-top: 4rem !important;
+}

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -538,8 +538,3 @@ a.has-text-grey {
 .w-half {
   width: 50%;
 }
-
-
-.mt-10 {
-  margin-top: 4rem !important;
-}

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -144,11 +144,11 @@
 
     <CarouselTypeRelated
       v-if="nft?.collection.id"
-      class="mt-8"
+      class="mt-10"
       :collection-id="nft?.collection.id"
       data-testid="carousel-related" />
 
-    <CarouselTypeVisited class="mt-8" />
+    <CarouselTypeVisited class="mt-10" />
   </section>
 </template>
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #7948
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1362" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/dc00a670-2d2c-4fb0-abf1-4e8eb1a283d8">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1645fa2</samp>

Added a new utility class `.mt-10` for vertical spacing and applied it to the `GalleryItem.vue` component. This improves the layout and readability of the NFT details and carousels.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1645fa2</samp>

> _`GalleryItem` changed_
> _`.mt-10` adds more space_
> _Autumn leaves breathe out_
  