### PR TITLE
fix: Search Hard to read (adjust colours)

### DIFF
--- a/components/shared/gallery/NeoTag.vue
+++ b/components/shared/gallery/NeoTag.vue
@@ -47,12 +47,14 @@ const onClose = () => {
   border-radius: 1rem !important;
   background: transparent;
   font-size: 1rem !important;
+  @include ktheme() {
+    color: theme('text-color');
+  }
 
   &--primary {
     @include ktheme() {
       border: 1px solid theme('k-primary');
       background-color: theme('k-accentlight2');
-      color: theme('text-color');
       .cross-icon {
         &:hover {
           color: theme('k-grey');
@@ -64,7 +66,6 @@ const onClose = () => {
   &--transparent {
     @include ktheme() {
       border: 1px solid theme('border-color');
-      color: theme('text-color');
       background: transparent;
     }
   }

--- a/components/shared/gallery/NeoTag.vue
+++ b/components/shared/gallery/NeoTag.vue
@@ -47,9 +47,7 @@ const onClose = () => {
   border-radius: 1rem !important;
   background: transparent;
   font-size: 1rem !important;
-  @include ktheme() {
-    color: theme('text-color');
-  }
+  @apply text-text-color #{!important};
 
   &--primary {
     @include ktheme() {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #8283

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1252" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/ff9abcf7-5511-4426-93bd-7dbd6fe320b0">

<img width="921" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/bdb5e2f4-29c2-49c6-aeef-cb1f55504d43">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07c697a</samp>

Improved color styling of `.tag` component using ktheme mixin. This change affects the `NeoTag.vue` file and enhances the UI design.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07c697a</samp>

> _Oh we're the coders of the `.tag` component_
> _And we like to keep our colors nice and bright_
> _We use the ktheme mixin for our styling_
> _So we can make our UI more accessible and tight_
  