### PR TITLE
mobile / Nova Wallet -> full screen button in galleryItem

### DIFF
--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -506,6 +506,13 @@ a.has-text-grey {
   z-index: 1;
 }
 
+// used in gallery item to disbale <main> z-index: 100
+// when fallback fullscreen is used (on Nova wallet)
+// without this the navbar is above the fullscreen image
+.no-z-index {
+  z-index: unset !important;
+}
+
 .modal {
   .modal-content {
     border: none !important;

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -283,7 +283,7 @@ useSeoMeta({
 
 const imgref = ref<HTMLElement | null>(null)
 const isFallbackActive = ref(false)
-const fullScreenDisabled = ref(false)
+const fullScreenDisabled = ref(true)
 const { toggle, isFullscreen, isSupported } = useFullscreen(imgref)
 
 function toggleFullscreen() {
@@ -299,9 +299,11 @@ function toggleFullscreen() {
 
 function toggleFallback() {
   if (imgref.value) {
+    const mainElement = document.querySelector('main')
     const isCurrentlyFullscreen = imgref.value.classList.toggle(
       'fullscreen-fallback',
     )
+    mainElement?.classList.toggle('no-z-index')
     isFallbackActive.value = isCurrentlyFullscreen
     isFullscreen.value = isCurrentlyFullscreen
   }
@@ -373,13 +375,9 @@ $break-point-width: 930px;
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-
-  & > .back-button {
-    top: 6rem;
-  }
+  width: 100vw;
+  height: 100vh;
+  z-index: 9999;
 }
 
 .fullscreen-button {

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -172,7 +172,7 @@ import {
 import { useFullscreen, useWindowSize } from '@vueuse/core'
 
 import { useGalleryItem } from './useGalleryItem'
-import { isMobileDevice } from '@/utils/extension'
+// import { isMobileDevice } from '@/utils/extension'
 
 import CarouselTypeRelated from '@/components/carousel/CarouselTypeRelated.vue'
 import CarouselTypeVisited from '@/components/carousel/CarouselTypeVisited.vue'
@@ -218,11 +218,9 @@ const tabs = {
 const activeTab = ref(tabs.offers)
 
 const canPreview = computed(() =>
-  isMobileDevice
-    ? true
-    : [MediaType.VIDEO, MediaType.IMAGE, MediaType.OBJECT].includes(
-        resolveMedia(nftMimeType.value),
-      ),
+  [MediaType.VIDEO, MediaType.IMAGE, MediaType.OBJECT].includes(
+    resolveMedia(nftMimeType.value),
+  ),
 )
 
 const activeCarousel = ref(0)

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -283,7 +283,7 @@ useSeoMeta({
 
 const imgref = ref<HTMLElement | null>(null)
 const isFallbackActive = ref(false)
-const fullScreenDisabled = ref(true)
+const fullScreenDisabled = ref(false)
 const { toggle, isFullscreen, isSupported } = useFullscreen(imgref)
 
 function toggleFullscreen() {

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -172,7 +172,6 @@ import {
 import { useFullscreen, useWindowSize } from '@vueuse/core'
 
 import { useGalleryItem } from './useGalleryItem'
-// import { isMobileDevice } from '@/utils/extension'
 
 import CarouselTypeRelated from '@/components/carousel/CarouselTypeRelated.vue'
 import CarouselTypeVisited from '@/components/carousel/CarouselTypeVisited.vue'


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #8078

## Tested

on Android phone with Nova Wallet
on desktop works as before -> no UX change

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

https://github.com/kodadot/nft-gallery/assets/22791238/a2cab763-7ae7-49d7-8d07-bffaf61cfb6b



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 505e00f</samp>

Enhanced the fullscreen functionality and mobile compatibility of the `GalleryItem` component. Removed unused code and added type annotations.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 505e00f</samp>

> _`GalleryItem` shines_
> _Fullscreen fallback and previews_
> _Winter of unused code_
