### PR TITLE
sync deposit with copies

### DIFF
--- a/components/create/CreateNft.vue
+++ b/components/create/CreateNft.vue
@@ -170,7 +170,7 @@
       <div>
         <div class="is-flex has-text-weight-medium has-text-info">
           <div>{{ $t('mint.deposit') }}:&nbsp;</div>
-          <div>{{ totalItemDeposit }} {{ chainSymbol }}</div>
+          <div>{{ deposit }} {{ chainSymbol }}</div>
         </div>
         <div class="is-flex">
           <div>{{ $t('general.balance') }}:&nbsp;</div>
@@ -196,10 +196,7 @@
         <p class="is-size-7">
           <span
             v-dompurify-html="
-              $t('mint.requiredDeposit', [
-                `${totalItemDeposit} ${chainSymbol}`,
-                'NFT',
-              ])
+              $t('mint.requiredDeposit', [`${deposit} ${chainSymbol}`, 'NFT'])
             " />
           <a
             href="https://hello.kodadot.xyz/multi-chain/fees"
@@ -323,6 +320,10 @@ watch(currentChain, () => {
 // deposit stuff
 const { balance, totalItemDeposit, chainSymbol, chain } =
   useDeposit(currentChain)
+
+const deposit = computed(() =>
+  (Number(totalItemDeposit.value) * form.copies).toFixed(4),
+)
 
 // create nft
 const transactionStatus = ref<


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Context

- [x] Closes #7935


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46aadec</samp>

Updated deposit logic and UI for minting multiple NFT copies in `CreateNft.vue` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 46aadec</samp>

> _We're minting NFTs on the blockchain_
> _We need to calculate the right deposit_
> _We use the `form.copies` to get the sum_
> _And then we show it with the `deposit` prop_
