### PR TITLE
Free drop signup modal iteration

### DIFF
--- a/components/collection/drop/DropConfirmModal.vue
+++ b/components/collection/drop/DropConfirmModal.vue
@@ -19,8 +19,8 @@
         <div class="is-capitalized is-flex is-align-items-center">
           <span>{{ $t('drops.plusGetA') }}</span>
 
-          <div class="voucher px-2 is-flex is-align-items-center">
-            <img :src="signUpVoucherIcon" alt="shop voucher" />
+          <div class="px-2 is-flex is-align-items-center">
+            <img width="58" :src="signUpVoucherIcon" alt="shop voucher" />
           </div>
 
           <span>{{ $t('drops.voucherToOurShop') }}</span>
@@ -111,12 +111,6 @@ const confirm = () => {
 
 .modal-width {
   width: 25rem;
-}
-
-.voucher {
-  img {
-    width: 58px;
-  }
 }
 
 .shine {

--- a/components/collection/drop/DropConfirmModal.vue
+++ b/components/collection/drop/DropConfirmModal.vue
@@ -15,6 +15,22 @@
         {{ $t('drops.subscribe') }}
       </p>
 
+      <div class="mb-5">
+        <div class="is-capitalized is-flex is-align-items-center">
+          <span>{{ $t('drops.plusGetA') }}</span>
+
+          <div class="voucher px-2 is-flex is-align-items-center">
+            <img :src="voucherIcon" alt="shop voucher" />
+          </div>
+
+          <span>{{ $t('drops.voucherToOurShop') }}</span>
+        </div>
+
+        <p class="has-text-k-grey is-capitalized mt-3 is-size-7">
+          ({{ $t('drops.justConfirmSubscriptionViaEmail') }})
+        </p>
+      </div>
+
       <form @submit.prevent="confirm">
         <NeoInput
           ref="emailInput"
@@ -55,6 +71,8 @@ const props = defineProps<{ modelValue: boolean }>()
 
 const isModalActive = useVModel(props, 'modelValue')
 
+const { voucherIcon } = useShopVoucherIcon()
+
 const emailInput = ref()
 const email = ref()
 const agree = ref(false)
@@ -93,6 +111,12 @@ const confirm = () => {
 
 .modal-width {
   width: 25rem;
+}
+
+.voucher {
+  img {
+    width: 58px;
+  }
 }
 
 .shine {

--- a/components/collection/drop/DropConfirmModal.vue
+++ b/components/collection/drop/DropConfirmModal.vue
@@ -20,7 +20,7 @@
           <span>{{ $t('drops.plusGetA') }}</span>
 
           <div class="voucher px-2 is-flex is-align-items-center">
-            <img :src="voucherIcon" alt="shop voucher" />
+            <img :src="signUpVoucherIcon" alt="shop voucher" />
           </div>
 
           <span>{{ $t('drops.voucherToOurShop') }}</span>
@@ -71,7 +71,7 @@ const props = defineProps<{ modelValue: boolean }>()
 
 const isModalActive = useVModel(props, 'modelValue')
 
-const { voucherIcon } = useShopVoucherIcon()
+const { signUpVoucherIcon } = useIcon()
 
 const emailInput = ref()
 const email = ref()

--- a/components/collection/unlockable/UnlockableTag.vue
+++ b/components/collection/unlockable/UnlockableTag.vue
@@ -19,9 +19,9 @@
 
 <script lang="ts" setup>
 import { NeoTooltip } from '@kodadot1/brick'
-import { useUnlockableIcon } from '@/composables/useUnlockableIcon'
+import { useIcon } from '@/composables/useIcon'
 
-const { unlockableIcon } = useUnlockableIcon()
+const { unlockableIcon } = useIcon()
 
 const props = defineProps({
   collectionId: {

--- a/components/gallery/UnlockableTag.vue
+++ b/components/gallery/UnlockableTag.vue
@@ -33,7 +33,7 @@
 import { NeoTooltip } from '@kodadot1/brick'
 import { NFT } from '@/components/rmrk/service/scheme'
 import { useWindowSize } from '@vueuse/core'
-import { useUnlockableIcon } from '@/composables/useUnlockableIcon'
+import { useIcon } from '@/composables/useIcon'
 
 const props = defineProps<{
   nft: NFT | undefined
@@ -42,7 +42,7 @@ const props = defineProps<{
 
 const { isCurrentOwner } = useAuth()
 const isMobile = computed(() => useWindowSize().width.value < 768)
-const { unlockableIcon } = useUnlockableIcon()
+const { unlockableIcon } = useIcon()
 
 const isOwner = computed(() => isCurrentOwner(props.nft?.currentOwner))
 </script>

--- a/components/landing/SignupBanner.vue
+++ b/components/landing/SignupBanner.vue
@@ -7,7 +7,7 @@
         </h3>
 
         <div class="ml-4 is-relative signup-banner-voucher is-flex-shrink-0">
-          <img :src="voucherIcon" alt="signup voucher" />
+          <img :src="signUpVoucherIcon" alt="signup voucher" />
           <img
             src="/signup-voucher-blur.svg"
             alt="signup voucher blur"
@@ -49,7 +49,7 @@ import { usePreferencesStore } from '@/stores/preferences'
 const { $i18n } = useNuxtApp()
 const preferencesStore = usePreferencesStore()
 
-const { voucherIcon } = useShopVoucherIcon()
+const { signUpVoucherIcon } = useIcon()
 
 const email = ref()
 const loading = ref(false)

--- a/components/landing/SignupBanner.vue
+++ b/components/landing/SignupBanner.vue
@@ -7,7 +7,7 @@
         </h3>
 
         <div class="ml-4 is-relative signup-banner-voucher is-flex-shrink-0">
-          <img :src="logoSrc" alt="signup voucher" />
+          <img :src="voucherIcon" alt="signup voucher" />
           <img
             src="/signup-voucher-blur.svg"
             alt="signup voucher blur"
@@ -48,11 +48,8 @@ import { usePreferencesStore } from '@/stores/preferences'
 
 const { $i18n } = useNuxtApp()
 const preferencesStore = usePreferencesStore()
-const { isDarkMode } = useTheme()
 
-const logoSrc = computed(() =>
-  isDarkMode.value ? '/signup-voucher-dark.svg' : '/signup-voucher.svg',
-)
+const { voucherIcon } = useShopVoucherIcon()
 
 const email = ref()
 const loading = ref(false)

--- a/composables/useIcon.ts
+++ b/composables/useIcon.ts
@@ -1,18 +1,18 @@
+const getTokenIconBySymbol = (token: string) => {
+  switch (token.toLowerCase()) {
+    case 'bsx':
+      return '/token/bsx.svg'
+    case 'dot':
+      return '/token/dot.svg'
+    case 'ksm':
+      return '/token/ksm.svg'
+    default:
+      return '/token/ksm.svg'
+  }
+}
+
 export const useIcon = () => {
   const { isDarkMode } = useTheme()
-
-  const getTokenIconBySymbol = (token: string) => {
-    switch (token.toLowerCase()) {
-      case 'bsx':
-        return '/token/bsx.svg'
-      case 'dot':
-        return '/token/dot.svg'
-      case 'ksm':
-        return '/token/ksm.svg'
-      default:
-        return '/token/ksm.svg'
-    }
-  }
 
   const signUpVoucherIcon = computed(() =>
     isDarkMode.value ? '/signup-voucher-dark.svg' : '/signup-voucher.svg',

--- a/composables/useIcon.ts
+++ b/composables/useIcon.ts
@@ -1,4 +1,6 @@
 export const useIcon = () => {
+  const { isDarkMode } = useTheme()
+
   const getTokenIconBySymbol = (token: string) => {
     switch (token.toLowerCase()) {
       case 'bsx':
@@ -12,5 +14,13 @@ export const useIcon = () => {
     }
   }
 
-  return { getTokenIconBySymbol }
+  const signUpVoucherIcon = computed(() =>
+    isDarkMode.value ? '/signup-voucher-dark.svg' : '/signup-voucher.svg',
+  )
+
+  const unlockableIcon = computed(() =>
+    isDarkMode.value ? '/unlockable-dark.svg' : '/unlockable.svg',
+  )
+
+  return { getTokenIconBySymbol, signUpVoucherIcon, unlockableIcon }
 }

--- a/composables/useNft.ts
+++ b/composables/useNft.ts
@@ -97,7 +97,7 @@ export function useNftCardIcon<
   },
 >(nft: Ref<T>) {
   const isAudio = ref(false)
-  const { unlockableIcon } = useUnlockableIcon()
+  const { unlockableIcon } = useIcon()
 
   const cardIcon = computed(() => {
     if (isAudio) {

--- a/composables/useShopVoucherIcon.ts
+++ b/composables/useShopVoucherIcon.ts
@@ -1,0 +1,9 @@
+export const useShopVoucherIcon = () => {
+  const { isDarkMode } = useTheme()
+
+  const voucherIcon = computed(() =>
+    isDarkMode.value ? '/signup-voucher-dark.svg' : '/signup-voucher.svg',
+  )
+
+  return { voucherIcon }
+}

--- a/composables/useShopVoucherIcon.ts
+++ b/composables/useShopVoucherIcon.ts
@@ -1,9 +1,0 @@
-export const useShopVoucherIcon = () => {
-  const { isDarkMode } = useTheme()
-
-  const voucherIcon = computed(() =>
-    isDarkMode.value ? '/signup-voucher-dark.svg' : '/signup-voucher.svg',
-  )
-
-  return { voucherIcon }
-}

--- a/composables/useUnlockableIcon.ts
+++ b/composables/useUnlockableIcon.ts
@@ -1,8 +1,0 @@
-export const useUnlockableIcon = () => {
-  const { isDarkMode } = useTheme()
-  const unlockableIcon = computed(() =>
-    isDarkMode.value ? '/unlockable-dark.svg' : '/unlockable.svg',
-  )
-
-  return { unlockableIcon }
-}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1417,7 +1417,10 @@
     "enterValidEmail": "Enter valid email address",
     "subscribeAndClaim": "Subscribe & Claim your NFT",
     "agreeToProceed": "Agree to proceed",
-    "consent": "I consent to receive updates."
+    "consent": "I consent to receive updates.",
+    "plusGetA": "+ Get a",
+    "voucherToOurShop": "Voucher to our shop",
+    "justConfirmSubscriptionViaEmail": "Just confirm your subscription via email"
   },
   "confirmPurchase": {
     "action": "Confirm Purchase",


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #8385

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2023-12-04 at 17 50 34@2x](https://github.com/kodadot/nft-gallery/assets/44554284/bbdcb400-5fc3-451e-9869-dda3e62c3357)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at add3a7e</samp>

Added a voucher feature to the `DropConfirmModal` and `SignupBanner` components to incentivize users to subscribe and claim their NFTs. Refactored the voucher icon logic into a reusable composable function and added translation keys for the voucher messages.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at add3a7e</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A composable function, `useShopVoucherIcon`, to decide_
> _Which image of the voucher, dark or light, to show_
> _To the subscribers who claim their NFTs as their own._


