### PR TITLE
fix: Refetch data after changing tab

### DIFF
--- a/components/collection/CollectionHeader/CollectionBanner.vue
+++ b/components/collection/CollectionHeader/CollectionBanner.vue
@@ -31,12 +31,13 @@ import HeroButtons from '@/components/collection/HeroButtons.vue'
 import { generateCollectionImage } from '@/utils/seoImageGenerator'
 import { convertMarkdownToText } from '@/utils/markdown'
 
+const collectionId = computed(() => route.params.id)
 const route = useRoute()
 const { placeholder } = useTheme()
 const { data } = useGraphql({
   queryName: 'collectionById',
   variables: {
-    id: route.params.id,
+    id: collectionId.value,
   },
 })
 

--- a/layouts/explore-layout.vue
+++ b/layouts/explore-layout.vue
@@ -12,7 +12,7 @@
         <div v-else>
           <!-- new header component for collection here -->
           <div v-if="isCollection">
-            <CollectionBanner :key="route.path" />
+            <CollectionBanner />
             <section class="pt-5">
               <div class="container is-fluid mobile-padding">
                 <CollectionInfo />

--- a/pages/[prefix]/collection/[id]/activity.vue
+++ b/pages/[prefix]/collection/[id]/activity.vue
@@ -30,6 +30,7 @@ const image = computed(() => {
 
 definePageMeta({
   layout: 'explore-layout',
+  keepalive: true,
 })
 
 useHead({

--- a/pages/[prefix]/collection/[id]/index.vue
+++ b/pages/[prefix]/collection/[id]/index.vue
@@ -11,6 +11,7 @@ import { usePreferencesStore } from '@/stores/preferences'
 
 definePageMeta({
   layout: 'explore-layout',
+  keepalive: true,
 })
 
 const preferencesStore = usePreferencesStore()


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8044
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eca15e0</samp>

This pull request optimizes the data fetching and rendering logic for collection pages. It simplifies the query for collection data in `CollectionBanner.vue`, removes an unnecessary `:key` prop from `CollectionBanner` in `explore-layout.vue`, and adds the `keepalive: true` option to `activity.vue` and `index.vue` to cache and reuse the page components.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eca15e0</samp>

> _Sing, O Muse, of the skillful coder who refined the Vue app_
> _With clever changes to the `:key` prop and the `keepalive` option_
> _He made the `CollectionBanner` shine like a star in the sky_
> _And the `activity` and `index` pages swift as the wind_
  