### PR TITLE
fix: Gap between banner and navbar

### DIFF
--- a/assets/styles/layouts/_main-navigation.scss
+++ b/assets/styles/layouts/_main-navigation.scss
@@ -355,4 +355,7 @@
 
 .has-navbar-fixed-top {
   padding-top: $navbar-desktop-min-height !important;
+  @include mobile {
+    padding-top: $navbar-mobile-min-height !important;
+  }
 }

--- a/assets/styles/layouts/_main-navigation.scss
+++ b/assets/styles/layouts/_main-navigation.scss
@@ -352,3 +352,7 @@
     height: 2.5rem;
   }
 }
+
+.has-navbar-fixed-top {
+  padding-top: $navbar-desktop-min-height !important;
+}

--- a/components/collection/collectionInfoLine.vue
+++ b/components/collection/collectionInfoLine.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="is-flex mb-2 is-align-items-center no-wrap">
     <div class="is-size-7 k-grey pr-4 is-flex-grow-1">{{ title }}:</div>
-    <div class="has-text-weight-bold">
+    <div class="has-text-weight-bold is-flex">
       <slot>
         <div>{{ value }}</div>
       </slot>


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8225

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 


![CleanShot 2023-11-27 at 11 57 23@2x](https://github.com/kodadot/nft-gallery/assets/44554284/f6ca202d-8619-41e4-a17f-dad2ebcf59fe)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4aa7966</samp>

Adjust body padding-top when navbar is fixed. This change improves the layout of the main navigation and the content area.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4aa7966</samp>

> _`padding-top` adjusts_
> _navbar and sidebar fixed_
> _autumn layout woes_


