### PR TITLE
:bug: cannot mint when capture fails

### DIFF
--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -120,6 +120,7 @@ const props = defineProps({
 
 const collectionId = computed(() => props.drop?.collection)
 const disabledByBackend = computed(() => props.drop?.disabled)
+const defaultImage = computed(() => props.drop?.image)
 
 const { neoModal } = useProgrammatic()
 const { $i18n } = useNuxtApp()
@@ -219,6 +220,17 @@ const scrollToTop = () => {
   })
 }
 
+const tryCapture = async () => {
+  try {
+    const imgFile = await makeScreenshot(sanitizeIpfsUrl(selectedImage.value))
+    const imageHash = await pinFileToIPFS(imgFile)
+    return imageHash
+  } catch (error) {
+    toast($i18n.t('drops.capture'))
+    return defaultImage.value
+  }
+}
+
 const handleSubmitMint = async () => {
   if (!isLogIn.value) {
     neoModal.open({
@@ -233,8 +245,7 @@ const handleSubmitMint = async () => {
   try {
     isImageFetching.value = true
 
-    const imgFile = await makeScreenshot(sanitizeIpfsUrl(selectedImage.value))
-    const imageHash = await pinFileToIPFS(imgFile)
+    const imageHash = await tryCapture()
 
     const hash = await createUnlockableMetadata(
       imageHash,

--- a/locales/en.json
+++ b/locales/en.json
@@ -1396,7 +1396,9 @@
     "mintingEnded": "Ended",
     "mintedBy": "Minted By",
     "mintPerAddress": "Each address can mint only once",
-    "recentMints": "Recent NFT Mints"
+    "recentMints": "Recent NFT Mints",
+    "capture": "Unable to screenshot your art continuting without"
+
   },
   "confirmPurchase": {
     "action": "Confirm Purchase",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

cc @kodadot/internal 

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

#### Community participation

- [ ] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 964c777</samp>

This pull request improves the user experience and code quality of generative drops. It refactors the `Generative.vue` component to handle screenshot capture and fallback, and adds a new localization key `capture` in `locales/en.json` for the error message.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 964c777</samp>

> _`Generative.vue` is the source of our art_
> _We capture and pin the screenshots of our drops_
> _But sometimes the capture fails and we fall apart_
> _Unable to screenshot your art continuing without_
