### PR TITLE
feat: Add to landing generative mints

### DIFF
--- a/components/carousel/CarouselTypeGenerative.vue
+++ b/components/carousel/CarouselTypeGenerative.vue
@@ -1,0 +1,14 @@
+<template>
+  <CarouselIndex
+    :key="ids"
+    data-testid="generative-activity"
+    :title="$t('general.generativeActivity')"
+    :nfts="nfts"
+    action-type="pagination" />
+</template>
+
+<script lang="ts" setup>
+import { useCarouselGenerativeNftEvents } from './utils/useCarouselEvents'
+
+const { nfts, ids } = await useCarouselGenerativeNftEvents('ahk', ['176'])
+</script>

--- a/components/carousel/utils/useCarouselEvents.ts
+++ b/components/carousel/utils/useCarouselEvents.ts
@@ -109,24 +109,8 @@ export const flattenNFT = (data, chain) => {
 
 const sortNftByTime = (data) => data.sort((a, b) => b.unixTime - a.unixTime)
 
-export const useCarouselNftEvents = async ({ type }: Types) => {
-  const { data: dataAhk } = await useChainEvents('ahk', type)
-  const { data: dataAhp } = await useChainEvents('ahp', type)
-  const { data: dataBsx } = await useChainEvents('bsx', type)
-  const { data: dataSnek } = await useChainEvents('snek', type)
-  const { data: dataRmrk } = await useChainEvents('rmrk', type)
-  const { data: dataRmrk2 } = await useChainEvents('ksm', type)
-
+const limitDisplayNfts = (data) => {
   const nfts = ref<CarouselNFT[]>([])
-
-  const data = [
-    ...flattenNFT(dataAhk.value, 'ahk'),
-    ...flattenNFT(dataAhp.value, 'ahp'),
-    ...flattenNFT(dataBsx.value, 'bsx'),
-    ...flattenNFT(dataSnek.value, 'snek'),
-    ...flattenNFT(dataRmrk.value, 'rmrk'),
-    ...flattenNFT(dataRmrk2.value, 'ksm'),
-  ]
 
   // show 30 nfts in carousel
   const sortedNfts = sortNftByTime(data).slice(0, 30)
@@ -138,6 +122,27 @@ export const useCarouselNftEvents = async ({ type }: Types) => {
     ids: computed(() => nfts.value.map((nft) => nft.id).join()),
   }
 }
+
+export const useCarouselNftEvents = async ({ type }: Types) => {
+  const { data: dataAhk } = await useChainEvents('ahk', type)
+  const { data: dataAhp } = await useChainEvents('ahp', type)
+  const { data: dataBsx } = await useChainEvents('bsx', type)
+  const { data: dataSnek } = await useChainEvents('snek', type)
+  const { data: dataRmrk } = await useChainEvents('rmrk', type)
+  const { data: dataRmrk2 } = await useChainEvents('ksm', type)
+
+  const data = [
+    ...flattenNFT(dataAhk.value, 'ahk'),
+    ...flattenNFT(dataAhp.value, 'ahp'),
+    ...flattenNFT(dataBsx.value, 'bsx'),
+    ...flattenNFT(dataSnek.value, 'snek'),
+    ...flattenNFT(dataRmrk.value, 'rmrk'),
+    ...flattenNFT(dataRmrk2.value, 'ksm'),
+  ]
+
+  return limitDisplayNfts(data)
+}
+
 export const useCarouselGenerativeNftEvents = async (
   chain: Prefix,
   collectionIds: string[],
@@ -153,20 +158,10 @@ export const useCarouselGenerativeNftEvents = async (
     collectionIds,
   )
 
-  const nfts = ref<CarouselNFT[]>([])
-
   const data = [
     ...flattenNFT(salesData.value, chain),
     ...flattenNFT(listData.value, chain),
   ]
 
-  // show 30 nfts in carousel
-  const sortedNfts = sortNftByTime(data).slice(0, 30)
-
-  nfts.value = sortedNfts
-
-  return {
-    nfts,
-    ids: computed(() => nfts.value.map((nft) => nft.id).join()),
-  }
+  return limitDisplayNfts(data)
 }

--- a/components/landing/LandingPage.vue
+++ b/components/landing/LandingPage.vue
@@ -38,6 +38,9 @@
 
             <!-- latest sales -->
             <LazyCarouselTypeLatestSales class="mt-8" />
+
+            <!-- generative  -->
+            <LazyCarouselTypeGenerative class="mt-8" />
           </div>
         </section>
       </ClientOnly>

--- a/locales/en.json
+++ b/locales/en.json
@@ -938,6 +938,7 @@
     "copyToClipboard": "Copied to clipboard",
     "copyRewardLink": "Copy Reward Me link",
     "latestSales": "Latest sales",
+    "generativeActivity": "Generative",
     "search": "Search",
     "searchResultsText": "Showing results for",
     "searchNoResultsTitle": "Whoops, Couldn't find anything matching your search",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #7974
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1036" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/f230ec16-9570-44fa-8dc4-1cb04b8fdbfd">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba243d1</samp>

This pull request adds a new carousel component for generative NFTs from a specific collection on the AHK chain. It also improves the performance and functionality of the existing carousel components by using custom hooks and lazy loading.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba243d1</samp>

> _`CarouselTypeGenerative` shows us the art of the chain_
> _NFTs of creation, beauty and pain_
> _We filter and sort them with hooks of power_
> _`Lazy` components make the landing page devour_
  