### PR TITLE
fix: Drop page heading truncation

### DIFF
--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -9,7 +9,7 @@
         :key="`${drop.collection?.id}=${index}`"
         class="w-full h-full"
         :data-testid="index">
-        <DropCard :drop="drop" />
+        <DropCard :drop="drop" class="h-full" />
       </div>
     </div>
     <hr class="my-7" />


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [X] Closes #8112
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [X] My contribution builds **clean without any errors or warnings**
- [X] I've merged recent default branch -- **main** and I've no conflicts
- [X] I've tried to respect high code quality standards
- [X] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [X] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16hqk8Tjugo9AwSzKkxXc1dsRK7iJetpx1YBaoXYwdHzuNAt&usdamount=50&donation=true)

#### Community participation

- [ ] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 930bd0f</samp>

Fixed drop card height and improved drops page UI. Added `h-full` class to `DropCard` component in `components/drops/Drops.vue`.
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 930bd0f</samp>

> _`DropCard` fills height_
> _A layout issue resolved_
> _Winter UI shines_