### PR TITLE
:sparkles: generative drop can be disabled

### DIFF
--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -116,6 +116,7 @@ const props = defineProps({
 })
 
 const collectionId = computed(() => props.drop?.collection)
+const disabledByBackend = computed(() => props.drop?.disabled)
 
 const { neoModal } = useProgrammatic()
 const { $i18n } = useNuxtApp()
@@ -196,7 +197,8 @@ const mintButtonDisabled = computed(() =>
     currentMintedLoading.value ||
       !mintCountAvailable.value ||
       !selectedImage.value ||
-      !accountId.value,
+      !accountId.value ||
+      disabledByBackend.value,
   ),
 )
 

--- a/params/types.ts
+++ b/params/types.ts
@@ -69,4 +69,5 @@ export type DropItem = {
   alias: string
   type: DropType
   meta: string
+  disabled: boolean
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

Generative art can be visible on drops page but can be disabled for various reasons
- https://github.com/kodadot/private-workers/pull/15


<img width="409" alt="Screenshot 2023-11-15 at 19 39 38" src="https://github.com/kodadot/nft-gallery/assets/22471030/8e9abf0c-e166-4c96-b97c-b6d96cdec9bd">


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8513bf6</samp>

This pull request adds a `disabled` field to the `DropItem` type and uses it to disable the minting button for drop items that are disabled by the backend. This improves the user experience and prevents invalid minting attempts.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8513bf6</samp>

> _The backend has the power to disable the drops_
> _But we won't let it crush our dreams of minting_
> _We use the `disabled` field to check the props_
> _And show the button only when it's fitting_
