### PR TITLE
trim leading zeroes

### DIFF
--- a/utils/nft.ts
+++ b/utils/nft.ts
@@ -12,10 +12,16 @@ export const parseNftAvatar = async (
   return meta.image
 }
 
+const trimLeadingZeros = (of: number | string) => {
+  const trimmedString = of.toString().replace(/^0+(?=\d)/, '')
+
+  return typeof of === 'number' ? Number(trimmedString) : trimmedString
+}
+
 const suffixRegex = /#\d+$/
 export const addSnSuffixName = (name: string = '', sn?: string) => {
   if (!name || !sn) {
     return name
   }
-  return suffixRegex.test(name) ? name : `${name} #${sn}`
+  return suffixRegex.test(name) ? name : `${name} #${trimLeadingZeros(sn)}`
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #8160


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

![Uploading image.png…]()


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7fe28e5</samp>

Improved NFT name formatting by removing leading zeros with a new utility function in `utils/nft.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7fe28e5</samp>

> _`removeZeros` helps_
> _NFT names look neater now_
> _Autumn of digits_
