### PR TITLE
fix: Loading screen boring

### DIFF
--- a/components/collection/drop/DropContainer.vue
+++ b/components/collection/drop/DropContainer.vue
@@ -3,7 +3,8 @@
     <CollectionUnlockableLoader
       v-if="isLoading"
       model-value
-      :minted="justMinted" />
+      :minted="justMinted"
+      @model-value="isLoading = false" />
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid">

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -2,8 +2,9 @@
   <div class="unlockable-container">
     <CollectionUnlockableLoader
       v-if="isLoading"
+      :minted="justMinted"
       model-value
-      :minted="justMinted" />
+      @model-value="isLoading = false" />
     <div class="container is-fluid border-top">
       <div class="columns is-desktop">
         <div class="column is-half-desktop mobile-padding">

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -2,6 +2,7 @@
   <div class="unlockable-container">
     <CollectionUnlockableLoader
       v-if="isLoading"
+      :duration="MINTING_SECOND"
       :minted="justMinted"
       model-value
       @model-value="isLoading = false" />
@@ -110,6 +111,7 @@ import { pinFileToIPFS } from '@/services/nftStorage'
 import { sanitizeIpfsUrl } from '@/utils/ipfs'
 
 const NuxtLink = resolveComponent('NuxtLink')
+const MINTING_SECOND = 120
 
 const props = defineProps({
   drop: {
@@ -221,6 +223,7 @@ const handleSubmitMint = async () => {
 
   try {
     isImageFetching.value = true
+    isLoading.value = true
 
     const imageHash = await tryCapture()
 
@@ -235,7 +238,6 @@ const handleSubmitMint = async () => {
     isImageFetching.value = false
 
     const { accountId } = useAuth()
-    isLoading.value = true
 
     const id = await doWaifu(
       {
@@ -257,7 +259,7 @@ const handleSubmitMint = async () => {
       justMinted.value = id
       toast('You will be redirected in few seconds', { duration: 3000 })
       return navigateTo(`/${urlPrefix.value}/gallery/${id}`)
-    }, 44000)
+    }, MINTING_SECOND * 1000)
   } catch (error) {
     toast($i18n.t('drops.mintPerAddress'))
     isLoading.value = false

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -3,7 +3,8 @@
     <CollectionUnlockableLoader
       v-if="isLoading"
       model-value
-      :minted="justMinted" />
+      :minted="justMinted"
+      @model-value="isLoading = false" />
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid">

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -89,10 +89,10 @@ const postTwitterUrl = computed(
       twitterText.value,
     )}`,
 )
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['modelValue'])
 
 const closeLoading = () => {
-  emit('update:modelValue', false)
+  emit('modelValue', false)
 }
 const buttonLabel = computed(() =>
   $i18n.t(

--- a/components/collection/unlockable/UnlockableLoader.vue
+++ b/components/collection/unlockable/UnlockableLoader.vue
@@ -23,8 +23,7 @@
           <span v-else>
             {{ $t('mint.unlockable.loader.viewNFTLater2') }}
             <span class="has-text-weight-bold">
-              {{ displaySeconds }}
-              {{ $t('mint.unlockable.loader.viewNFTLater3') }}
+              {{ displayDuration }}
             </span>
           </span>
         </div>
@@ -50,6 +49,7 @@
 <script lang="ts" setup>
 import { NeoButton, NeoLoading } from '@kodadot1/brick'
 import { resolveComponent } from 'vue'
+import { useCountDown } from './utils/useCountDown'
 
 const NuxtLink = resolveComponent('NuxtLink')
 const props = withDefaults(
@@ -57,25 +57,30 @@ const props = withDefaults(
     modelValue: boolean
     canCancel?: boolean
     minted?: string
+    duration?: number
   }>(),
   {
     modelValue: false,
     canCancel: true,
+    duration: 51, // second
     minted: '',
   },
 )
 const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
 const isLoading = useVModel(props, 'modelValue')
-import { useCountDown } from './utils/useCountDown'
 
-const COUNT_DOWN_SECONDS = 51
-const { seconds } = useCountDown(
-  new Date().getTime() + COUNT_DOWN_SECONDS * 1000,
+const { minutes, seconds } = useCountDown(
+  new Date().getTime() + props.duration * 1000,
 )
 
-const displaySeconds = computed(() => {
-  return seconds.value >= 0 ? seconds.value : 'few'
+const displayDuration = computed(() => {
+  if (minutes.value > 0) {
+    return `${minutes.value} minute${minutes.value > 1 ? 's' : ''}${
+      seconds.value ? ` ${seconds.value} seconds` : ''
+    }`
+  }
+  return seconds.value >= 0 ? `${seconds.value} seconds` : 'few seconds'
 })
 
 const twitterText = computed(

--- a/components/collection/voteDrop/DropContainer.vue
+++ b/components/collection/voteDrop/DropContainer.vue
@@ -3,7 +3,8 @@
     <CollectionUnlockableLoader
       v-if="isLoading"
       model-value
-      :minted="justMinted" />
+      :minted="justMinted"
+      @model-value="isLoading = false" />
     <CountdownTimer />
     <hr class="text-color my-0" />
     <div class="container is-fluid pb-4">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8307
  - [x] Closes #8296

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![Kapture 2023-11-30 at 18 45 22](https://github.com/kodadot/nft-gallery/assets/31397967/3b176f73-f1d6-4461-8e78-484b2ba8f07a)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 379646d</samp>

This pull request refactors the `CollectionUnlockableLoader` component and its usage in different drop types. It simplifies the loading logic by delegating the loading state to the parent components and using a consistent event name.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 379646d</samp>

> _`model-value` changes_
> _loading state is now controlled_
> _by parent components_
  