### PR TITLE
LatestSales---show-sale-price

### DIFF
--- a/components/base/types.ts
+++ b/components/base/types.ts
@@ -30,6 +30,7 @@ export interface CarouselNFT extends ItemResources {
   }
   name: string
   price: string
+  latestSalePrice?: string
   timestamp: string
   unixTime: number
   metadata?: string

--- a/components/carousel/module/CarouselInfo.vue
+++ b/components/carousel/module/CarouselInfo.vue
@@ -41,7 +41,9 @@
           inline
           :prefix="item.chain"
           :unit-symbol="unitSymbol" />
-        <span class="ml-2 has-text-grey is-size-7">- Sold</span>
+        <span v-if="showSold" class="ml-2 has-text-grey is-size-7"
+          >- {{ $t('spotlight.sold') }}</span
+        >
       </div>
       <p class="is-size-7 chain-name is-capitalized">{{ chainName }}</p>
     </div>
@@ -74,6 +76,7 @@ const chainName = computed(() => {
 })
 
 const price = computed(() => props.item.latestSalePrice ?? props.item.price)
+const showSold = computed(() => Number(props.item.latestSalePrice) > 0)
 
 const showPrice = computed((): boolean => {
   return Number(price.value) > 0 && !isCollection

--- a/components/carousel/module/CarouselInfo.vue
+++ b/components/carousel/module/CarouselInfo.vue
@@ -35,12 +35,14 @@
           ? 'is-justify-content-space-between'
           : 'is-justify-content-end',
       ]">
-      <Money
-        v-if="showPrice"
-        :value="item.price"
-        inline
-        :prefix="item.chain"
-        :unit-symbol="unitSymbol" />
+      <div v-if="showPrice" class="is-flex is-align-items-center">
+        <Money
+          :value="price"
+          inline
+          :prefix="item.chain"
+          :unit-symbol="unitSymbol" />
+        <span class="ml-2 has-text-grey is-size-7">- Sold</span>
+      </div>
       <p class="is-size-7 chain-name is-capitalized">{{ chainName }}</p>
     </div>
   </div>
@@ -71,8 +73,10 @@ const chainName = computed(() => {
   return getChainNameByPrefix(props.item.chain || urlPrefix.value)
 })
 
+const price = computed(() => props.item.latestSalePrice ?? props.item.price)
+
 const showPrice = computed((): boolean => {
-  return Number(props.item.price) > 0 && !isCollection
+  return Number(price.value) > 0 && !isCollection
 })
 
 const unitSymbol = computed(() => prefixToToken[props.item.chain || 'ksm'])

--- a/components/carousel/utils/useCarouselEvents.ts
+++ b/components/carousel/utils/useCarouselEvents.ts
@@ -39,7 +39,9 @@ const fetchLatestEvents = async (chain, type, where = {}, limit = 5) => {
 }
 
 const useChainEvents = async (chain, type, eventQueryLimit, collectionIds) => {
-  const nfts = ref<{ nft: NFTWithMetadata; timestamp: string }[]>([])
+  const nfts = ref<
+    { nft: NFTWithMetadata; timestamp: string; latestSalePrice?: string }[]
+  >([])
   const uniqueNftId = ref<string[]>([])
   const totalCollection = reactive({})
   const excludeCollectionId = ref<string[]>([])
@@ -54,6 +56,9 @@ const useChainEvents = async (chain, type, eventQueryLimit, collectionIds) => {
   const pushNft = (nft) => {
     if (!uniqueNftId.value.includes(nft.nft.id) && nfts.value.length < limit) {
       uniqueNftId.value.push(nft.nft.id)
+      if (type === 'latestSales') {
+        nft.latestSalePrice = nft.meta
+      }
       nfts.value.push(nft)
     }
   }
@@ -107,6 +112,7 @@ export const flattenNFT = (data, chain) => {
     return {
       ...nft.nft,
       timestamp: nft.timestamp,
+      latestSalePrice: nft.latestSalePrice,
     }
   })
 

--- a/queries/subsquid/general/latestEvents.graphql
+++ b/queries/subsquid/general/latestEvents.graphql
@@ -4,6 +4,7 @@ query latestEvents(
   $where: EventWhereInput
 ) {
   events(limit: $limit, orderBy: $orderBy, where: $where) {
+    meta
     nft {
       id
       name

--- a/queries/subsquid/ksm/latestEvents.graphql
+++ b/queries/subsquid/ksm/latestEvents.graphql
@@ -4,6 +4,7 @@ query latestEvents(
   $where: EventWhereInput
 ) {
   events(limit: $limit, orderBy: $orderBy, where: $where) {
+    meta
     nft {
       id
       name


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type


- [x] Feature


## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #8109

#### Did your issue had any of the "$" label on it?
Yes $

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [x] My fix has changed UI

![Uploading image.png…]()


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 665e723</samp>

This pull request adds a feature to display the latest sale price and a sold label for NFTs that have been sold recently in the `CarouselInfo` component. It also updates the GraphQL queries and the `CarouselNFT` interface to include the sale price data from the chain events.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 665e723</samp>

> _`CarouselNFT` shows_
> _latest sale price from `meta`_
> _autumn leaves fall fast_
