### PR TITLE
Drops-max-card-width

### DIFF
--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -27,8 +27,10 @@
       <div class="py-5 px-6">
         <div
           class="is-flex is-justify-content-space-between flex-direction column-gap">
-          <div class="is-flex is-flex-direction-column column-gap">
-            <span class="has-text-weight-bold">{{ drop.collection.name }}</span>
+          <div class="is-flex is-flex-direction-column column-gap is-ellipsis">
+            <span class="has-text-weight-bold is-ellipsis">{{
+              drop.collection.name
+            }}</span>
             <div v-if="drop.collection.issuer" class="is-flex">
               <div class="mr-2 has-text-grey">
                 {{ $t('activity.creator') }}:

--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -212,4 +212,10 @@ onMounted(async () => {
     }
   }
 }
+// allow text to wrap on mobile
+.is-ellipsis {
+  @include mobile {
+    white-space: unset;
+  }
+}
 </style>

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -56,7 +56,6 @@ $gap: 1rem;
   .grid-container {
     grid-template-columns: repeat(2, minmax(0, $max-card-width));
     max-width: calc(2 * $max-card-width);
-    margin: 0 auto;
   }
 }
 </style>

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -44,14 +44,15 @@ onBeforeMount(() => {
 </script>
 
 <style lang="scss" scoped>
+$gap: 1rem;
 .grid-container {
   display: grid;
-  gap: 1rem;
+  gap: $gap;
   grid-template-columns: repeat(1, 1fr);
 }
 
 @media (min-width: 1000px) {
-  $max-card-width: 910px;
+  $max-card-width: calc(910px + 0.5 * #{$gap});
   .grid-container {
     grid-template-columns: repeat(2, minmax(0, $max-card-width));
     max-width: calc(2 * $max-card-width);

--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -51,8 +51,11 @@ onBeforeMount(() => {
 }
 
 @media (min-width: 1000px) {
+  $max-card-width: 910px;
   .grid-container {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, $max-card-width));
+    max-width: calc(2 * $max-card-width);
+    margin: 0 auto;
   }
 }
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #8111
- [x] Closes #8112
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

yes , $

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)
## Screenshot 📸

- [x] My fix has changed UI


![image](https://github.com/kodadot/nft-gallery/assets/22791238/43d8ba34-c6e2-4f9e-97a5-81437444d100)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2b39045</samp>

Improved the drop card component by adding text truncation and responsive grid layout. Modified `DropCard.vue` and `Drops.vue` files.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2b39045</samp>

> _`is-ellipsis` class_
> _truncates collection names_
> _cleaner drop cards_
