### PR TITLE
fix: Scrolling down on collection activity tab resets the page

### DIFF
--- a/layouts/explore-layout.vue
+++ b/layouts/explore-layout.vue
@@ -27,7 +27,7 @@
             </div>
           </section>
           <hr class="text-color my-0" />
-          <NuxtPage />
+          <NuxtPage :keepalive="keepalive" />
         </div>
       </main>
     </div>
@@ -69,6 +69,8 @@ const isExplore = computed(() => route.path.includes('/explore'))
 const isCollection = computed(
   () => route.name?.toString().includes('prefix-collection-id'),
 )
+
+const keepalive = computed(() => (isCollection.value ? false : undefined))
 
 const getExploreTitle = computed(() => {
   if (


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

**useScroll -> useEventListener -> onUnmounted** not called making scroll code from **items** tab still run on **activity** tab

- [x] Closes #8164

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ae5e94d</samp>

Improved explore page caching with `keepalive` prop. This allows faster navigation and smoother transitions between collections and filters on the explore page.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ae5e94d</samp>

> _`NuxtPage` is the key to our fate_
> _We control the cache with `keepalive` state_
> _Exploring the collections with blazing speed_
> _We unleash the power of the Nuxt breed_

