### PR TITLE
:bug: cannot click on drops minted via kodadot

### DIFF
--- a/components/collection/unlockable/UnlockableLandingTag.vue
+++ b/components/collection/unlockable/UnlockableLandingTag.vue
@@ -14,7 +14,7 @@
     <div class="separator mx-2" />
     <nuxt-link
       class="is-flex is-align-items-center has-text-weight-bold my-2"
-      to="/ahk/drops/chained">
+      to="/ahp/drops/pareidoscope">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>

--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -140,7 +140,9 @@ onMounted(async () => {
   image.value = sanitizeIpfsUrl(
     metadata.image || metadata.thumbnailUri || metadata.mediaUri || '',
   )
-  externalUrl.value = metadata.external_url || ''
+  externalUrl.value = metadata.external_url?.match('kodadot')
+    ? ''
+    : metadata.external_url
   isLoadingMeta.value = false
 })
 </script>


### PR DESCRIPTION
- :zap: take me to the correct url
- :facepalm: kodadot is not external url

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

Drops treated `metadata.external_url` as something special 

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 670867b</samp>

Updated the `nuxt-link` route for the Pareidoscope collection and removed redundant links to kodadot from the drop cards. These changes improve the user experience and navigation of the website.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 670867b</samp>

> _`nuxt-link` changes_
> _route to Pareidoscope_
> _cutting old name off_
