### PR TITLE
fix: preheat wrong file

### DIFF
--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -157,7 +157,6 @@ export const fetchCollectionMetadata = (
 export const preheatFileFromIPFS = (ipfsUrl: string) => {
   const url = sanitizeIpfsUrl(`${ipfsUrlPrefix}${ipfsUrl}`)
 
-  console.log('start preheatFileFromIPFS', url, ipfsUrl)
 
   // preheat to r2/cfi
   api(url)

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -157,7 +157,6 @@ export const fetchCollectionMetadata = (
 export const preheatFileFromIPFS = (ipfsUrl: string) => {
   const url = sanitizeIpfsUrl(`${ipfsUrlPrefix}${ipfsUrl}`)
 
-
   // preheat to r2/cfi
   api(url)
     .then(async () => consola.log(`[PREHEAT] ${url}`))

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -155,16 +155,14 @@ export const fetchCollectionMetadata = (
 ): Promise<CollectionMetadata> => fetchMetadata<CollectionMetadata>(rmrk)
 
 export const preheatFileFromIPFS = (ipfsUrl: string) => {
-  const url = sanitizeIpfsUrl(ipfsUrl, 'image')
-  const hash = fastExtract(url)
-  api(url)
-    .then(async () => {
-      consola.log(`[PREHEAT] ${hash}`)
+  const url = sanitizeIpfsUrl(`${ipfsUrlPrefix}${ipfsUrl}`)
 
-      // preheat to r2/cfi
-      await $fetch(hash)
-    })
-    .catch((err) => consola.warn(`[PREHEAT] ${hash} ${err.message}`))
+  console.log('start preheatFileFromIPFS', url, ipfsUrl)
+
+  // preheat to r2/cfi
+  api(url)
+    .then(async () => consola.log(`[PREHEAT] ${url}`))
+    .catch((err) => consola.error(`[PREHEAT] ${url} ${err.message}`))
 }
 
 export const getSanitizer = (


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #8052

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)


## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 081436e</samp>

Fixed IPFS preheating bug and improved logging in `utils/ipfs.ts`. Used `ipfsUrlPrefix` variable to build IPFS URLs and changed log level to error for failures.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 081436e</samp>

> _`preheatFileFromIPFS`_
> _uses `ipfsUrlPrefix` now_
> _bug is fixed - autumn_
