### PR TITLE
fix: Countdown gone in drop page

### DIFF
--- a/components/collection/drop/DropContainer.vue
+++ b/components/collection/drop/DropContainer.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="unlockable-container">
-    <Loader v-model="isLoading" :minted="justMinted" />
+    <CollectionUnlockableLoader
+      v-if="isLoading"
+      model-value
+      :minted="justMinted" />
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid">
@@ -114,10 +117,6 @@ import { MINT_ADDRESS, countDownTime } from './const'
 import { DropItem } from '@/params/types'
 
 import { TokenToBuy } from '@/composables/transaction/types'
-
-const Loader = defineAsyncComponent(
-  () => import('@/components/collection/unlockable/UnlockableLoader.vue'),
-)
 
 const Money = defineAsyncComponent(
   () => import('@/components/shared/format/Money.vue'),

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="unlockable-container">
-    <CollectionUnlockableLoader v-model="isLoading" :minted="justMinted" />
+    <CollectionUnlockableLoader
+      v-if="isLoading"
+      model-value
+      :minted="justMinted" />
     <div class="container is-fluid border-top">
       <div class="columns is-desktop">
         <div class="column is-half-desktop mobile-padding">

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="unlockable-container">
-    <Loader v-model="isLoading" :minted="justMinted" />
+    <CollectionUnlockableLoader
+      v-if="isLoading"
+      model-value
+      :minted="justMinted" />
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid">
@@ -105,7 +108,6 @@ import { ConnectWalletModalConfig } from '@/components/common/ConnectWallet/useC
 import { NeoButton } from '@kodadot1/brick'
 import { useCountDown } from './utils/useCountDown'
 import CarouselTypeLatestMints from '@/components/carousel/CarouselTypeLatestMints.vue'
-import Loader from '@/components/collection/unlockable/UnlockableLoader.vue'
 import { DropItem } from '@/params/types'
 
 const props = defineProps({

--- a/components/collection/voteDrop/DropContainer.vue
+++ b/components/collection/voteDrop/DropContainer.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="unlockable-container">
-    <Loader v-model="isLoading" :minted="justMinted" />
+    <CollectionUnlockableLoader
+      v-if="isLoading"
+      model-value
+      :minted="justMinted" />
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid pb-4">
@@ -105,10 +108,6 @@ import { VOTE_DROP_DESCRIPTION, countDownTime } from './const'
 import { DropItem } from '@/params/types'
 
 import { useCheckReferenDumVote } from '@/composables/drop/useCheckReferenDumVote'
-
-const Loader = defineAsyncComponent(
-  () => import('@/components/collection/unlockable/UnlockableLoader.vue'),
-)
 
 const props = defineProps({
   drop: {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8090
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![20231116-233634](https://github.com/kodadot/nft-gallery/assets/31397967/3cf76f5f-a829-4b7a-a5b3-13cd250e7b8c)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 43b2862</samp>

Refactored the collection drop features to use a custom loader component and avoid code duplication. Renamed `Generative.vue` to `DropContainer.vue` and deleted `UnlockableContainer.vue`.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 43b2862</samp>

> _To render the generative art_
> _They renamed `Generative.vue` to `DropContainer.vue` for a start_
> _Then they deleted `UnlockableContainer.vue`_
> _And moved the vote drop feature too_
> _And used custom loaders for a better user part_
  