### PR TITLE
fix: Change link to recent generative mint on mobile landing

### DIFF
--- a/components/collection/unlockable/UnlockableLandingMobileBanner.vue
+++ b/components/collection/unlockable/UnlockableLandingMobileBanner.vue
@@ -9,7 +9,7 @@
         alt="unlockable icon" />
       <span>{{ $t('mint.unlockable.mintLive') }}</span>
     </div>
-    <nuxt-link class="has-text-weight-bold" to="/ahk/drops/chained">
+    <nuxt-link class="has-text-weight-bold" to="/ahp/drops/pareidoscope">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Context

  - [x] Closes #8104
  - [ ] Requires deployment <snek/rubick/worker>

<img width="384" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/9c40172e-ab99-47d4-b266-e0925e95ad1f">


  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 77d5bf8</samp>

Updated the mobile banner link for the unlockable collection feature to direct users to the current drop page. Changed the `nuxt-link` component in `UnlockableLandingMobileBanner.vue` to use the correct drop ID.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 77d5bf8</samp>

> _`nuxt-link` changes_
> _pointing to pareidoscope_
> _a new drop in spring_
  