### PR TITLE
Fixed slider borders

### DIFF
--- a/components/collection/unlockable/UnlockableSlider.vue
+++ b/components/collection/unlockable/UnlockableSlider.vue
@@ -3,7 +3,7 @@
     <div
       v-if="value > 0"
       class="unlockable-slider-inner border slider-bar"
-      :style="style"></div>
+      :style="widthStyle"></div>
   </div>
 </template>
 
@@ -17,9 +17,7 @@ const props = withDefaults(
   },
 )
 
-const style = computed(() => ({
-  width: `${props.value * 100}%`,
-}))
+const widthStyle = computed(() => ({ width: `${props.value * 100}%` }))
 </script>
 
 <style lang="scss" scoped>

--- a/components/collection/unlockable/UnlockableSlider.vue
+++ b/components/collection/unlockable/UnlockableSlider.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="unlockable-slider border is-flex is-flex-1 slider-bar">
+  <div class="unlockable-slider border slider-bar">
     <div
       v-if="value > 0"
-      class="unlockable-slider-inner border slider-bar"
-      :style="widthStyle"></div>
+      class="unlockable-slider-inner slider-bar"
+      :style="style"></div>
   </div>
 </template>
 
@@ -17,26 +17,33 @@ const props = withDefaults(
   },
 )
 
-const widthStyle = computed(() => ({ width: `${props.value * 100}%` }))
+const style = computed(() => {
+  const progress = props.value * 100
+
+  return {
+    width: `${progress}%`,
+    'border-right': progress === 100 ? 'none' : '',
+  }
+})
 </script>
 
 <style lang="scss" scoped>
 @import '@/assets/styles/abstracts/variables.scss';
 .unlockable-slider {
   position: relative;
+  height: 14px;
+  overflow: hidden;
   @include ktheme() {
     background: theme('background-color');
   }
   &-inner {
-    position: absolute;
-    left: -1px;
-    top: -1px;
+    height: 100%;
     background: $primary;
+    border-right: inherit;
   }
 }
 
 .slider-bar {
   border-radius: 2.5rem;
-  height: 14px;
 }
 </style>

--- a/components/collection/unlockable/UnlockableSlider.vue
+++ b/components/collection/unlockable/UnlockableSlider.vue
@@ -2,7 +2,7 @@
   <div class="unlockable-slider border slider-bar">
     <div
       v-if="value > 0"
-      class="unlockable-slider-inner slider-bar"
+      class="unlockable-slider-inner border slider-bar"
       :style="style"></div>
   </div>
 </template>
@@ -17,14 +17,9 @@ const props = withDefaults(
   },
 )
 
-const style = computed(() => {
-  const progress = props.value * 100
-
-  return {
-    width: `${progress}%`,
-    'border-right': progress === 100 ? 'none' : '',
-  }
-})
+const style = computed(() => ({
+  width: `${props.value * 100}%`,
+}))
 </script>
 
 <style lang="scss" scoped>
@@ -37,9 +32,12 @@ const style = computed(() => {
     background: theme('background-color');
   }
   &-inner {
+    position: absolute;
+    left: -1px;
+    top: -1px;
     height: 100%;
     background: $primary;
-    border-right: inherit;
+    box-sizing: content-box;
   }
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8139 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="826" alt="Screenshot 2023-11-19 at 12 30 54" src="https://github.com/kodadot/nft-gallery/assets/19692986/a538d19f-a7a6-4f24-922c-850ad5013775">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 41568a9</samp>

Refactored and styled the `unlockable-slider` component to make it more responsive and consistent with the design.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 41568a9</samp>

> _To make the `unlockable-slider` look better_
> _The coder removed some classes and a letter_
> _They enhanced a computed prop_
> _And tweaked some CSS on top_
> _And now the component is a go-getter_