### PR TITLE
query for resources on ksm collection activity

### DIFF
--- a/composables/collectionActivity/useCollectionActivity.ts
+++ b/composables/collectionActivity/useCollectionActivity.ts
@@ -8,7 +8,12 @@ export const useCollectionActivity = ({ collectionId }) => {
   const flippers = ref<Flippers>()
   const offers = ref<Offer[]>([])
 
-  const queryPrefix = urlPrefix.value === 'bsx' ? 'chain-bsx' : 'subsquid'
+  const queryPrefixMap = {
+    bsx: 'chain-bsx',
+    ksm: 'chain-ksm',
+  }
+
+  const queryPrefix = queryPrefixMap[urlPrefix.value] || 'subsquid'
 
   const { data } = useGraphql({
     queryPrefix,

--- a/queries/subsquid/ksm/collectionActivityEvents.graphql
+++ b/queries/subsquid/ksm/collectionActivityEvents.graphql
@@ -1,0 +1,36 @@
+query collectionActivityEvents($id: String!) {
+  collection: collectionEntityById(id: $id) {
+    id
+    nfts {
+      events(orderBy: timestamp_ASC) {
+        timestamp
+        meta
+        interaction
+        id
+        caller
+        currentOwner
+      }
+      currentOwner
+      name
+      price
+      metadata
+      meta {
+        id
+        image
+      }
+      updatedAt
+      id
+      resources {
+        id
+        meta {
+          id
+          image
+          animationUrl
+        }
+        metadata
+        src
+        thumb
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #8034

## Problem fixed

collection activity query was missing the resources field, which is how we get the images on ksm
tested on other chains as well, works as it should

## Link 
https://deploy-preview-8035--koda-canary.netlify.app/ksm/collection/dac5c7f54029d0e73c-XCHIMPZ/activity


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/22791238/7b31c302-46c7-4001-ab2e-a295bd82a6f2)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88d0e56</samp>

Refactored `queryPrefix` variable in `useCollectionActivity` composable to use a map object. Added `collectionActivityEvents` query for Kusama network to fetch and display NFT collection events.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 88d0e56</samp>

> _`queryPrefix` maps_
> _blockchain networks to queries_
> _autumn of refactor_
