### PR TITLE
fix: ipfs utils bypass kodaimage

### DIFF
--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -3,6 +3,7 @@ import { CollectionMetadata } from '@/components/rmrk/types'
 import api from '@/utils/fetch'
 import { Collection, NFT, NFTMetadata } from '@/components/rmrk/service/scheme'
 import consola from 'consola'
+
 import {
   ArweaveProviders,
   CF_IMAGE_URL,
@@ -11,6 +12,7 @@ import {
   getIPFSProvider,
   kodaImage,
 } from './config/ipfs'
+
 export const ipfsUrlPrefix = 'ipfs://ipfs/'
 
 export const fastExtract = (ipfsLink?: string): string => {
@@ -89,7 +91,7 @@ export const sanitizeIpfsUrl = (
     return ''
   }
 
-  if (!isIpfsUrl(ipfsUrl)) {
+  if (!isIpfsUrl(ipfsUrl) && !ipfsUrl.includes(kodaImage)) {
     const kodaUrl = new URL('/type/url', kodaImage)
     kodaUrl.searchParams.set('endpoint', ipfsUrl)
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Prevent unnecessary loop kodaimage domain. `https://image-beta.w.kodadot.xyz/type/url?endpoint=https%3A%2F%2Fimage-beta.w.kodadot.xyz%2Fipfs%2FQmemp5BQHr6QBBqd3Qf3subgZ4tm2xVYjFv5AC4Tf2bzqS%2Flegs%2FSports+Shorts+thumb.png`
- [x] Open https://canary.kodadot.xyz/ksm/gallery/15878768-342f12106eab6d904c-YOUDLECHEST-YOUDLECHEST-00011691 and see `Media` link on the Details tab. The link was not broken, but it was unnecessary

<img width="492" alt="Screenshot 2023-11-13 at 9 36 01 PM" src="https://github.com/kodadot/nft-gallery/assets/734428/cd17bf0c-65d8-40c2-9bf1-16bb6e3fa94f">


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)


## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba952cb</samp>

Refactored IPFS utils to handle different URL formats and added documentation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba952cb</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the IPFS utils, that wondrous tool of the web,_
> _where images of Koda, the swift-footed hound, reside_
> _and shine like stars in the dark vault of the net._
