### PR TITLE
fix: Dynamic modal copy based on context

### DIFF
--- a/components/common/autoTeleport/AutoTeleportActionButton.vue
+++ b/components/common/autoTeleport/AutoTeleportActionButton.vue
@@ -194,10 +194,7 @@ const hasNoFundsAtAll = computed(
 const confirmButtonTitle = computed(() => {
   const interaction =
     transactions.value.actions[0].interaction?.toLocaleLowerCase()
-  return (
-    $i18n.t(`autoTeleport.steps.${interaction}.confirm`) ||
-    $i18n.t('autoTeleport.steps.common.confirm')
-  )
+  return $i18n.t(`autoTeleport.steps.${interaction}.confirm`)
 })
 
 const autoTeleportLabel = computed(() => {

--- a/components/common/autoTeleport/AutoTeleportActionButton.vue
+++ b/components/common/autoTeleport/AutoTeleportActionButton.vue
@@ -191,6 +191,15 @@ const hasNoFundsAtAll = computed(
   () => !hasEnoughInCurrentChain.value && !hasEnoughInRichestChain.value,
 )
 
+const confirmButtonTitle = computed(() => {
+  const interaction =
+    transactions.value.actions[0].interaction?.toLocaleLowerCase()
+  return (
+    $i18n.t(`autoTeleport.steps.${interaction}.confirm`) ||
+    $i18n.t('autoTeleport.steps.common.confirm')
+  )
+})
+
 const autoTeleportLabel = computed(() => {
   if (hasEnoughInCurrentChain.value || props.disabled) {
     return props.label
@@ -211,7 +220,7 @@ const autoTeleportLabel = computed(() => {
         name.value,
       ])
     } else {
-      return $i18n.t('autoTeleport.teleportAndConfirm')
+      return confirmButtonTitle.value
     }
   }
 

--- a/components/common/autoTeleport/AutoTeleportModal.vue
+++ b/components/common/autoTeleport/AutoTeleportModal.vue
@@ -132,8 +132,12 @@ const mainActionDetails = computed(() => {
   const interaction =
     props.transactions.actions[0].interaction?.toLocaleLowerCase()
   return {
-    action: $i18n.t(`autoTeleport.steps.${interaction}.action`),
-    item: $i18n.t(`autoTeleport.steps.${interaction}.item`),
+    action:
+      $i18n.t(`autoTeleport.steps.${interaction}.action`) ||
+      $i18n.t('autoTeleport.steps.common.action'),
+    item:
+      $i18n.t(`autoTeleport.steps.${interaction}.item`) ||
+      $i18n.t('autoTeleport.steps.common.item'),
   }
 })
 

--- a/components/common/autoTeleport/AutoTeleportModal.vue
+++ b/components/common/autoTeleport/AutoTeleportModal.vue
@@ -132,12 +132,8 @@ const mainActionDetails = computed(() => {
   const interaction =
     props.transactions.actions[0].interaction?.toLocaleLowerCase()
   return {
-    action:
-      $i18n.t(`autoTeleport.steps.${interaction}.action`) ||
-      $i18n.t('autoTeleport.steps.common.action'),
-    item:
-      $i18n.t(`autoTeleport.steps.${interaction}.item`) ||
-      $i18n.t('autoTeleport.steps.common.item'),
+    action: $i18n.t(`autoTeleport.steps.${interaction}.action`),
+    item: $i18n.t(`autoTeleport.steps.${interaction}.item`),
   }
 })
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1541,7 +1541,6 @@
     "dontExit": "Stay on this page until all steps are complete.",
     "tip": "<strong>Tip:</strong> Look for popups from your wallet extension for signing.",
     "notEnoughTokenInChain": "Not enough {0} on {1}",
-    "teleportAndConfirm": "Teleport and confirm purchase",
     "addFundsViaOnramp": "Add Funds Via Onramp",
     "welcomeToAutoTeleport": "Welcome to auto teleport!",
     "insufficientFunds": "Insufficient funds",
@@ -1581,28 +1580,60 @@
         "tooltip": "Verifying fund arrival on destination chain for seamless operations.<br> this may take few seconds"
       },
       "buy": {
+        "confirm": "Teleport And Confirm Purchase",
         "action": "Purchase",
         "item": "NFT",
         "title": "Buying NFT",
         "submit": "Buying NFT..."
       },
       "list": {
+        "confirm": "Teleport And Confirm Listing(s)",
         "action": "List",
-        "item": "NFT",
+        "item": "NFT(s)",
         "title": "Listing NFT",
         "submit": "Listing NFT..."
       },
       "mint": {
-        "action": "Mint",
-        "item": "NFT Collection",
+        "confirm": "Teleport and Create Collection",
+        "action": "Create",
+        "item": "Collection",
         "title": "Minting NFT Collection",
         "submit": "Minting NFT Collection..."
       },
       "mintnft": {
+        "confirm": "Teleport and Mint NFT",
         "action": "Mint",
         "item": "NFT",
         "title": "Minting NFT",
         "submit": "Minting NFT..."
+      },
+      "send": {
+        "confirm": "Teleport and Transfer NFT",
+        "action": "Transfer",
+        "item": "NFT",
+        "title": "Transferring NFT",
+        "submit": "Transferring NFT..."
+      },
+      "delete": {
+        "confirm": "Teleport and Delete Collection",
+        "action": "Delete",
+        "item": "Collection",
+        "title": "Deleting Collection",
+        "submit": "Deleting Collection..."
+      },
+      "consume": {
+        "confirm": "Teleport and Burn NFT",
+        "action": "Burn",
+        "item": "NFT",
+        "title": "Burning NFT",
+        "submit": "Burning NFT..."
+      },
+      "common": {
+        "confirm": "Teleport and Execute",
+        "action": "Execute",
+        "item": "Item",
+        "title": "Executing",
+        "submit": "Executing..."
       }
     }
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -1627,13 +1627,6 @@
         "item": "NFT",
         "title": "Burning NFT",
         "submit": "Burning NFT..."
-      },
-      "common": {
-        "confirm": "Teleport and Execute",
-        "action": "Execute",
-        "item": "Item",
-        "title": "Executing",
-        "submit": "Executing..."
       }
     }
   },


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8134
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fbb483f</samp>

This pull request enhances the user interface and localization of the auto-teleport feature for NFT transactions. It adds different confirmation messages for the action button, updates the localization file with new and improved strings, and adds fallback values for the modal dialog.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fbb483f</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous feature for the auto-teleport action,_
> _That lets the users swiftly move their NFTs across_
> _The blockchain realms with ease and satisfaction._
  