### PR TITLE
feat: On teleport should be selected related pair of chain

### DIFF
--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -130,6 +130,7 @@ import {
   allowedTransitions,
   chainToPrefixMap,
   getChainCurrency,
+  prefixToChainMap,
 } from '@/utils/teleport'
 import Loader from '@/components/shared/Loader.vue'
 import shortAddress from '@/utils/shortAddress'
@@ -150,6 +151,7 @@ const {
   status,
 } = useTeleport(true)
 
+const { urlPrefix } = usePrefix()
 const fiatStore = useFiatStore()
 const fromChain = ref(Chain.POLKADOT) //Selected origin parachain
 const toChain = ref(Chain.ASSETHUBPOLKADOT) //Selected destination parachain
@@ -280,6 +282,21 @@ const onChainChange = (selectedChain, setFrom = true) => {
     fromChain.value = getFirstAllowedDestination(selectedChain)
   }
 }
+
+const setRelatedChain = () => {
+  const relatedFromChain = prefixToChainMap[urlPrefix.value] || Chain.POLKADOT
+  onChainChange(relatedFromChain, true)
+}
+
+watch(
+  urlPrefix,
+  () => {
+    setRelatedChain()
+  },
+  {
+    immediate: true,
+  },
+)
 
 const fromAddress = computed(() => getAddressByChain(fromChain.value))
 const toAddress = computed(() => getAddressByChain(toChain.value))

--- a/utils/teleport.ts
+++ b/utils/teleport.ts
@@ -52,7 +52,7 @@ export type TeleportTransition = {
 }
 
 export const allowedTransitions = {
-  [Chain.KUSAMA]: [Chain.BASILISK, Chain.ASSETHUBKUSAMA],
+  [Chain.KUSAMA]: [Chain.ASSETHUBKUSAMA, Chain.BASILISK],
   [Chain.BASILISK]: [Chain.KUSAMA],
   [Chain.ASSETHUBKUSAMA]: [Chain.KUSAMA],
   [Chain.POLKADOT]: [Chain.ASSETHUBPOLKADOT],


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8021
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="921" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/eb7b0d5a-2330-4043-ae0f-06ebf3492da8">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9f4e21</samp>

Added chain switching functionality to `Teleport.vue` component. It detects the chain name from the URL prefix and updates the state and UI accordingly.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d9f4e21</samp>

> _To switch chains with ease and no glitch_
> _The `Teleport.vue` got a switch_
> _It uses `usePrefix`_
> _And `prefixToChainMap`_
> _To set `fromChain` and the UI niche_
  