### PR TITLE
chore: revert nuxt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lazysizes": "^5.3.2",
     "lodash": "^4.17.21",
     "mingo": "^5.1.0",
-    "nuxt": "^3.8.1",
+    "nuxt": "3.8.1",
     "nuxt-speedkit": "3.0.0-next.27",
     "ofetch": "^1.3.3",
     "pinia": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       nuxt:
-        specifier: ^3.8.1
+        specifier: 3.8.1
         version: 3.8.1(@types/node@20.8.10)(eslint@8.53.0)(rollup@2.79.1)(sass@1.69.5)(typescript@4.9.5)(vite@4.4.11)
       nuxt-speedkit:
         specifier: 3.0.0-next.27
@@ -6494,19 +6494,6 @@ packages:
       rollup: 3.29.0
     dev: true
 
-  /@rollup/plugin-replace@5.0.4(rollup@3.29.4):
-    resolution: {integrity: sha512-E2hmRnlh09K8HGT0rOnnri9OTh+BILGr7NVJGB30S4E3cLRn3J0xjdiyOZ74adPs4NiAMgrjUMGAZNJDBgsdmQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
-      magic-string: 0.30.5
-      rollup: 3.29.4
-
   /@rollup/plugin-replace@5.0.5(rollup@2.79.1):
     resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
     engines: {node: '>=14.0.0'}
@@ -6519,6 +6506,19 @@ packages:
       '@rollup/pluginutils': 5.0.5(rollup@2.79.1)
       magic-string: 0.30.5
       rollup: 2.79.1
+
+  /@rollup/plugin-replace@5.0.5(rollup@3.29.4):
+    resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
+      magic-string: 0.30.5
+      rollup: 3.29.4
 
   /@rollup/plugin-terser@0.4.4(rollup@3.29.4):
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
@@ -14158,7 +14158,7 @@ packages:
       '@rollup/plugin-inject': 5.0.5(rollup@3.29.4)
       '@rollup/plugin-json': 6.0.1(rollup@3.29.4)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@3.29.4)
-      '@rollup/plugin-replace': 5.0.4(rollup@3.29.4)
+      '@rollup/plugin-replace': 5.0.5(rollup@3.29.4)
       '@rollup/plugin-terser': 0.4.4(rollup@3.29.4)
       '@rollup/plugin-wasm': 6.2.2(rollup@3.29.4)
       '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
@@ -15480,6 +15480,7 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /prettier@3.0.3:
@@ -16730,6 +16731,7 @@ packages:
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    requiresBuild: true
     dependencies:
       safe-buffer: 5.2.1
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [ ] Closes #<issue_number>
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba37afc</samp>

Fixed the `nuxt` version and updated some `rollup` plugins in `pnpm-lock.yaml` and `package.json`. This was done to improve the stability and compatibility of the project dependencies.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba37afc</samp>

> _To avoid any breaking changes_
> _We fixed the `nuxt` version ranges_
> _And updated the lock_
> _With `rollup` and `replace` in stock_
> _And added some `requiresBuild` changes_
