### PR TITLE
fix: Email signup modal button animation 

### DIFF
--- a/assets/styles/abstracts/_animations.scss
+++ b/assets/styles/abstracts/_animations.scss
@@ -105,7 +105,8 @@
   animation: dots 1.5s infinite;
 }
 
-@mixin shineEffect($shineColor, $shineHover) {
+@mixin shineEffect($shineColor, $shineHover, $overChild: true) {
+  position: relative;
   overflow: hidden;
 
   &::before,
@@ -117,7 +118,7 @@
     background-color: $shineColor;
     transform: skewX(-30deg);
     transition: background-color 0.3s;
-    z-index: 0;
+    z-index: 1;
   }
 
   &::before {
@@ -136,6 +137,12 @@
     &::before,
     &::after {
       background-color: $shineHover
+    }
+  }
+
+  @if not $overChild {
+    > :first-child {
+      z-index: 2;
     }
   }
 }

--- a/components/collection/drop/DropConfirmModal.vue
+++ b/components/collection/drop/DropConfirmModal.vue
@@ -95,12 +95,11 @@ const confirm = () => {
   width: 25rem;
 }
 
-.shine {
-  &:not(:disabled) {
-    @include shineEffect(var(--k-accent-light-3), lightgrey, false);
-    &:hover {
-      color: var(--k-accent2) !important;
-    }
+.shine:not(:hover):not(:disabled) {
+  @include shineEffect(var(--k-accent-light-3), lightgrey, false);
+
+  &:hover {
+    color: var(--k-accent2) !important;
   }
 }
 </style>

--- a/components/collection/drop/DropConfirmModal.vue
+++ b/components/collection/drop/DropConfirmModal.vue
@@ -97,7 +97,7 @@ const confirm = () => {
 
 .shine {
   &:not(:disabled) {
-    @include shineEffect(var(--k-accent-light-3), lightgrey);
+    @include shineEffect(var(--k-accent-light-3), lightgrey, false);
     &:hover {
       color: var(--k-accent2) !important;
     }

--- a/components/collection/drop/DropConfirmModal.vue
+++ b/components/collection/drop/DropConfirmModal.vue
@@ -99,7 +99,7 @@ const confirm = () => {
   &:not(:disabled) {
     @include shineEffect(var(--k-accent-light-3), lightgrey);
     &:hover {
-      color: var(--k-accent) !important;
+      color: var(--k-accent2) !important;
     }
   }
 }

--- a/libs/ui/src/scss/tailwind.scss
+++ b/libs/ui/src/scss/tailwind.scss
@@ -18,6 +18,7 @@
     --background-color-inverse: #191718;
     --link-hover: #6b6b6b;
     --k-accent: #ff7ac3;
+    --k-accent2: #ff7ac3;
     --k-accent-light: #ffe5f3;
     --k-accent-hover: #ffe5f3;
     --k-accent-light-2: #ffe5f3;
@@ -68,6 +69,7 @@
       --link-hover: #cccccc;
       --border-color: var(--white);
       --k-accent: #191718;
+      --k-accent2: var(--white);
       --k-accent-hover: #363234;
       --k-accent-light-2: #363234;
       --k-accent-light-2-dark: var(--white);
@@ -110,6 +112,7 @@
     --link-hover: #cccccc;
     --border-color: var(--white);
     --k-accent: #191718;
+    --k-accent2: var(--white);
     --k-accent-hover: #363234;
     --k-accent-light-2: #363234;
     --k-accent-light-2-dark: var(--white);

--- a/libs/ui/tailwind.config.js
+++ b/libs/ui/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
         'background-color-inverse': 'var(--background-color-inverse)',
         'link-hover': 'var(--link-hover)',
         'k-accent': 'var(--k-accent)',
+        'k-accent2': 'var(--k-accent2)',
         'k-accent-light': 'var(--k-accent-light)',
         'k-accent-hover': 'var(--k-accent-hover)',
         'k-accent-light-2': 'var(--k-accent-light-2)',


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8317

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 


![CleanShot 2023-12-02 at 12 06 57@2x](https://github.com/kodadot/nft-gallery/assets/44554284/54203b3b-49a1-4bb1-9d66-4a77c918a5a5)

![CleanShot 2023-12-02 at 12 08 04@2x](https://github.com/kodadot/nft-gallery/assets/44554284/89daeab0-7c47-4a7b-a9d7-ee184b39c98a)



## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 854d471</samp>

Added a new custom color variable `--k-accent2` and used it for various UI elements. Improved the `shineEffect` mixin to allow more flexibility in positioning the effect.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 854d471</samp>

> _We're shining in the dark with our custom accent_
> _We're using mixins to control the effect_
> _We're changing colors on hover to make them react_
> _We're the masters of the `tailwind` dialect_


