### PR TITLE
fix: minting confirmation modal overflows

### DIFF
--- a/components/create/Confirm/MintConfirmModal.vue
+++ b/components/create/Confirm/MintConfirmModal.vue
@@ -225,6 +225,10 @@ watchEffect(async () => {
 
 .modal-width {
   width: 25rem;
+
+  @include mobile {
+    width: unset;
+  }
 }
 .btn-height {
   height: 3.5rem;


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #8081
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="385" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/3ffc7c82-bfe6-4f34-9c65-04dcac1d168f">

<img width="775" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/6893d2c1-58e8-4911-aedb-abeda5ce3600">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  