### PR TITLE
fix: floor price dose not load on profile page

### DIFF
--- a/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
+++ b/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
@@ -199,7 +199,7 @@ const onClickShoppingCart = async () => {
 const onClickListingCart = async () => {
   const nftsToProcess = await getTokensNfts([props.entity])
 
-  const floorPrice = nftsToProcess[0].collection.floorPrice[0].price
+  const floorPrice = nftsToProcess[0].collection.floorPrice[0]?.price || '0'
 
   for (const nft of nftsToProcess) {
     if (listingCartStore.isItemInCart(nft.id)) {

--- a/queries/subsquid/ahk/nftListWithSearch.graphql
+++ b/queries/subsquid/ahk/nftListWithSearch.graphql
@@ -27,14 +27,11 @@ query nftListWithSearch(
     collection {
       id
       name
-      floorPrice: nfts (
-        where: {
-          burned_eq: false,
-          },
-        orderBy: price_ASC,
+      floorPrice: nfts(
+        where: { burned_eq: false, price_gt: "0" }
+        orderBy: price_ASC
         limit: 1
-      ) 
-      {
+      ) {
         price
       }
     }

--- a/queries/subsquid/general/nftListWithSearch.graphql
+++ b/queries/subsquid/general/nftListWithSearch.graphql
@@ -28,7 +28,7 @@ query nftListWithSearch(
       id
       name
       floorPrice: nfts(
-        where: { burned_eq: false }
+        where: { burned_eq: false, price_gt: "0" }
         orderBy: price_ASC
         limit: 1
       ) {

--- a/queries/subsquid/ksm/nftListWithSearch.graphql
+++ b/queries/subsquid/ksm/nftListWithSearch.graphql
@@ -27,14 +27,11 @@ query nftListWithSearch(
     collection {
       id
       name
-      floorPrice: nfts (
-        where: {
-          burned_eq: false,
-          },
-        orderBy: price_ASC,
+      floorPrice: nfts(
+        where: { burned_eq: false, price_gt: "0" }
+        orderBy: price_ASC
         limit: 1
-      ) 
-      {
+      ) {
         price
       }
     }

--- a/queries/subsquid/rmrk/nftListWithSearch.graphql
+++ b/queries/subsquid/rmrk/nftListWithSearch.graphql
@@ -26,14 +26,11 @@ query nftListWithSearch(
     collection {
       id
       name
-      floorPrice: nfts (
-        where: {
-          burned_eq: false,
-          },
-        orderBy: price_ASC,
+      floorPrice: nfts(
+        where: { burned_eq: false, price_gt: "0" }
+        orderBy: price_ASC
         limit: 1
-      ) 
-      {
+      ) {
         price
       }
     }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  
  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8245 

(The issue related with width of modal was solved in another PR #8255)

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="423" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1504d3f0-c0e6-4a23-b7ab-93faba4cac22">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8c9bd44</samp>

This pull request fixes the floor price calculation and display for different collections of nfts. It adds a fallback value of `0` for the floor price in `ItemsGridImageTokenEntity.vue` and filters out zero-priced nfts from the queries in `nftListWithSearch.graphql` files.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8c9bd44</samp>

> _`floorPrice` query_
> _filters out zero values_
> _no more false floors - spring_
  