### PR TITLE
remove only if dataset not affected too much

### DIFF
--- a/components/collection/activity/ActivityChart.vue
+++ b/components/collection/activity/ActivityChart.vue
@@ -37,12 +37,18 @@ const buyEvents = computed(() =>
   ),
 )
 const listEvents = computed(() => {
+  const CUTOFF = 0.1 // 10% of the data is outliers
   const listDataPoints = sortAsc(
     props.events
       .filter((e) => e.interaction === Interaction.LIST)
       .map(toDataPoint),
   )
-  return removeOutliers(listDataPoints)
+  const withoutOutliers = removeOutliers(listDataPoints)
+  const ratio = withoutOutliers.length / listDataPoints.length
+  if (ratio < CUTOFF) {
+    return withoutOutliers
+  }
+  return listDataPoints
 })
 
 const chartData = computed(() => {

--- a/components/collection/activity/ActivityChart.vue
+++ b/components/collection/activity/ActivityChart.vue
@@ -45,10 +45,7 @@ const listEvents = computed(() => {
   )
   const withoutOutliers = removeOutliers(listDataPoints)
   const ratio = withoutOutliers.length / listDataPoints.length
-  if (ratio < CUTOFF) {
-    return withoutOutliers
-  }
-  return listDataPoints
+  return ratio < CUTOFF ? withoutOutliers : listDataPoints
 })
 
 const chartData = computed(() => {

--- a/components/collection/activity/ActivityChart.vue
+++ b/components/collection/activity/ActivityChart.vue
@@ -45,7 +45,10 @@ const listEvents = computed(() => {
   )
   const withoutOutliers = removeOutliers(listDataPoints)
   const ratio = withoutOutliers.length / listDataPoints.length
-  return ratio < CUTOFF ? withoutOutliers : listDataPoints
+
+  // if less than 90% of the data remains after removing outliers,
+  // use the original data
+  return ratio < 1 - CUTOFF ? listDataPoints : withoutOutliers
 })
 
 const chartData = computed(() => {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] Closes #8108

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/22791238/ba3d8194-c386-4dee-9235-9c6543f63841)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3aa3a30</samp>

Improved activity chart by filtering out outliers if they are not too prevalent. Modified `ActivityChart.vue` to implement this logic.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3aa3a30</samp>

> _The data is corrupted by the outliers_
> _They distort the truth and the vision_
> _But we have a `CUTOFF` to defy them_
> _And a condition to avoid division_
