### PR TITLE
Collection-activity-toggle-hide-outliers

### DIFF
--- a/assets/styles/components/_price-chart.scss
+++ b/assets/styles/components/_price-chart.scss
@@ -6,13 +6,13 @@
     left: 0;
     top: 0;
   }
-  .neo-dropdown {
+  .time-range-dropdown {
     $width: 89px;
     $height: 30px;
     $font-size: 12px;
 
     position: absolute;
-    right: 10px;
+    right: 60px;
     top: -8px;
     font-size: $font-size;
 

--- a/components/chart/PriceChart.vue
+++ b/components/chart/PriceChart.vue
@@ -29,11 +29,7 @@
       position="bottom-left">
       <template #trigger>
         <NeoButton no-shadow variant="icon">
-          <NeoIcon
-            icon="gear"
-            pack="fas"
-            size="medium"
-            :color="isDarkMode ? 'white' : 'black'" />
+          <NeoIcon icon="gear" pack="fas" size="medium" />
         </NeoButton>
       </template>
 

--- a/components/chart/PriceChart.vue
+++ b/components/chart/PriceChart.vue
@@ -3,7 +3,7 @@
     <span class="chart-y-description is-size-7">
       Price ({{ chainSymbol }})
     </span>
-    <NeoDropdown class="py-0" :mobile-modal="false">
+    <NeoDropdown class="py-0 time-range-dropdown" :mobile-modal="false">
       <template #trigger="{ active }">
         <NeoButton
           :label="selectedTimeRange.label"
@@ -23,6 +23,29 @@
       </NeoDropdownItem>
     </NeoDropdown>
 
+    <NeoDropdown
+      :mobile-modal="false"
+      class="chart-setting-icon min-width-fit-content"
+      position="bottom-left">
+      <template #trigger>
+        <NeoButton no-shadow variant="icon">
+          <NeoIcon
+            icon="gear"
+            pack="fas"
+            size="medium"
+            :color="isDarkMode ? 'white' : 'black'" />
+        </NeoButton>
+      </template>
+
+      <NeoDropdownItem class="px-4 py-3">
+        <div
+          class="w-full is-flex is-justify-content-space-between is-align-items-center">
+          <div class="no-wrap mr-5">{{ $t('activity.hideOutliers') }}</div>
+          <NeoCheckbox v-model="vHideOutliers" class="m-0" />
+        </div>
+      </NeoDropdownItem>
+    </NeoDropdown>
+
     <div :class="{ content: !chartHeight }" :style="heightStyle">
       <canvas id="priceChart" />
     </div>
@@ -35,8 +58,14 @@ import 'chartjs-adapter-date-fns'
 import zoomPlugin from 'chartjs-plugin-zoom'
 import { getChartData } from '@/utils/chart'
 import { format } from 'date-fns'
-import { NeoButton, NeoDropdown, NeoDropdownItem } from '@kodadot1/brick'
-import { useEventListener } from '@vueuse/core'
+import {
+  NeoButton,
+  NeoCheckbox,
+  NeoDropdown,
+  NeoDropdownItem,
+  NeoIcon,
+} from '@kodadot1/brick'
+import { useEventListener, useVModel } from '@vueuse/core'
 ChartJS.register(zoomPlugin)
 const { $i18n } = useNuxtApp()
 const { chainSymbol } = useChain()
@@ -71,7 +100,11 @@ const setTimeRange = (value: { value: number; label: string }) => {
 const props = defineProps<{
   priceChartData?: [Date, number][][]
   chartHeight?: string
+  modelValue: boolean
 }>()
+const emit = defineEmits(['update:modelValue'])
+
+const vHideOutliers = useVModel(props, 'modelValue', emit)
 
 const heightStyle = computed(() =>
   props.chartHeight ? `height: ${props.chartHeight}` : '',
@@ -300,5 +333,17 @@ watch([isDarkMode, selectedTimeRange], () => {
 <style scoped>
 .content {
   height: 15rem;
+}
+
+.chart-setting-icon {
+  position: absolute;
+  right: 8px;
+  top: -3px;
+}
+
+.min-width-fit-content {
+  :deep(.o-drop__menu) {
+    min-width: fit-content !important;
+  }
 }
 </style>

--- a/components/chart/PriceChart.vue
+++ b/components/chart/PriceChart.vue
@@ -27,16 +27,22 @@
       :mobile-modal="false"
       class="chart-setting-icon min-width-fit-content"
       position="bottom-left">
-      <template #trigger>
+      <template #trigger="{ active }">
         <NeoButton no-shadow variant="icon">
-          <NeoIcon icon="gear" pack="fas" size="medium" />
+          <NeoIcon
+            icon="gear"
+            pack="fass"
+            size="large"
+            :variant="!active ? 'k-grey' : undefined" />
         </NeoButton>
       </template>
 
-      <NeoDropdownItem class="px-4 py-3">
+      <NeoDropdownItem class="px-4 py-3 no-hover">
         <div
           class="w-full is-flex is-justify-content-space-between is-align-items-center">
-          <div class="no-wrap mr-5">{{ $t('activity.hideOutliers') }}</div>
+          <div class="no-wrap mr-5 is-size-7">
+            {{ $t('activity.hideOutliers') }}
+          </div>
           <NeoCheckbox v-model="vHideOutliers" class="m-0" />
         </div>
       </NeoDropdownItem>
@@ -334,7 +340,7 @@ watch([isDarkMode, selectedTimeRange], () => {
 .chart-setting-icon {
   position: absolute;
   right: 8px;
-  top: -3px;
+  top: -5px;
 }
 
 .min-width-fit-content {

--- a/components/collection/activity/ActivityChart.vue
+++ b/components/collection/activity/ActivityChart.vue
@@ -1,6 +1,7 @@
 <template>
   <PriceChart
     v-if="events.length > 0"
+    v-model="hideOutliers"
     :price-chart-data="chartData"
     chart-height="350px"
     data-testid="collection-activity-chart" />
@@ -29,6 +30,7 @@ const props = withDefaults(
     events: () => [],
   },
 )
+const hideOutliers = ref(true)
 
 const buyEvents = computed(() =>
   sortAsc(
@@ -43,7 +45,7 @@ const listEvents = computed(() => {
       .filter((e) => e.interaction === Interaction.LIST)
       .map(toDataPoint),
   )
-  return removeOutliers(listDataPoints)
+  return hideOutliers.value ? removeOutliers(listDataPoints) : listDataPoints
 })
 
 const chartData = computed(() => {

--- a/libs/ui/src/components/NeoDropdown/NeoDropdown.vue
+++ b/libs/ui/src/components/NeoDropdown/NeoDropdown.vue
@@ -60,7 +60,7 @@ export default {
           [this.computedClass(
             'menuPositionClass',
             'o-drop__menu--',
-            this.autoPosition,
+            this.position,
           )]: this.autoPosition,
         },
         {

--- a/locales/en.json
+++ b/locales/en.json
@@ -901,7 +901,8 @@
     "noResults": "Looks Like There's Nothing Here Yet",
     "noFlips": "Looks like it's quiet in here",
     "noHolders": "Start collecting NFTs and make your mark at the top!",
-    "noResultsSub": "Check back later or reset your filters"
+    "noResultsSub": "Check back later or reset your filters",
+    "hideOutliers": "Hide Outliers"
   },
   "profileStats": {
     "listed": "Listed",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Feature


## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #8234
- [x] Closes #8108

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/22791238/716ae06d-46e3-4a2d-9245-9597ff23e627)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 74bbdff</samp>

Added a feature to hide outliers in the price charts of NFT collections and the global market. Improved the UI and positioning of the dropdown components used to control the chart options. Refactored the `NeoDropdown.vue` component and updated the translation file.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 74bbdff</samp>

> _Sing, O Muse, of the skillful coder who refined the chart_
> _Of the collection's price, with many a clever art._
> _He made a dropdown menu, `NeoDropdown`, shining bright,_
> _And gave it a position prop, to place it left or right._
