### PR TITLE
fix: Chart tooltip is in background

### DIFF
--- a/components/chart/PriceChart.vue
+++ b/components/chart/PriceChart.vue
@@ -237,6 +237,8 @@ const getPriceChartData = () => {
               },
             },
             tooltip: {
+              xAlign: 'center',
+              yAlign: 'top',
               callbacks: {
                 label: function (context) {
                   return `Price: ${context.parsed.y} ${chainSymbol.value}`

--- a/components/shared/collection/PriceChart.vue
+++ b/components/shared/collection/PriceChart.vue
@@ -97,6 +97,8 @@ const priceChart = () => {
       maintainAspectRatio: false,
       plugins: {
         tooltip: {
+          xAlign: 'center',
+          yAlign: 'top',
           callbacks: {
             afterLabel: ({ dataIndex, dataset }) => {
               return `Count: ${dataset.data[dataIndex]?.count || 0}`


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8285
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="611" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/b158d38a-6334-4950-a7e2-d8c17d90793c">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3602bed</samp>

The pull request modifies the tooltip options of the `PriceChart` component in two files: `components/chart/PriceChart.vue` and `components/shared/collection/PriceChart.vue`. The changes center the tooltip on the x-axis and place it on the top of the y-axis, to improve the readability and consistency of the price charts.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3602bed</samp>

> _`PriceChart` tooltip_
> _Aligns with x and y axis_
> _A clear winter view_
  