### PR TITLE
fix: disable verbatimModuleSyntax

### DIFF
--- a/components/collectionDetailsPopover/CollectionDetailsPopover.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopover.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts" setup>
-import { CarouselNFT } from '../base/types'
+import type { CarouselNFT } from '../base/types'
 import CollectionDetailsPopoverContent from './CollectionDetailsPopoverContent.vue'
 
 const body = ref(document.body)

--- a/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopoverContent.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script lang="ts" setup>
-import { CarouselNFT } from '../base/types'
+import type { CarouselNFT } from '../base/types'
 import {
   useBuyEvents,
   useCollectionDetails,

--- a/components/search/SearchSuggestion.vue
+++ b/components/search/SearchSuggestion.vue
@@ -256,8 +256,8 @@ import { useDebounceFn } from '@vueuse/core'
 import seriesInsightList from '@/queries/rmrk/subsquid/seriesInsightList.graphql'
 import { denyList } from '@/utils/constants'
 import {
-  CollectionWithMeta,
-  NFTWithMeta,
+  type CollectionWithMeta,
+  type NFTWithMeta,
 } from '@/components/rmrk/service/scheme'
 import { sanitizeIpfsUrl } from '@/utils/ipfs'
 import { logError, mapNFTorCollectionMetadata } from '@/utils/mappers'

--- a/components/shared/QRCode.vue
+++ b/components/shared/QRCode.vue
@@ -8,7 +8,8 @@
 </template>
 
 <script setup lang="ts">
-import QrcodeVue, { Level } from 'qrcode.vue'
+import type { Level } from 'qrcode.vue'
+import QrcodeVue from 'qrcode.vue'
 
 withDefaults(
   defineProps<{

--- a/libs/ui/src/components/NeoButton/NeoButton.vue
+++ b/libs/ui/src/components/NeoButton/NeoButton.vue
@@ -25,8 +25,8 @@
 
 <script lang="ts" setup>
 import type { ComputedOptions, ConcreteComponent, MethodOptions } from 'vue'
+import type { NeoButtonVariant } from '../../types'
 import { OButton } from '@oruga-ui/oruga-next'
-import { NeoButtonVariant } from '@kodadot1/brick'
 
 withDefaults(
   defineProps<{

--- a/libs/ui/src/components/NeoNftCard/NFTMediaInfo.vue
+++ b/libs/ui/src/components/NeoNftCard/NFTMediaInfo.vue
@@ -44,11 +44,11 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { NftCardVariant } from '@kodadot1/brick'
+import { type NftCardVariant } from '@kodadot1/brick'
 
 import CommonTokenMoney from '@/components/shared/CommonTokenMoney.vue'
 import { getChainNameByPrefix } from '@/utils/chain'
-import { NeoNFT } from './types'
+import type { NeoNFT } from './types'
 
 const props = withDefaults(
   defineProps<{

--- a/libs/ui/src/components/NeoNftCard/NFTMediaInfoStacked.vue
+++ b/libs/ui/src/components/NeoNftCard/NFTMediaInfoStacked.vue
@@ -62,11 +62,11 @@
 </template>
 
 <script lang="ts" setup>
+import type { NeoNFT } from './types'
 import { computed } from 'vue'
-import { NeoButton, NftCardVariant } from '@kodadot1/brick'
+import { NeoButton, type NftCardVariant } from '@kodadot1/brick'
 
 import CommonTokenMoney from '@/components/shared/CommonTokenMoney.vue'
-import { NeoNFT } from './types'
 
 const props = withDefaults(
   defineProps<{

--- a/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
+++ b/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
@@ -71,13 +71,13 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { NeoSkeleton, NftCardVariant } from '@kodadot1/brick'
+import { NeoSkeleton, type NftCardVariant } from '@kodadot1/brick'
 import type { ComputedOptions, ConcreteComponent, MethodOptions } from 'vue'
 
 import MediaItem from '../MediaItem/MediaItem.vue'
 import NFTMediaInfoStacked from './NFTMediaInfoStacked.vue'
 import NFTMediaInfo from './NFTMediaInfo.vue'
-import { NeoNFT } from './types'
+import type { NeoNFT } from './types'
 
 const props = withDefaults(
   defineProps<{

--- a/libs/ui/src/components/NeoSecondaryButton/NeoSecondaryButton.vue
+++ b/libs/ui/src/components/NeoSecondaryButton/NeoSecondaryButton.vue
@@ -5,8 +5,8 @@
 </template>
 
 <script lang="ts" setup>
+import type { NeoButtonVariant } from '../../types'
 import { OButton } from '@oruga-ui/oruga-next'
-import { NeoButtonVariant } from '@kodadot1/brick'
 
 defineProps<{
   variant?: NeoButtonVariant

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -36,9 +36,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { OTooltip } from '@oruga-ui/oruga-next'
-import { LocaleMessage } from 'vue-i18n'
+
 export interface Props {
-  label?: string | LocaleMessage
+  label?: string
   position?: 'top' | 'bottom' | 'left' | 'right'
   active?: boolean
   multiline?: boolean

--- a/services/waifu.ts
+++ b/services/waifu.ts
@@ -1,7 +1,6 @@
 import { $fetch, FetchError } from 'ofetch'
 import type { DropItem } from '@/params/types'
-// const WAIFU_BASE_URL = 'https://waifu-me.kodadot.workers.dev'
-const WAIFU_BASE_URL = 'https://waifu-me.preschian-cdn.workers.dev/'
+const WAIFU_BASE_URL = 'https://waifu-me.kodadot.workers.dev'
 
 const table = 'mints'
 // const campaign = 'corn'

--- a/services/waifu.ts
+++ b/services/waifu.ts
@@ -1,6 +1,7 @@
 import { $fetch, FetchError } from 'ofetch'
 import type { DropItem } from '@/params/types'
-const WAIFU_BASE_URL = 'https://waifu-me.kodadot.workers.dev'
+// const WAIFU_BASE_URL = 'https://waifu-me.kodadot.workers.dev'
+const WAIFU_BASE_URL = 'https://waifu-me.preschian-cdn.workers.dev/'
 
 const table = 'mints'
 // const campaign = 'corn'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,13 +14,14 @@
     "experimentalDecorators": true,
     "noImplicitAny": false,
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": false, // TODO: would be good if true
     "types": [
       "@nuxt/types",
       "@nuxtjs/i18n",
       "@nuxtjs/color-mode",
       "@types/node",
       "vue-apollo",
-      "vitest/globals",
+      "vitest/globals"
     ]
   },
   "exclude": ["node_modules", "dist", "**/*.spec.ts"]


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Fix unable open the app on localhost
- [x] Fix unit test `FAIL  tests/transactionMintStatemine.spec.ts [ tests/transactionMintStatemine.spec.ts ]`

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b415bb</samp>

Optimized and harmonized component imports in various files, using `import type` syntax and relative paths where appropriate. Fixed some build and runtime errors caused by unused or broken imports and constants. Changed the domain for the waifu service to a working one.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b415bb</samp>

> _Sing, O Muse, of the valiant code review_
> _That optimized the imports of the NFTs_
> _And fixed the errors of the waifu service_
> _With skillful changes and harmonious comments_
