### PR TITLE
"to" below "from" on narrow device

### DIFF
--- a/components/collection/activity/events/eventRow/EventRowTablet.vue
+++ b/components/collection/activity/events/eventRow/EventRowTablet.vue
@@ -39,7 +39,7 @@
       </div>
     </div>
 
-    <div class="is-flex gap">
+    <div class="is-flex gap flex-direction">
       <div v-if="fromAddress !== blank" class="is-flex is-align-items-center">
         <span class="is-size-7 mr-3">{{ $t('activity.event.from') }}:</span>
         <nuxt-link
@@ -109,6 +109,7 @@ const getAvatar = async () => {
 
 <style scoped lang="scss">
 @import '@/assets/styles/abstracts/variables';
+$breakpoint: 400px;
 
 .fixed-width {
   width: 66px;
@@ -134,5 +135,14 @@ const getAvatar = async () => {
 
 .gap {
   gap: 1rem;
+  @include until($breakpoint) {
+    gap: 0;
+  }
+}
+
+.flex-direction {
+  @include until($breakpoint) {
+    flex-direction: column;
+  }
 }
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #8117

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI
![image](https://github.com/kodadot/nft-gallery/assets/22791238/4b411594-c930-4a8c-9bfa-044314433148)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 34a7820</samp>

Improved the layout of the event row component for tablet devices. Used Bulma's classes and a custom variable to adjust the flex direction and spacing of the elements.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 34a7820</samp>

> _We're making the event row responsive_
> _With `flex-direction` and `until`_
> _We'll adjust the layout with a breakpoint_
> _Heave away, me hearties, heave with skill_
