### PR TITLE
Migrated NeoCheckbox to tailwindcss

### DIFF
--- a/libs/ui/src/components/NeoCheckbox/NeoCheckbox.scss
+++ b/libs/ui/src/components/NeoCheckbox/NeoCheckbox.scss
@@ -2,6 +2,7 @@
 @import '@oruga-ui/oruga-next/src/scss/utilities/variables.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/animations.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/helpers.scss';
+@import '../../scss/tailwind.scss';
 
 $checkbox-checkmark-color: #000;
 

--- a/libs/ui/src/components/NeoCheckbox/NeoCheckbox.scss
+++ b/libs/ui/src/components/NeoCheckbox/NeoCheckbox.scss
@@ -2,7 +2,6 @@
 @import '@oruga-ui/oruga-next/src/scss/utilities/variables.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/animations.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/helpers.scss';
-@import '../../scss/tailwind.scss';
 
 $checkbox-checkmark-color: #000;
 

--- a/libs/ui/src/components/NeoCheckbox/NeoCheckbox.scss
+++ b/libs/ui/src/components/NeoCheckbox/NeoCheckbox.scss
@@ -1,5 +1,3 @@
-@import '../../scss/variable.scss';
-@import '../../scss/theme.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/expressions.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/variables.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/animations.scss';
@@ -9,21 +7,11 @@ $checkbox-checkmark-color: #000;
 
 .neo-checkbox {
   .o-chk__check {
-    border-radius: 0;
-    @include ktheme() {
-      border: 1px solid theme('border-color');
-      color: theme('text-color');
-      background-color: theme('background-color');
-    }
+    @apply rounded-none border-default border-border-color text-text-color bg-background-color;
   }
 
   .o-chk__check--checked {
-    background-size: 10px;
-    background-repeat: no-repeat;
-    background-position: center;
-    @include ktheme() {
-      background-color: theme('k-primary');
-    }
+    @apply bg-[length:10px] bg-no-repeat bg-center bg-k-primary;
   }
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #8340 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 638bc15</samp>

Refactored `NeoCheckbox` component to use Tailwind CSS instead of scss. This simplifies the styling and reduces the number of imported files.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 638bc15</samp>

> _Sing, O Muse, of the skillful coder who refactored_
> _The neo-checkbox component, removing the imports that cluttered_
> _The scss file, and using instead the classes of Tailwind_
> _That make the code more readable and easy to amend._