### PR TITLE
remove not enough balance disabled status

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
@@ -3,42 +3,13 @@
     <GalleryItemPriceSection v-if="nft.price" title="Price" :price="nft.price">
       <div v-if="Number(nft.price)" class="is-flex desktop-full-w">
         <div class="is-flex buy-button-width">
-          <NeoTooltip
-            :active="disabled"
-            class="w-full"
-            content-class="buy-tooltip"
-            :auto-close="isMobileDevice ? true : ['outside']"
-            :position="isMobileDevice ? 'top' : 'left'"
-            :triggers="[isMobileDevice ? 'click' : 'hover']"
-            multiline>
-            <template #content>
-              <div class="is-size-6">
-                {{
-                  $t('tooltip.notEnoughBalanceChain', {
-                    chain: chainNames[urlPrefix],
-                  })
-                }}
-                <div>
-                  {{ $t('tip') }}:
-                  <nuxt-link :to="`/${urlPrefix}/teleport`" target="_blank">
-                    {{ $t('useTeleport') }}</nuxt-link
-                  >
-
-                  {{ $t('or') }}
-
-                  <a @click="addFunds"> {{ $t('addFunds') }}</a>
-                </div>
-              </div>
-            </template>
-            <NeoButton
-              :label="label"
-              size="large"
-              class="button-height w-full"
-              variant="k-accent"
-              :disabled="disabled"
-              data-testid="item-buy"
-              @click="onClick" />
-          </NeoTooltip>
+          <NeoButton
+            :label="label"
+            size="large"
+            class="button-height w-full"
+            variant="k-accent"
+            data-testid="item-buy"
+            @click="onClick" />
         </div>
 
         <NeoButton
@@ -57,25 +28,17 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoTooltip } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 import GalleryItemPriceSection from '../GalleryItemActionSection.vue'
-import { getKusamaAssetId } from '@/utils/api/bsx/query'
-import { useIdentityStore } from '@/stores/identity'
 import { useShoppingCartStore } from '@/stores/shoppingCart'
 import { usePreferencesStore } from '@/stores/preferences'
 import OnRampModal from '@/components/shared/OnRampModal.vue'
 import { openShoppingCart } from '@/components/common/shoppingCart/ShoppingCartModalConfig'
-import { NFT } from '@/components/rmrk/service/scheme'
+import type { NFT } from '@/components/rmrk/service/scheme'
 import { nftToShoppingCartItem } from '@/components/common/shoppingCart/utils'
-import { chainNames } from '@/libs/static/src/chains'
-
-import { useWindowSize } from '@vueuse/core'
 
 const props = defineProps<{ nft: NFT }>()
-const isMobileDevice = computed(() => useWindowSize().width.value < 1024)
 
-const { urlPrefix } = usePrefix()
-const { accountId } = useAuth()
 const { $i18n } = useNuxtApp()
 const preferencesStore = usePreferencesStore()
 const shoppingCartStore = useShoppingCartStore()
@@ -83,8 +46,6 @@ const { cartIcon } = useShoppingCartIcon(props.nft.id)
 
 const instance = getCurrentInstance()
 const { doAfterLogin } = useDoAfterlogin(instance)
-const identityStore = useIdentityStore()
-const connected = computed(() => Boolean(accountId.value))
 const showRampModal = ref(false)
 
 enum BuyStatus {
@@ -103,36 +64,6 @@ const label = computed(() => {
   return $i18n.t(
     preferencesStore.getReplaceBuyNowWithYolo ? 'YOLO' : 'nft.action.buy',
   )
-})
-
-const addFunds = () => {
-  showRampModal.value = true
-}
-
-const balance = computed<string>(() => {
-  switch (urlPrefix.value) {
-    case 'rmrk':
-    case 'ksm':
-    case 'ahk':
-    case 'ahp':
-      return identityStore.getAuthBalance
-    case 'bsx':
-      return identityStore.multiBalances.chains.basilisk?.ksm?.nativeBalance
-    case 'snek':
-      return identityStore.multiBalances.chains['basilisk-testnet']?.ksm
-        ?.nativeBalance
-    default:
-      return identityStore.getTokenBalanceOf(getKusamaAssetId(urlPrefix.value))
-  }
-})
-const disabled = computed(() => {
-  if (btnStatus.value === BuyStatus.CART) {
-    return false
-  }
-  if (!(Number(props.nft.price) && balance.value) || !connected.value) {
-    return false
-  }
-  return Number(balance.value) <= Number(props.nft.price)
 })
 
 const openCompletePurcahseModal = () => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 \_\_ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7880
- [ ] Requires deployment <snek/rubick/worker>

Now, even if the balance is insufficient, the Buy button will be active.
![CleanShot 2023-11-08-4yOStO6p@2x](https://github.com/kodadot/nft-gallery/assets/10708802/c328688b-302e-4e3d-9a3c-ccb5bb35318f)


#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63026c4</samp>

Refactored the GalleryItemBuy component to use a single hook and property for buying NFTs. Removed unused code and simplified the UI logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 63026c4</samp>

> _The GalleryItemBuy component_
> _Was cluttered and needed improvement_
> _So they cut out the fluff_
> _And left just enough_
> _To use `nft.price` and `useShoppingCartStore` hook content_
