### PR TITLE
feat: Disable video controls on explore cards 

### DIFF
--- a/components/items/ItemsGrid/ItemsGrid.vue
+++ b/components/items/ItemsGrid/ItemsGrid.vue
@@ -19,6 +19,7 @@
           :nft="entity"
           :hide-media-info="hideMediaInfo"
           :hide-action="hideNFTHoverAction"
+          hide-video-controls
           :variant="
             slotProps.isMobileVariant || slotProps.grid === 'small'
               ? 'minimal'
@@ -29,6 +30,7 @@
           :entity="entity"
           :hide-media-info="hideMediaInfo"
           :hide-action="hideNFTHoverAction"
+          hide-video-controls
           :variant="
             slotProps.isMobileVariant || slotProps.grid === 'small'
               ? 'minimal'

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -18,6 +18,7 @@
     :link="NuxtLink"
     bind-key="to"
     :media-player-cover="mediaPlayerCover"
+    :media-hide-video-controls="hideVideoControls"
     media-hover-on-cover-play>
     <template v-if="!hideAction" #action>
       <div v-if="!isOwner && Number(nft?.price)" class="is-flex">
@@ -81,6 +82,7 @@ const props = defineProps<{
   variant?: NftCardVariant
   hideMediaInfo?: boolean
   hideAction?: boolean
+  hideVideoControls?: boolean
 }>()
 
 const { showCardIcon, cardIcon } = useNftCardIcon(computed(() => props.nft))

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -18,7 +18,7 @@
     :link="NuxtLink"
     bind-key="to"
     :media-player-cover="mediaPlayerCover"
-    :media-hide-video-controls="hideVideoControls"
+    :media-static-video="hideVideoControls"
     media-hover-on-cover-play>
     <template v-if="!hideAction" #action>
       <div v-if="!isOwner && Number(nft?.price)" class="is-flex">

--- a/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
+++ b/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
@@ -19,7 +19,7 @@
     :link="NuxtLink"
     bind-key="to"
     :media-player-cover="mediaPlayerCover"
-    :media-hide-video-controls="hideVideoControls"
+    :media-static-video="hideVideoControls"
     media-hover-on-cover-play>
     <template v-if="!hideAction" #action>
       <div v-if="!isOwner && isAvailableToBuy" class="is-flex">

--- a/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
+++ b/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
@@ -19,6 +19,7 @@
     :link="NuxtLink"
     bind-key="to"
     :media-player-cover="mediaPlayerCover"
+    :media-hide-video-controls="hideVideoControls"
     media-hover-on-cover-play>
     <template v-if="!hideAction" #action>
       <div v-if="!isOwner && isAvailableToBuy" class="is-flex">
@@ -96,6 +97,7 @@ const props = defineProps<{
   variant?: NftCardVariant
   hideMediaInfo?: boolean
   hideAction?: boolean
+  hideVideoControls?: boolean
 }>()
 
 const {

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -13,7 +13,8 @@
       :player-cover="audioPlayerCover"
       :hover-on-cover-play="audioHoverOnCoverPlay"
       :parent-hovering="isMediaItemHovering"
-      :preview="preview" />
+      :preview="preview"
+      :autoplay="autoplay" />
     <div
       v-if="isLewd && isLewdBlurredLayer"
       class="nsfw-blur is-capitalized is-flex is-align-items-center is-justify-content-center is-flex-direction-column">
@@ -76,7 +77,9 @@ const props = withDefaults(
     disableOperation?: boolean
     audioPlayerCover?: string
     audioHoverOnCoverPlay?: boolean
-    preview?: boolean // props for video component
+    // props for video component
+    preview?: boolean
+    autoplay?: boolean
   }>(),
   {
     src: '',

--- a/libs/ui/src/components/MediaItem/type/VideoMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/VideoMedia.vue
@@ -6,7 +6,7 @@
       :controls="controls"
       playsinline
       loop
-      :autoplay="preview"
+      :autoplay="autoPlay"
       :muted="preview"
       :poster="src"
       :src="animationSrc || src"
@@ -25,13 +25,19 @@ const props = withDefaults(
     src?: string
     alt?: string
     preview?: boolean
+    autoplay?: boolean
   }>(),
   {
     animationSrc: '',
     src: '',
     alt: '',
     preview: false,
+    autoplay: undefined,
   },
+)
+
+const autoPlay = computed(() =>
+  props.autoplay === undefined ? props.preview : props.autoplay,
 )
 const controls = computed(() => !props.preview)
 </script>

--- a/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
+++ b/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
@@ -23,7 +23,8 @@
           :mime-type="nft.mimeType"
           :placeholder="placeholder"
           :title="nft?.name"
-          :preview="mediaHideVideoControls"
+          :preview="mediaStaticVideo"
+          :autoplay="autoplay"
           disable-operation
           :audio-player-cover="mediaPlayerCover"
           :audio-hover-on-cover-play="mediaHoverOnCoverPlay" />
@@ -99,7 +100,7 @@ const props = withDefaults(
     showActionOnHover?: boolean
     mediaPlayerCover?: string
     mediaHoverOnCoverPlay?: boolean
-    mediaHideVideoControls?: boolean
+    mediaStaticVideo?: boolean
     hideMediaInfo?: boolean
     linkTo?: string
   }>(),
@@ -125,6 +126,9 @@ const isStacked = computed(() =>
   props.variant ? props.variant.includes('stacked') : false,
 )
 const isMinimal = props.variant.includes('minimal')
+const autoplay = computed(() =>
+  props.mediaStaticVideo === undefined ? undefined : !props.mediaStaticVideo,
+)
 </script>
 
 <style lang="scss" scoped>

--- a/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
+++ b/libs/ui/src/components/NeoNftCard/NeoNftCard.vue
@@ -23,6 +23,7 @@
           :mime-type="nft.mimeType"
           :placeholder="placeholder"
           :title="nft?.name"
+          :preview="mediaHideVideoControls"
           disable-operation
           :audio-player-cover="mediaPlayerCover"
           :audio-hover-on-cover-play="mediaHoverOnCoverPlay" />
@@ -98,6 +99,7 @@ const props = withDefaults(
     showActionOnHover?: boolean
     mediaPlayerCover?: string
     mediaHoverOnCoverPlay?: boolean
+    mediaHideVideoControls?: boolean
     hideMediaInfo?: boolean
     linkTo?: string
   }>(),


### PR DESCRIPTION
👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #8022

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2023-11-14 at 13 32 12](https://github.com/kodadot/nft-gallery/assets/44554284/0bb540e7-1aec-49da-b556-de6186939c9d)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7549d0c</samp>

This pull request adds a new prop `hideVideoControls` to several components related to NFT media previews. This prop allows hiding the video controls for NFT videos, improving the user experience and the gallery design.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7549d0c</samp>

> _Oh we are the coders of the NFT sea_
> _And we like to make our previews tidy_
> _We added a prop to `hideVideoControls`_
> _So pull up the sail and let the wind roll_


