### PR TITLE
fix: download image does not work

### DIFF
--- a/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
+++ b/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
@@ -8,17 +8,13 @@
           icon="ellipsis-vertical"
           :active="active" />
       </template>
-      <component
-        :is="isMobileDevice ? 'a' : 'div'"
+
+      <NeoDropdownItem
         v-if="mimeType?.includes('image') && ipfsImage"
-        v-safe-href="toOriginalContentUrl(ipfsImage)"
-        target="_blank">
-        <NeoDropdownItem
-          data-testid="gallery-item-more-dropdown-download"
-          @click="downloadMedia">
-          Download
-        </NeoDropdownItem>
-      </component>
+        data-testid="gallery-item-more-dropdown-download"
+        @click="downloadMedia">
+        Download
+      </NeoDropdownItem>
 
       <template v-if="accountId === currentOwner">
         <NeoDropdownItem @click="burn">Burn</NeoDropdownItem>
@@ -55,7 +51,15 @@ const props = defineProps<{
 }>()
 
 const downloadMedia = () => {
-  if (!isMobileDevice && props.ipfsImage) {
+  if (props.ipfsImage) {
+    const originalUrl = toOriginalContentUrl(props.ipfsImage)
+    if (isMobileDevice) {
+      toast($i18n.t('toast.downloadOnMobile'))
+      setTimeout(() => {
+        window.open(originalUrl, '_blank')
+      }, 2000)
+      return
+    }
     try {
       downloadImage(toOriginalContentUrl(props.ipfsImage), props.name)
     } catch (error) {

--- a/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
+++ b/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
@@ -8,13 +8,18 @@
           icon="ellipsis-vertical"
           :active="active" />
       </template>
-
-      <NeoDropdownItem
+      <component
+        :is="isMobileDevice ? 'a' : 'div'"
         v-if="mimeType?.includes('image') && ipfsImage"
-        data-testid="gallery-item-more-dropdown-download"
-        @click="downloadMedia">
-        Download
-      </NeoDropdownItem>
+        :href="toOriginalContentUrl(ipfsImage)"
+        target="_blank">
+        <NeoDropdownItem
+          data-testid="gallery-item-more-dropdown-download"
+          @click="downloadMedia">
+          Download
+        </NeoDropdownItem>
+      </component>
+
       <template v-if="accountId === currentOwner">
         <NeoDropdownItem @click="burn">Burn</NeoDropdownItem>
         <NeoDropdownItem v-if="price !== '0'" @click="unlist">
@@ -32,6 +37,7 @@ import { Interaction } from '@kodadot1/minimark/v1'
 import { downloadImage } from '@/utils/download'
 import { toOriginalContentUrl } from '@/utils/ipfs'
 import Loader from '@/components/shared/Loader.vue'
+import { isMobileDevice } from '@/utils/extension'
 
 const { $i18n, $consola } = useNuxtApp()
 const { toast } = useToast()
@@ -49,7 +55,7 @@ const props = defineProps<{
 }>()
 
 const downloadMedia = () => {
-  if (props.ipfsImage) {
+  if (!isMobileDevice && props.ipfsImage) {
     try {
       downloadImage(toOriginalContentUrl(props.ipfsImage), props.name)
     } catch (error) {

--- a/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
+++ b/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
@@ -11,7 +11,7 @@
       <component
         :is="isMobileDevice ? 'a' : 'div'"
         v-if="mimeType?.includes('image') && ipfsImage"
-        :href="toOriginalContentUrl(ipfsImage)"
+        v-safe-href="toOriginalContentUrl(ipfsImage)"
         target="_blank">
         <NeoDropdownItem
           data-testid="gallery-item-more-dropdown-download"

--- a/locales/en.json
+++ b/locales/en.json
@@ -1145,7 +1145,8 @@
   "toast": {
     "urlCopy": "URL copied to clipboard ✓",
     "paymentLinkCopy": "Payment link copied to clipboard",
-    "downloadError": "Unable to download image"
+    "downloadError": "Unable to download image",
+    "downloadOnMobile": "To download the image, copy the URL from the address bar and open it in your browser. The page will open in 2 seconds."
   },
   "profileMenu": {
     "darkMode": "Dark Mode",

--- a/utils/download.ts
+++ b/utils/download.ts
@@ -1,11 +1,5 @@
-import { isMobileDevice } from './extension'
 export const downloadImage = async (imageSrc: string, name = 'unnamed') => {
   if (!imageSrc) {
-    return
-  }
-
-  if (isMobileDevice) {
-    window.open(imageSrc, '_blank')
     return
   }
 

--- a/utils/download.ts
+++ b/utils/download.ts
@@ -1,5 +1,11 @@
+import { isMobileDevice } from './extension'
 export const downloadImage = async (imageSrc: string, name = 'unnamed') => {
   if (!imageSrc) {
+    return
+  }
+
+  if (isMobileDevice) {
+    window.open(imageSrc, '_blank')
     return
   }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8170
  - [ ] Requires deployment <snek/rubick/worker>

I could not detect if it's in the nova wallet because there is nothing difference on the UA. 
We may also have similar cases on other mobile wallets, so I only check if it's in the mobile device.

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 08a6bab</samp>

Enhanced the user experience of downloading images on mobile devices by opening them in a new tab instead of saving them locally. Modified the `utils/download.ts` file to use the `isMobileDevice` function.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 08a6bab</samp>

> _Mobile devices_
> _Use `isMobileDevice` now_
> _Open image in spring_
  