### PR TITLE
:wrench: new drop is snowflakes

### DIFF
--- a/components/carousel/CarouselTypeGenerative.vue
+++ b/components/carousel/CarouselTypeGenerative.vue
@@ -12,6 +12,6 @@ import { useCarouselGenerativeNftEvents } from './utils/useCarouselEvents'
 
 const { nfts, ids } = await useCarouselGenerativeNftEvents(
   ['176'],
-  ['38', '40'],
+  ['38', '40', '46'],
 )
 </script>

--- a/components/collection/unlockable/UnlockableLandingTag.vue
+++ b/components/collection/unlockable/UnlockableLandingTag.vue
@@ -14,7 +14,7 @@
     <div class="separator mx-2" />
     <nuxt-link
       class="is-flex is-align-items-center has-text-weight-bold my-2"
-      to="/ahp/drops/swirls">
+      to="/ahp/drops/snowflakes">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

We have new drop! (yay!)



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b3280c</samp>

This pull request adds support for the Snowflakes collection, a new generative NFT drop by the AHP project, to the carousel component. It updates the function that fetches the generative NFTs and the link that leads to the landing page of the drop.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b3280c</samp>

> _`useCarousel` fetches_
> _Snowflakes, new NFTs for winter_
> _Link points to landing_
