### PR TITLE
fix: When switching from transfer on polkadot, refresh network

### DIFF
--- a/middleware/prefix.global.ts
+++ b/middleware/prefix.global.ts
@@ -17,7 +17,7 @@ export default defineNuxtRouteMiddleware((route) => {
 
   if (
     [urlPrefix.value, prefixInPath].includes('dot') &&
-    route.path !== '/dot/transfer'
+    route.name !== 'prefix-transfer'
   ) {
     setUrlPrefix('ahp')
     navigateTo(route.path.replace(prefixInPath, 'ahp'))

--- a/middleware/prefix.global.ts
+++ b/middleware/prefix.global.ts
@@ -15,6 +15,15 @@ export default defineNuxtRouteMiddleware((route) => {
     (prefix) => location.hostname.startsWith(`${prefix}.`),
   )
 
+  if (
+    [urlPrefix.value, prefixInPath].includes('dot') &&
+    route.path !== '/dot/transfer'
+  ) {
+    setUrlPrefix('ahp')
+    navigateTo(route.path.replace(prefixInPath, 'ahp'))
+    return
+  }
+
   if (rmrk2ChainPrefixInHostname) {
     // fixed chain domain (for example: rmrk2.kodadot.xyz)
 

--- a/pages/[prefix]/explore/collectibles.vue
+++ b/pages/[prefix]/explore/collectibles.vue
@@ -12,7 +12,7 @@ const { urlPrefix } = usePrefix()
 
 const checkRouteAvailability = () => {
   if (!explorerVisible(urlPrefix.value)) {
-    navigateTo('/')
+    navigateTo('/ahp/explore/collectibles')
   }
 }
 

--- a/pages/[prefix]/explore/items.vue
+++ b/pages/[prefix]/explore/items.vue
@@ -17,7 +17,7 @@ const isSidebarOpen = computed(() => preferencesStore.getsidebarFilterCollapse)
 
 const checkRouteAvailability = () => {
   if (!explorerVisible(urlPrefix.value)) {
-    navigateTo('/')
+    navigateTo('/ahp/explore/items')
   }
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  
  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8321
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c9330f8</samp>

This pull request redirects users from the `dot` prefix to the `ahp` prefix for some routes using the `prefix.global.ts` middleware. It also moves the logic for checking the route availability for the explorer feature from the components to the middleware.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c9330f8</samp>

> _`dot` to `ahp`_
> _redirecting users now_
> _fall of old prefix_
  