### PR TITLE
fix: Loader text [stuck...] can be hidden once tx is signed

### DIFF
--- a/components/shared/Loader.vue
+++ b/components/shared/Loader.vue
@@ -6,7 +6,7 @@
         <figcaption v-if="status" class="loading-text">
           {{ $t(status) }}
         </figcaption>
-        <div v-if="status" class="mt-3 mb-3 has-text-primary">
+        <div v-if="!status" class="mt-3 mb-3 has-text-primary">
           {{ $t('helper.signStuckText') }}
         </div>
       </figure>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8092
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="332" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/a725785e-c4e6-4b26-8319-45fa3d3b595a">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aadfc18</samp>

Fixed a bug in `Loader.vue` that showed the wrong message when signing transactions. The message now only appears when the status is null, indicating a possible signing issue.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aadfc18</samp>

> _`signStuckText` shows_
> _when status is null, not set_
> _a bug fixed in spring_
  