### PR TITLE
fix: Unable to mint continuously on ahk

### DIFF
--- a/tests/transactionMintStatemine.spec.ts
+++ b/tests/transactionMintStatemine.spec.ts
@@ -8,6 +8,16 @@ import {
   expandCopies,
 } from '@/composables/transaction/mintToken/utils'
 
+const MOCK_API = {
+  query: {
+    nfts: {
+      collection: () =>
+        Promise.resolve({
+          toHuman: () => ({ items: '0' }),
+        }),
+    },
+  },
+}
 describe('transactionMintStatemine.ts functions', () => {
   describe('assignIds function', () => {
     it('should assign id correctly for a single token', () => {
@@ -234,7 +244,7 @@ describe('transactionMintStatemine.ts functions', () => {
     })
   })
   describe('prepTokens function', () => {
-    it('should correctly prepare a single token with unique id', () => {
+    it('should correctly prepare a single token with unique id', async () => {
       const token: TokenToMint = {
         name: 'test',
         selectedCollection: { alreadyMinted: 4, lastIndexUsed: 4 },
@@ -244,7 +254,7 @@ describe('transactionMintStatemine.ts functions', () => {
         token,
       }
 
-      const result = prepTokens(item)
+      const result = await prepTokens(item, MOCK_API)
 
       const expectedResult = [
         {
@@ -256,7 +266,7 @@ describe('transactionMintStatemine.ts functions', () => {
       expect(result).toEqual(expectedResult)
     })
 
-    it('should correctly prepare a single token with unique id and copies', () => {
+    it('should correctly prepare a single token with unique id and copies', async () => {
       const token: TokenToMint = {
         name: 'test',
         copies: 3,
@@ -268,7 +278,7 @@ describe('transactionMintStatemine.ts functions', () => {
         token,
       }
 
-      const result = prepTokens(item)
+      const result = await prepTokens(item, MOCK_API)
 
       const expectedResult = [
         {
@@ -297,7 +307,7 @@ describe('transactionMintStatemine.ts functions', () => {
       expect(result).toEqual(expectedResult)
     })
 
-    it('should correctly prepare an array of tokens with unique ids and no copies', () => {
+    it('should correctly prepare an array of tokens with unique ids and no copies', async () => {
       const tokens: TokenToMint[] = [
         {
           name: 'test1',
@@ -317,7 +327,7 @@ describe('transactionMintStatemine.ts functions', () => {
         token: tokens,
       }
 
-      const result = prepTokens(item)
+      const result = await prepTokens(item, MOCK_API)
 
       const expectedResult = [
         {
@@ -340,7 +350,7 @@ describe('transactionMintStatemine.ts functions', () => {
       expect(result).toEqual(expectedResult)
     })
 
-    it('should correctly prepare an array of tokens with unique ids and some have copies', () => {
+    it('should correctly prepare an array of tokens with unique ids and some have copies', async () => {
       const tokens: TokenToMint[] = [
         {
           name: 'test1',
@@ -364,7 +374,7 @@ describe('transactionMintStatemine.ts functions', () => {
         token: tokens,
       }
 
-      const result = prepTokens(item)
+      const result = await prepTokens(item, MOCK_API)
 
       const expectedResult = [
         {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8054
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

<img width="1191" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/0a335209-72ea-43f4-8da2-39bd6a887e96">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 20d5b2f</samp>

Improved token minting logic for Statemine collections by querying the chain for the last used token id and avoiding id collisions. Modified `transactionMintStatemine.ts` to implement this logic.

  <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 20d5b2f</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning scheme to mint the tokens of the chain,_
> _Avoiding the dread peril of colliding ids_
> _That would mar the beauty of the digital domain._
  