### PR TITLE
fix: Errors on landing

### DIFF
--- a/components/collectionDetailsPopover/CollectionDetailsPopover.vue
+++ b/components/collectionDetailsPopover/CollectionDetailsPopover.vue
@@ -3,12 +3,13 @@
     :append-to="body"
     placement="bottom"
     :delay="[showDelay, hideDelay]"
-    data-testid="identity">
+    data-testid="identity"
+    @show="triggered = true">
     <slot name="content" />
 
     <template #content>
       <div class="popover-container">
-        <CollectionDetailsPopoverContent :nft="nft" />
+        <CollectionDetailsPopoverContent v-if="triggered" :nft="nft" />
       </div>
     </template>
   </tippy>
@@ -19,6 +20,7 @@ import type { CarouselNFT } from '../base/types'
 import CollectionDetailsPopoverContent from './CollectionDetailsPopoverContent.vue'
 
 const body = ref(document.body)
+const triggered = ref(false)
 
 withDefaults(
   defineProps<{

--- a/queries/subsquid/general/latestEvents.graphql
+++ b/queries/subsquid/general/latestEvents.graphql
@@ -9,6 +9,7 @@ query latestEvents(
       name
       price
       currentOwner
+      issuer
       meta {
         id
         name

--- a/queries/subsquid/ksm/latestEvents.graphql
+++ b/queries/subsquid/ksm/latestEvents.graphql
@@ -9,6 +9,7 @@ query latestEvents(
       name
       price
       currentOwner
+      issuer
       meta {
         id
         name


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7972
  - [x] on-demand loading for popover

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4307595</samp>

Added a `triggered` flag to lazily load the collection details popover content and added the `issuer` field to the Subsquid queries to display the collection owner and creator information. These changes improve the performance and user experience of the collection details popover feature.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4307595</samp>

> _We're fetching the `issuer` of the latest events_
> _From Subsquid endpoints of different kinds_
> _We're loading the popover content only when it shows_
> _To save some time and bandwidth for our minds_
  