### PR TITLE
feat: Lazy Drops

### DIFF
--- a/components/collection/drop/DropContainer.vue
+++ b/components/collection/drop/DropContainer.vue
@@ -115,6 +115,7 @@ import {
 import { useCountDown } from '../unlockable/utils/useCountDown'
 import { MINT_ADDRESS, countDownTime } from './const'
 import { DropItem } from '@/params/types'
+import { useDropStatus } from '@/components/drops/useDrops'
 
 import { TokenToBuy } from '@/composables/transaction/types'
 
@@ -137,6 +138,7 @@ const props = defineProps({
 
 const collectionId = computed(() => props.drop?.collection)
 const pricePerMint = computed(() => props.drop?.meta)
+const { mintedDropCount, fetchDropStatus } = useDropStatus(props.drop.alias)
 
 const { neoModal } = useProgrammatic()
 const { $i18n } = useNuxtApp()
@@ -180,7 +182,7 @@ const totalCount = computed(
   () => collectionData.value?.collectionEntity?.nftCount || 200,
 )
 const totalAvailableMintCount = computed(
-  () => collectionData.value?.nftEntitiesConnection?.totalCount,
+  () => totalCount.value - Math.min(mintedDropCount.value, totalCount.value),
 )
 
 const { data, refetch } = useGraphql({
@@ -311,6 +313,7 @@ const handleSubmitMint = async (tokenId: string) => {
       justMinted.value = `${collectionId.value}-${res.result.sn}`
       scrollToTop()
     })
+    fetchDropStatus()
   } catch (error) {
     toast('failed to mint')
   } finally {

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -17,9 +17,7 @@
           <div
             class="is-flex is-justify-content-space-between is-align-items-center my-5">
             <span class="">Total available items</span>
-            <span class=""
-              >{{ totalAvailableMintCount }} / {{ totalCount }}</span
-            >
+            <span class="">{{ totalAvailableMintCount }} / {{ maxCount }}</span>
           </div>
           <UnlockableTag :collection-id="collectionId" />
 
@@ -109,6 +107,7 @@ import { NeoButton } from '@kodadot1/brick'
 import { useCountDown } from './utils/useCountDown'
 import CarouselTypeLatestMints from '@/components/carousel/CarouselTypeLatestMints.vue'
 import { DropItem } from '@/params/types'
+import { useDropStatus } from '@/components/drops/useDrops'
 
 const props = defineProps({
   drop: {
@@ -130,9 +129,11 @@ const selectedImage = ref('')
 const MAX_PER_WINDOW = 10
 
 const isLoading = ref(false)
-const { accountId, isLogIn } = useAuth()
+const { isLogIn } = useAuth()
 const { hours, minutes, seconds } = useCountDown(countDownTime)
 const justMinted = ref('')
+const { currentAccountMintedToken, mintedDropCount, fetchDropStatus } =
+  useDropStatus(props.drop.alias)
 
 onMounted(async () => {
   const res = await getLatestWaifuImages()
@@ -164,29 +165,17 @@ const { data: collectionData } = useGraphql({
   },
 })
 
-const {
-  data: stats,
-  loading: currentMintedLoading,
-  refetch: tryAgain,
-} = useGraphql({
-  queryName: 'firstNftOwnedByAccountAndCollectionId',
-  variables: {
-    id: collectionId.value,
-    account: accountId.value,
-  },
-})
-
-const hasUserMinted = computed(
-  () => stats.value?.collection.nfts?.at(0)?.id || justMinted.value,
+const hasUserMinted = computed(() =>
+  currentAccountMintedToken.value
+    ? `${collectionId.value}-${currentAccountMintedToken.value.id}`
+    : justMinted.value,
 )
 
-const totalCount = computed(
+const maxCount = computed(
   () => collectionData.value?.collectionEntity?.max || 300,
 )
 const totalAvailableMintCount = computed(
-  () =>
-    totalCount.value -
-    (collectionData.value?.nftEntitiesConnection?.totalCount || 0),
+  () => maxCount.value - Math.min(mintedDropCount.value, maxCount.value),
 )
 
 const { data, refetch } = useGraphql({
@@ -200,7 +189,6 @@ const { data, refetch } = useGraphql({
 
 const refetchData = async () => {
   await refetch()
-  await tryAgain()
 }
 
 useSubscriptionGraphql({
@@ -208,12 +196,6 @@ useSubscriptionGraphql({
     nftCount
   }`,
   onChange: refetchData,
-})
-
-watch(accountId, () => {
-  tryAgain({
-    account: accountId.value,
-  })
 })
 
 const mintedCount = computed(() => data.value?.minted?.count || 0)
@@ -271,6 +253,7 @@ const handleSubmitMint = async () => {
       scrollToTop()
       return `${collectionId.value}-${res.result.sn}`
     })
+    fetchDropStatus()
     // 40s timeout
     setTimeout(() => {
       isLoading.value = false

--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -77,14 +77,9 @@ export const useDropStatus = (id: string) => {
       ? await getDropMintedStatus(id, accountId.value)
       : null
   }
+  onBeforeMount(fetchDropStatus)
 
-  watch(accountId, () => {
-    fetchDropStatus()
-  })
-
-  onBeforeMount(() => {
-    fetchDropStatus()
-  })
+  watch(accountId, fetchDropStatus)
 
   return {
     currentAccountMintedToken,

--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -1,5 +1,10 @@
 import { CollectionWithMeta } from '../rmrk/service/scheme'
-import { getDropById, getDrops } from '@/services/waifu'
+import {
+  getDropById,
+  getDropMintedStatus,
+  getDropStatus,
+  getDrops,
+} from '@/services/waifu'
 import unlockableCollectionById from '@/queries/subsquid/general/unlockableCollectionById.graphql'
 
 export interface Drop {
@@ -28,15 +33,16 @@ export function useDrops() {
         { clientId: drop.chain },
       )
 
-      watchEffect(() => {
+      watchEffect(async () => {
         if (collectionData.value?.collectionEntity) {
-          const { collectionEntity, nftEntitiesConnection } =
-            collectionData.value
+          const { collectionEntity } = collectionData.value
+          const chainMax = collectionEntity?.max ?? 300
+          const { count } = await getDropStatus(drop.alias)
           drops.value.push({
             ...drop,
             collection: collectionEntity,
-            minted: nftEntitiesConnection.totalCount,
-            max: collectionEntity?.max ?? 300,
+            minted: Math.min(count, chainMax),
+            max: chainMax,
             dropStartTime: new Date(2023, 5, 6),
             price: ['paid', 'generative'].includes(drop.type) ? drop.meta : '0',
           })
@@ -52,4 +58,37 @@ export async function useDrop(id: string) {
   const drop = await getDropById(id)
 
   return drop
+}
+
+export const useDropStatus = (id: string) => {
+  const currentAccountMintedToken = ref<{
+    created_at: string
+    id: number
+    image: string
+    metadata: string
+  } | null>(null)
+  const mintedDropCount = ref(0)
+  const { accountId } = useAuth()
+
+  const fetchDropStatus = async () => {
+    const { count } = await getDropStatus(id)
+    mintedDropCount.value = count
+    currentAccountMintedToken.value = accountId.value
+      ? await getDropMintedStatus(id, accountId.value)
+      : null
+  }
+
+  watch(accountId, () => {
+    fetchDropStatus()
+  })
+
+  onBeforeMount(() => {
+    fetchDropStatus()
+  })
+
+  return {
+    currentAccountMintedToken,
+    mintedDropCount,
+    fetchDropStatus,
+  }
 }

--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -1,5 +1,6 @@
 import { CollectionWithMeta } from '../rmrk/service/scheme'
 import {
+  DropMintedStatus,
   getDropById,
   getDropMintedStatus,
   getDropStatus,
@@ -61,12 +62,7 @@ export async function useDrop(id: string) {
 }
 
 export const useDropStatus = (id: string) => {
-  const currentAccountMintedToken = ref<{
-    created_at: string
-    id: number
-    image: string
-    metadata: string
-  } | null>(null)
+  const currentAccountMintedToken = ref<DropMintedStatus | null>(null)
   const mintedDropCount = ref(0)
   const { accountId } = useAuth()
 

--- a/params/types.ts
+++ b/params/types.ts
@@ -69,5 +69,5 @@ export type DropItem = {
   alias: string
   type: DropType
   meta: string
-  disabled: boolean
+  disabled: number
 }

--- a/queries/subsquid/general/firstNftOwnedByAccountAndCollectionId.graphql
+++ b/queries/subsquid/general/firstNftOwnedByAccountAndCollectionId.graphql
@@ -1,8 +1,0 @@
-query firstNftOwnedByAccountAndCollectionId($id: String!, $account: String!) {
-  collection: collectionEntityById(id: $id) {
-    id
-    nfts(limit: 1, where: { currentOwner_eq:$account, burned_eq: false }) {
-      id
-    }
-  }
-}

--- a/services/waifu.ts
+++ b/services/waifu.ts
@@ -29,13 +29,16 @@ export const getDropStatus = async (alias: string) => {
   })
 }
 
+export type DropMintedStatus = {
+  created_at: string
+  id: number
+  image: string
+  metadata: string
+}
 export const getDropMintedStatus = async (alias: string, accountId: string) => {
-  return await api<{ id: string; image: string }>(
-    `/drops/${alias}/accounts/${accountId}`,
-    {
-      method: 'GET',
-    },
-  )
+  return await api<DropMintedStatus>(`/drops/${alias}/accounts/${accountId}`, {
+    method: 'GET',
+  })
 }
 
 export const getLatestWaifuImages = async () => {

--- a/services/waifu.ts
+++ b/services/waifu.ts
@@ -23,6 +23,21 @@ export const getDropById = async (id: string) => {
   })
 }
 
+export const getDropStatus = async (alias: string) => {
+  return await api<{ count: number }>(`/drops/${alias}/status`, {
+    method: 'GET',
+  })
+}
+
+export const getDropMintedStatus = async (alias: string, accountId: string) => {
+  return await api<{ id: string; image: string }>(
+    `/drops/${alias}/accounts/${accountId}`,
+    {
+      method: 'GET',
+    },
+  )
+}
+
 export const getLatestWaifuImages = async () => {
   const value = await api<{
     result: { id: string; output: string; image: string }[]


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  - [x] Feature

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8268
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a923299</samp>

This pull request improves the accuracy and performance of the drop components by using the `useDropStatus` function and the `services/waifu.ts` API to fetch and update the minted status of drops from the blockchain. It also refactors some components to use the `maxCount` property and the `disabled` timestamp of drops, and deletes an unused GraphQL query file.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a923299</samp>

> _To show when and why drops are disabled_
> _The `disabled` prop was made able_
> _To store a timestamp as a number_
> _Instead of a boolean, how clever_
> _This change was part of a pull request table_
  