### PR TITLE
Setup @nuxt/image

### DIFF
--- a/components/carousel/module/CarouselMedia.vue
+++ b/components/carousel/module/CarouselMedia.vue
@@ -16,6 +16,7 @@
         :src="imageSrc || ''"
         :animation-src="item.animationUrl || ''"
         :title="item.name"
+        :image-component="NuxtImg"
         disable-operation
         :audio-player-cover="imageSrc || ''"
         audio-hover-on-cover-play />
@@ -36,6 +37,8 @@ const props = defineProps<{
   index: number
   length: number
 }>()
+
+const NuxtImg = resolveComponent('NuxtImg')
 
 const { urlOf } = useCarouselUrl()
 const url = inject('itemUrl', 'gallery') as string

--- a/components/collection/CollectionHeader/CollectionBanner.vue
+++ b/components/collection/CollectionHeader/CollectionBanner.vue
@@ -8,8 +8,10 @@
       <div class="container is-fluid collection-banner-content">
         <div class="is-flex is-flex-direction-column is-align-items-start">
           <div class="collection-banner-avatar">
-            <img
+            <NuxtImg
               v-if="collectionAvatar"
+              width="88"
+              height="88"
               :src="collectionAvatar"
               class="object-fit-cover"
               :alt="collectionName" />

--- a/components/collection/CollectionHeader/CollectionBanner.vue
+++ b/components/collection/CollectionHeader/CollectionBanner.vue
@@ -10,8 +10,8 @@
           <div class="collection-banner-avatar">
             <NuxtImg
               v-if="collectionAvatar"
-              width="88"
               height="88"
+              densities="2x"
               :src="collectionAvatar"
               class="object-fit-cover"
               :alt="collectionName" />

--- a/components/collection/activity/events/eventRow/EventRowDesktop.vue
+++ b/components/collection/activity/events/eventRow/EventRowDesktop.vue
@@ -6,6 +6,7 @@
           :to="`/${urlPrefix}/gallery/${event.nft.id}`"
           class="height-50px">
           <NeoAvatar
+            :image-component="NuxtImg"
             :avatar="avatar"
             :placeholder="placeholder"
             :name="event.nft.name"
@@ -90,6 +91,8 @@ import {
 } from './common'
 import EventTag from './EventTag.vue'
 import { NeoAvatar } from '@kodadot1/brick'
+
+const NuxtImg = resolveComponent('NuxtImg')
 
 const { urlPrefix } = usePrefix()
 const props = defineProps<{

--- a/components/collection/activity/events/eventRow/EventRowTablet.vue
+++ b/components/collection/activity/events/eventRow/EventRowTablet.vue
@@ -4,6 +4,7 @@
       <nuxt-link :to="`/${urlPrefix}/gallery/${event.nft.id}`">
         <div class="mr-5">
           <NeoAvatar
+            :image-component="NuxtImg"
             :avatar="avatar"
             :placeholder="placeholder"
             :name="event.nft.name"
@@ -78,6 +79,8 @@ import {
   interactionNameMap,
 } from './common'
 import { NeoAvatar } from '@kodadot1/brick'
+
+const NuxtImg = resolveComponent('NuxtImg')
 
 const { urlPrefix } = usePrefix()
 const props = defineProps<{

--- a/components/collection/unlockable/UnlockableCollectionBanner.vue
+++ b/components/collection/unlockable/UnlockableCollectionBanner.vue
@@ -6,7 +6,12 @@
       <div class="container is-fluid collection-banner-content">
         <div class="is-flex is-flex-direction-column is-align-items-start">
           <div class="collection-banner-avatar">
-            <img :src="image" alt="avatar" class="object-fit-cover" />
+            <NuxtImg
+              width="88"
+              height="88"
+              :src="image"
+              alt="avatar"
+              class="object-fit-cover" />
           </div>
           <h1 class="collection-banner-name">{{ title }}</h1>
         </div>

--- a/components/collection/unlockable/UnlockableCollectionBanner.vue
+++ b/components/collection/unlockable/UnlockableCollectionBanner.vue
@@ -7,8 +7,8 @@
         <div class="is-flex is-flex-direction-column is-align-items-start">
           <div class="collection-banner-avatar">
             <NuxtImg
-              width="88"
               height="88"
+              densities="2x"
               :src="image"
               alt="avatar"
               class="object-fit-cover" />

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -47,6 +47,7 @@
                   :mime-type="resource.mimeType"
                   :animation-src="resource.animation"
                   :audio-player-cover="galleryItem.nftImage.value"
+                  :image-component="NuxtImg"
                   is-detail />
               </NeoCarouselItem>
             </NeoCarousel>
@@ -63,6 +64,7 @@
             is-detail
             :is-lewd="galleryDescriptionRef?.isLewd"
             :placeholder="placeholder"
+            :image-component="NuxtImg"
             sizes="original"
             :audio-player-cover="nftImage" />
         </div>
@@ -192,6 +194,8 @@ import { MediaType } from '@/components/rmrk/types'
 import { resolveMedia } from '@/utils/gallery/media'
 import UnlockableTag from './UnlockableTag.vue'
 import { usePreferencesStore } from '@/stores/preferences'
+
+const NuxtImg = resolveComponent('NuxtImg')
 
 const { urlPrefix } = usePrefix()
 const route = useRoute()

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -63,6 +63,7 @@
             is-detail
             :is-lewd="galleryDescriptionRef?.isLewd"
             :placeholder="placeholder"
+            sizes="original"
             :audio-player-cover="nftImage" />
         </div>
       </div>

--- a/components/massmint/EditPanel.vue
+++ b/components/massmint/EditPanel.vue
@@ -25,6 +25,7 @@
             @click="closePanel" />
         </div>
         <NeoAvatar
+          :image-component="NuxtImg"
           :avatar="nft?.imageUrl"
           :name="nft?.name || `${nft?.id}`"
           :size="128"
@@ -88,6 +89,8 @@ const props = defineProps<{
   nft?: NFT
   open: boolean
 }>()
+
+const NuxtImg = resolveComponent('NuxtImg')
 
 const internalNfT = ref<Partial<NFT>>({})
 const dirty = ref({ name: false, description: false, price: false })

--- a/components/massmint/OverviewTable.vue
+++ b/components/massmint/OverviewTable.vue
@@ -31,6 +31,7 @@
             </div>
             <div class="column is-flex is-align-items-center">
               <NeoAvatar
+                :image-component="NuxtImg"
                 :avatar="nft.imageUrl"
                 :name="nft.name || `${nft.id}`"
                 :size="48"
@@ -109,6 +110,8 @@ import {
   statusTranslation,
 } from '@/composables/massmint/useMassMint'
 const { placeholder } = useTheme()
+
+const NuxtImg = resolveComponent('NuxtImg')
 
 const offset = ref(10)
 const sentinel = ref<HTMLDivElement | null>(null)

--- a/components/profile/activityTab/HistoryRow.vue
+++ b/components/profile/activityTab/HistoryRow.vue
@@ -4,6 +4,7 @@
       <div class="is-flex is-align-items-center">
         <nuxt-link :to="`/${urlPrefix}/gallery/${event.Item.id}`" class="h-50">
           <NeoAvatar
+            :image-component="NuxtImg"
             :avatar="avatar"
             :placeholder="placeholder"
             :name="event.Item.name"
@@ -79,6 +80,7 @@
       <nuxt-link :to="`/${urlPrefix}/gallery/${event.Item.id}`">
         <div class="mr-5">
           <NeoAvatar
+            :image-component="NuxtImg"
             :avatar="avatar"
             :placeholder="placeholder"
             :name="event.Item.name"
@@ -152,6 +154,8 @@ const props = defineProps<{
   withToColumn: boolean
   variant: 'Desktop' | 'Touch'
 }>()
+
+const NuxtImg = resolveComponent('NuxtImg')
 
 const { urlPrefix } = usePrefix()
 const avatar = ref()

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -86,7 +86,7 @@ const props = withDefaults(
     src: '',
     animationSrc: '',
     mimeType: '',
-    sizes: '225px md:175px lg:135px',
+    sizes: '450px md:350px lg:270px',
     title: 'KodaDot NFT',
     original: false,
     isLewd: false,

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -14,6 +14,7 @@
       :player-cover="audioPlayerCover"
       :hover-on-cover-play="audioHoverOnCoverPlay"
       :parent-hovering="isMediaItemHovering"
+      :image-component="imageComponent"
       :preview="preview"
       :autoplay="autoplay" />
     <div
@@ -49,7 +50,8 @@
 </template>
 
 <script lang="ts" setup>
-import { type Component, computed, defineAsyncComponent, ref, watch } from 'vue'
+import type { ComputedOptions, ConcreteComponent, MethodOptions } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useElementHover, useElementVisibility } from '@vueuse/core'
 import { NeoButton, NeoIcon } from '@kodadot1/brick'
 
@@ -81,6 +83,10 @@ const props = withDefaults(
     autoplay?: boolean
     // props for image component
     sizes?: string
+    imageComponent?:
+      | string
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+      | ConcreteComponent<{}, any, any, ComputedOptions, MethodOptions>
   }>(),
   {
     src: '',
@@ -94,6 +100,7 @@ const props = withDefaults(
     placeholder: '',
     disableOperation: undefined,
     audioPlayerCover: '',
+    imageComponent: 'img',
   },
 )
 

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -3,6 +3,7 @@
     <component
       :is="resolveComponent"
       :src="properSrc"
+      :sizes="sizes"
       :animation-src="animationSrc"
       :alt="title"
       :placeholder="placeholder"
@@ -67,6 +68,7 @@ const props = withDefaults(
     src?: string
     animationSrc?: string
     mimeType?: string
+    sizes?: string
     title?: string
     original?: boolean
     isLewd?: boolean
@@ -83,6 +85,7 @@ const props = withDefaults(
     src: '',
     animationSrc: '',
     mimeType: '',
+    sizes: '225px md:175px lg:135px',
     title: 'KodaDot NFT',
     original: false,
     isLewd: false,

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -92,7 +92,6 @@ const props = withDefaults(
     src: '',
     animationSrc: '',
     mimeType: '',
-    sizes: '450px md:350px lg:270px',
     title: 'KodaDot NFT',
     original: false,
     isLewd: false,

--- a/libs/ui/src/components/MediaItem/MediaItem.vue
+++ b/libs/ui/src/components/MediaItem/MediaItem.vue
@@ -68,7 +68,6 @@ const props = withDefaults(
     src?: string
     animationSrc?: string
     mimeType?: string
-    sizes?: string
     title?: string
     original?: boolean
     isLewd?: boolean
@@ -80,6 +79,8 @@ const props = withDefaults(
     // props for video component
     preview?: boolean
     autoplay?: boolean
+    // props for image component
+    sizes?: string
   }>(),
   {
     src: '',
@@ -100,6 +101,10 @@ const mediaItem = ref<HTMLDivElement>()
 
 // props.mimeType may be empty string "". Add `image/png` as fallback
 const mimeType = computed(() => props.mimeType || type.value || 'image/png')
+
+const sizes = computed(() =>
+  props.sizes === 'original' ? undefined : props.sizes,
+)
 
 const targetIsVisible = useElementVisibility(mediaItem)
 const modelComponent = ref<Component>()

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -5,12 +5,12 @@
       'is-square image': !original,
       'is-detail': isDetail,
     }">
-    <NuxtImg
+    <TheImage
+      :image-component="imageComponent"
+      :image-component-props="{ sizes }"
       :src="src"
-      :sizes="sizes"
-      class="is-block image-media__image no-border-radius"
-      densities="x1"
       :alt="alt"
+      class="is-block image-media__image no-border-radius"
       data-testid="type-image"
       @error.once="onError" />
   </figure>
@@ -18,8 +18,11 @@
 
 <script lang="ts" setup>
 import consola from 'consola'
+import TheImage from '../../TheImage/TheImage.vue'
+import type { ImageComponent } from '../../TheImage/TheImage.vue'
 
 const props = defineProps<{
+  imageComponent?: ImageComponent
   sizes?: string
   src?: string
   alt?: string

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -5,8 +5,9 @@
       'is-square image': !original,
       'is-detail': isDetail,
     }">
-    <img
+    <NuxtImg
       :src="src"
+      :sizes="sizes"
       class="is-block image-media__image no-border-radius"
       :alt="alt"
       data-testid="type-image"
@@ -18,6 +19,7 @@
 import consola from 'consola'
 
 const props = defineProps<{
+  sizes?: string
   src?: string
   alt?: string
   original: boolean
@@ -30,6 +32,7 @@ const onError = (e: Event) => {
   const target = e.target as HTMLImageElement
   if (target) {
     consola.log('[KODADOT::IMAGE] unable to load', props.src, e)
+    target.removeAttribute('srcset')
     target.src = props.placeholder
   }
 }

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -9,6 +9,7 @@
       :src="src"
       :sizes="sizes"
       class="is-block image-media__image no-border-radius"
+      densities="x1"
       :alt="alt"
       data-testid="type-image"
       @error.once="onError" />

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -21,16 +21,21 @@ import consola from 'consola'
 import TheImage from '../../TheImage/TheImage.vue'
 import type { ImageComponent } from '../../TheImage/TheImage.vue'
 
-const props = defineProps<{
-  imageComponent?: ImageComponent
-  sizes?: string
-  src?: string
-  alt?: string
-  original: boolean
-  placeholder: string
-  isDetail?: boolean
-  isDarkMode?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    imageComponent?: ImageComponent
+    sizes?: string
+    src?: string
+    alt?: string
+    original: boolean
+    placeholder: string
+    isDetail?: boolean
+    isDarkMode?: boolean
+  }>(),
+  {
+    sizes: '450px md:350px lg:270px',
+  },
+)
 
 const onError = (e: Event) => {
   const target = e.target as HTMLImageElement

--- a/libs/ui/src/components/NeoAvatar/NeoAvatar.vue
+++ b/libs/ui/src/components/NeoAvatar/NeoAvatar.vue
@@ -1,27 +1,39 @@
 <template>
-  <NuxtImg
+  <TheImage
     v-if="avatar"
+    :image-component="imageComponent"
     :src="avatar"
     :alt="name"
     class="border neo-avatar"
     :width="size"
     :height="size"
+    :style="customStyle"
     @error="onError" />
   <img
     v-else
     :src="placeholder"
     :width="size"
     :height="size"
+    :style="customStyle"
     class="border neo-avatar" />
 </template>
 
 <script setup lang="ts">
+import type { ImageComponent } from '../TheImage/TheImage.vue'
+import TheImage from '../TheImage/TheImage.vue'
+
 const props = defineProps<{
+  imageComponent?: ImageComponent
   avatar?: string
   placeholder: string
   name: string
   size: number
 }>()
+
+const customStyle = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+}))
 
 const onError = (e: Event) => {
   const target = e.target as HTMLImageElement

--- a/libs/ui/src/components/NeoAvatar/NeoAvatar.vue
+++ b/libs/ui/src/components/NeoAvatar/NeoAvatar.vue
@@ -1,32 +1,27 @@
 <template>
-  <img
+  <NuxtImg
     v-if="avatar"
     :src="avatar"
     :alt="name"
     class="border neo-avatar"
-    :style="customStyle"
+    :width="size"
+    :height="size"
     @error="onError" />
   <img
     v-else
     :src="placeholder"
-    :style="customStyle"
+    :width="size"
+    :height="size"
     class="border neo-avatar" />
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-
 const props = defineProps<{
   avatar?: string
   placeholder: string
   name: string
   size: number
 }>()
-
-const customStyle = computed(() => ({
-  width: `${props.size}px`,
-  height: `${props.size}px`,
-}))
 
 const onError = (e: Event) => {
   const target = e.target as HTMLImageElement

--- a/libs/ui/src/components/TheImage/TheImage.vue
+++ b/libs/ui/src/components/TheImage/TheImage.vue
@@ -10,7 +10,6 @@ import type {
   MethodOptions,
   ReservedProps,
 } from 'vue'
-import omit from 'lodash/omit'
 
 export type ImageComponent =
   | 'img'
@@ -30,6 +29,16 @@ const props = withDefaults(defineProps<Props>(), {
     return {}
   },
 })
+
+const omit = <T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+): Omit<T, K> => {
+  const clone = { ...obj } as const
+
+  keys.forEach((key) => delete clone[key])
+  return clone
+}
 
 const attrs = computed(() => {
   const imgAttrs = omit(props, ['imageComponent', 'imageComponentProps'])

--- a/libs/ui/src/components/TheImage/TheImage.vue
+++ b/libs/ui/src/components/TheImage/TheImage.vue
@@ -1,0 +1,46 @@
+<template>
+  <component :is="imageComponent" v-bind="attrs" />
+</template>
+
+<script lang="ts" setup>
+import type {
+  ComputedOptions,
+  ConcreteComponent,
+  ImgHTMLAttributes,
+  MethodOptions,
+  ReservedProps,
+} from 'vue'
+import omit from 'lodash/omit'
+
+export type ImageComponent =
+  | 'img'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+  | ConcreteComponent<{}, any, any, ComputedOptions, MethodOptions>
+  | string
+export type ImageComponentProps = Record<string, unknown>
+
+interface Props extends /* @vue-ignore */ ImgHTMLAttributes, ReservedProps {
+  imageComponent?: ImageComponent
+  imageComponentProps?: ImageComponentProps
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  imageComponent: 'img',
+  imageComponentProps() {
+    return {}
+  },
+})
+
+const attrs = computed(() => {
+  const imgAttrs = omit(props, ['imageComponent', 'imageComponentProps'])
+
+  if (props.imageComponent === 'img') {
+    return imgAttrs
+  }
+
+  return {
+    ...imgAttrs,
+    ...props.imageComponentProps,
+  }
+})
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -213,6 +213,7 @@ export default defineNuxtConfig({
 
   // Modules: https://nuxt.com/docs/api/nuxt-config#components
   modules: [
+    '@nuxt/image',
     '@nuxtjs/apollo',
     '@nuxtjs/i18n',
     // '@nuxtjs/sentry',
@@ -224,6 +225,16 @@ export default defineNuxtConfig({
     'nuxt-simple-sitemap',
     '@nuxtjs/google-fonts',
   ],
+
+  image: {
+    format: ['avif', 'webp'],
+    providers: {
+      customCloudflare: {
+        provider: '~/providers/cloudflare.ts',
+      },
+    },
+    provider: 'customCloudflare',
+  },
 
   googleFonts: {
     families: {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@kodadot1/minipfs": "0.4.1-rc.0",
     "@kodadot1/static": "workspace:*",
     "@kodadot1/sub-api": "0.2.0-rc.0",
+    "@nuxt/image": "^1.1.0",
     "@nuxtjs/apollo": "5.0.0-alpha.6",
     "@nuxtjs/i18n": "8.0.0-rc.3",
     "@paraspell/sdk": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false
@@ -35,6 +35,9 @@ importers:
       '@kodadot1/sub-api':
         specifier: 0.2.0-rc.0
         version: 0.2.0-rc.0
+      '@nuxt/image':
+        specifier: ^1.1.0
+        version: 1.1.0(rollup@2.79.1)
       '@nuxtjs/apollo':
         specifier: 5.0.0-alpha.6
         version: 5.0.0-alpha.6(rollup@2.79.1)(typescript@4.9.5)(vue@3.3.8)
@@ -3689,6 +3692,39 @@ packages:
     optionalDependencies:
       ipx: 1.3.1
     transitivePeerDependencies:
+      - rollup
+      - supports-color
+    dev: false
+
+  /@nuxt/image@1.1.0(rollup@2.79.1):
+    resolution: {integrity: sha512-+zZqsjVfR83UOrChGeaYuWZeLYMkFD0gNY0T6L4W1y4YaRbKNN5iynZJ71Bmg7lcOPRbf5OmSPBTSU0ieYJq4w==}
+    engines: {node: ^14.16.0 || >=16.11.0}
+    dependencies:
+      '@nuxt/kit': 3.8.2(rollup@2.79.1)
+      consola: 3.2.3
+      defu: 6.1.3
+      h3: 1.9.0
+      image-meta: 0.2.0
+      node-fetch-native: 1.4.1
+      ohash: 1.1.3
+      pathe: 1.1.1
+      std-env: 3.5.0
+      ufo: 1.3.2
+    optionalDependencies:
+      ipx: 2.0.2
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - idb-keyval
       - rollup
       - supports-color
     dev: false
@@ -12434,6 +12470,44 @@ packages:
     dev: false
     optional: true
 
+  /ipx@2.0.2:
+    resolution: {integrity: sha512-avedYlD04mN3alN4BYoXtZuMrQP/Fln86uN1hUFRCjzIZxl7Et3oKX+V1YTEodFvPs8tk5NAQJXZeowu0OgOKQ==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@fastify/accept-negotiator': 1.1.0
+      citty: 0.1.5
+      consola: 3.2.3
+      defu: 6.1.3
+      destr: 2.0.2
+      etag: 1.8.1
+      h3: 1.9.0
+      image-meta: 0.2.0
+      listhen: 1.5.5
+      ofetch: 1.3.3
+      pathe: 1.1.1
+      sharp: 0.32.6
+      svgo: 3.0.4
+      ufo: 1.3.2
+      unstorage: 1.10.1
+      xss: 1.0.14
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - idb-keyval
+      - supports-color
+    dev: false
+    optional: true
+
   /iron-webcrypto@1.0.0:
     resolution: {integrity: sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==}
 
@@ -16822,6 +16896,7 @@ packages:
 
   /smoldot@2.0.7:
     resolution: {integrity: sha512-VAOBqEen6vises36/zgrmAT1GWk2qE3X8AGnO7lmQFdskbKx8EovnwS22rtPAG+Y1Rk23/S22kDJUdPANyPkBA==}
+    requiresBuild: true
     dependencies:
       ws: 8.14.2
     transitivePeerDependencies:
@@ -17208,6 +17283,22 @@ packages:
       css-tree: 2.3.1
       csso: 5.0.5
       picocolors: 1.0.0
+
+  /svgo@3.0.4:
+    resolution: {integrity: sha512-T+Xul3JwuJ6VGXKo/p2ndqx1ibxNKnLTvRc1ZTWKCfyKS/GgNjRZcYsK84fxTsy/izr91g/Rwx6fGnVgaFSI5g==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@trysound/sax': 0.2.0
+      commander: 7.2.0
+      css-select: 5.1.0
+      css-tree: 2.3.1
+      css-what: 6.1.0
+      csso: 5.0.5
+      picocolors: 1.0.0
+    dev: false
+    optional: true
 
   /symbol-observable@1.2.0:
     resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}

--- a/providers/cloudflare.ts
+++ b/providers/cloudflare.ts
@@ -1,0 +1,57 @@
+import { type QueryValue, encodeQueryItem, joinURL } from 'ufo'
+import type { ProviderGetImage } from '@nuxt/image'
+import { createOperationsGenerator } from '#image'
+
+const operationsGenerator = createOperationsGenerator({
+  keyMap: {
+    width: 'w',
+    height: 'h',
+    dpr: 'dpr',
+    fit: 'fit',
+    gravity: 'g',
+    quality: 'q',
+    format: 'f',
+    sharpen: 'sharpen',
+  },
+  valueMap: {
+    fit: {
+      cover: 'cover',
+      contain: 'contain',
+      fill: 'scale-down',
+      outside: 'crop',
+      inside: 'pad',
+    },
+    gravity: {
+      auto: 'auto',
+      side: 'side',
+    },
+  },
+  joinWith: ',',
+  formatter: (key: string, val: QueryValue | QueryValue[]) =>
+    encodeQueryItem(key, val),
+})
+
+const defaultModifiers = {}
+
+export const getImage: ProviderGetImage = (
+  src,
+  { modifiers = {}, baseURL = 'https://kodadot.xyz' } = {},
+) => {
+  const mergeModifiers = { ...defaultModifiers, ...modifiers }
+  const operations = operationsGenerator(mergeModifiers as any)
+
+  const match = src.match(/\/ipfs\/(.+)/)
+  const cid = match ? encodeURI(match[1]) : null
+
+  if (!cid) {
+    return { url: src }
+  }
+
+  const cf = 'cdn-cgi/imagedelivery/jk5b6spi_m_-9qC4VTnjpg'
+
+  const url = operations ? joinURL(baseURL, cf, cid, operations) : src
+
+  return {
+    url,
+  }
+}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #7807  
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="385" alt="Screenshot 2023-11-22 at 11 21 48" src="https://github.com/kodadot/nft-gallery/assets/19692986/abe4de50-1ea8-4f64-a84a-acf3aedfd97f">
<img width="389" alt="Screenshot 2023-11-22 at 11 21 29" src="https://github.com/kodadot/nft-gallery/assets/19692986/f7818ca6-833e-4357-bc61-abe540025be8">

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5593dd5</samp>

This pull request adds the `@nuxt/image` module and configures it to use Cloudflare Image Resizing for optimizing and resizing images in the project. It also updates the `MediaItem.vue`, `ImageMedia.vue`, `NeoAvatar.vue`, `CollectionBanner.vue`, and `UnlockableCollectionBanner.vue` components to use the `NuxtImg` tag instead of the `img` tag for rendering images. Additionally, it adds a custom provider script for Cloudflare in the `cloudflare.ts` file and fixes a bug in the `srcset` attribute of the `ImageMedia.vue` component.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5593dd5</samp>

> _We are the masters of the image_
> _We optimize and resize with `NuxtImg`_
> _We unleash the power of Cloudflare_
> _We make the web faster and fairer_