### PR TITLE
Fix/mint-collection-ksm

### DIFF
--- a/composables/transaction/mintCollection/transactionMintCollectionRmrk.ts
+++ b/composables/transaction/mintCollection/transactionMintCollectionRmrk.ts
@@ -10,7 +10,6 @@ import {
   createInteraction,
 } from '@kodadot1/minimark/v2'
 import { asSystemRemark } from '@kodadot1/minimark/common'
-import { canSupport } from '@/utils/support'
 
 export async function execMintCollectionRmrk({
   item,
@@ -44,13 +43,7 @@ export async function execMintCollectionRmrk({
     : createMintInteraction(Interaction.MINT, mint)
 
   const cb = api.tx.utility.batchAll
-  const hasSupport = true
-  const arg = [
-    [
-      asSystemRemark(api, mintInteraction),
-      ...(await canSupport(api, hasSupport)),
-    ],
-  ]
+  const arg = [[asSystemRemark(api, mintInteraction)]]
   executeTransaction({
     cb,
     arg,

--- a/utils/support.ts
+++ b/utils/support.ts
@@ -21,6 +21,9 @@ export const cost = async (
   fee: number = BASE_FEE,
 ): Promise<number> => {
   const ksmPrice = await getApproximatePriceOf('kusama')
+  if (ksmPrice === 0) {
+    return 0
+  }
   console.log('[SUPPORT] 💋💋💋', fee / ksmPrice, 'KSM')
   const decimals: number = getTokenDecimals(api)
   return Math.round((fee / ksmPrice) * 10 ** decimals)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #8085

## Root Cause

`utils/coinprice/getApproximatePriceOf` returns 0 if failed to fetch price

that makes the fee in `utils/support/cost` => Infinty

polkadot api expects a number

## Solution

1. don't charge fees for collection creation (we don't on other chains)

2. return 0 fee in case price of coin could not be obtained


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9c1728</samp>

Fixed a bug in the `cost` function that caused NaN values when `ksmPrice` was zero. Simplified the mint collection remark transaction in `transactionMintCollectionRmrk.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9c1728</samp>

> _No more NaN in the cost of support_
> _We divide by ksmPrice or abort_
> _We clean up the code of mint collection_
> _We only remark what we need for action_
