### PR TITLE
fix-create nft test

### DIFF
--- a/tests/e2e/createnft.spec.ts
+++ b/tests/e2e/createnft.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './fixtures'
 
 test('Create NFT', async ({ page, Commands }) => {
+  const numOfCopies = 5
   await Commands.e2elogin()
   //await page.goto('/ahk/create')
   await page.goto('/ksm/create')
@@ -34,7 +35,9 @@ test('Create NFT', async ({ page, Commands }) => {
     //set price
     await page.getByTestId('create-nft-input-list-value').fill('5.5')
     //set number of copies
-    await page.getByTestId('create-nft-input-copies').fill('5')
+    await page
+      .getByTestId('create-nft-input-copies')
+      .fill(numOfCopies.toString())
     await expect(
       page.getByTestId('create-nft-input-copies-switch'),
     ).toBeVisible()
@@ -71,8 +74,9 @@ test('Create NFT', async ({ page, Commands }) => {
     //NSFW switch
     await page.getByTestId('create-nft-nsfw-switch').click()
     //deposit check
+    const expectedDeposit = `${0.0077 * numOfCopies} KSM`
     await expect(page.getByTestId('create-nft-deposit-amount')).toHaveText(
-      '0.0077 KSM',
+      expectedDeposit,
       { timeout: 30000 },
     )
     //preview box


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

playwright test is failing
createnft.spec.ts
https://github.com/kodadot/nft-gallery/actions/runs/6810071903/job/18517633836

![image](https://github.com/kodadot/nft-gallery/assets/22791238/a16a0080-3058-4f30-b873-9febb4149344)


#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04482e3</samp>

Refactored a test case for creating NFTs with multiple copies in `createnft.spec.ts` to use a constant variable and calculate the deposit amount.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 04482e3</samp>

> _To test NFTs with multiple copies_
> _We refactored the code with some poppies_
> _We used a constant `numCopies`_
> _And calculated `deposit`_
> _To make the test code more snappy_
