### PR TITLE
fix: allow opengraph on details page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,4 @@
 User-agent: *
-Disallow: */details/
-Disallow: */gallery/
-Disallow: */u/
 Disallow: */transfer
 
 Sitemap: https://kodadot.xyz/sitemap.xml


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Allow open graph on the details page
- [x] After some checking about why the open graph on Twitter is not working for the details page because we are blocking access on `robots.txt`. IMO, it is better to allow the page even though the page still had bad scores on page speed insights

![Screenshot 2023-11-17 130745](https://github.com/kodadot/nft-gallery/assets/734428/d89b8fa1-e922-4bee-be67-b7db2ee7fbeb)

ref: https://wordpress.org/support/topic/twitter-cards-image-not-always-showing/

![image](https://github.com/kodadot/nft-gallery/assets/734428/3525b304-ed8c-468f-b3a3-6053316887e1)

please note:
1. ensure that `robots.txt` does not block the access
2. not always work, sometimes twitter fails to parse the page

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)


## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 415cf88</samp>

Removed `robots.txt` file to enable search engine indexing of NFT gallery pages. This is part of a pull request to improve SEO and visibility of the website.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 415cf88</samp>

> _`code` was removed_
> _to let search engines crawl_
> _NFTs in springtime_
