### PR TITLE
NeoLoading to tailwindcss and added icons to historie

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -22,6 +22,8 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.4.2",
+    "@fortawesome/vue-fontawesome": "^3.0.5",
     "@google/model-viewer": "^3.3.0",
     "@vueuse/core": "^9.13.0",
     "bulma": "0.9.4",

--- a/libs/ui/src/components/NeoLoading/NeoLoading.scss
+++ b/libs/ui/src/components/NeoLoading/NeoLoading.scss
@@ -1,13 +1,8 @@
-@import '../../scss/theme';
 @import '@oruga-ui/oruga-next/src/scss/utilities/expressions.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/variables.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/animations.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/helpers.scss';
-@import '../../scss/variable.scss';
 
+$loading-overlay: rgb(0 0 0 / 0.5);
 
 @import '@oruga-ui/oruga-next/src/scss/components/loading.scss';
-
-.o-load__overlay {
-  background-color: rgba(0, 0, 0, 0.5);
-}

--- a/libs/ui/src/components/NeoLoading/NeoLoading.story.vue
+++ b/libs/ui/src/components/NeoLoading/NeoLoading.story.vue
@@ -1,7 +1,7 @@
 <template>
   <Story title="NeoLoading" :layout="{ type: 'grid', width: '200px' }">
     <Variant title="Loading">
-      <NeoLoading> Neo Loader</NeoLoading>
+      <NeoLoading :active="true" />
     </Variant>
   </Story>
 </template>

--- a/libs/ui/src/components/NeoLoading/NeoLoading.vue
+++ b/libs/ui/src/components/NeoLoading/NeoLoading.vue
@@ -1,7 +1,7 @@
 <template>
   <OLoading v-bind="$attrs">
     <slot>
-      <NeoIcon icon="spinner-third" spin size="large" class="has-text-white" />
+      <NeoIcon icon="spinner-third" spin size="large" class="text-white" />
     </slot>
   </OLoading>
 </template>

--- a/libs/ui/src/histoire.setup.ts
+++ b/libs/ui/src/histoire.setup.ts
@@ -1,1 +1,28 @@
 import './histoire.scss'
+
+import { defineSetupVue3 } from '@histoire/plugin-vue'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Neo } from './'
+
+export const setupVue3 = defineSetupVue3(({ app }) => {
+  const script = document.createElement('script')
+  script.src = 'https://kit.fontawesome.com/54f29b7997.js'
+  script.crossOrigin = 'anonymous'
+  script.async = true
+
+  document.body.appendChild(script)
+
+  app.component('FontAwesomeIcon', FontAwesomeIcon).use(Neo, {
+    customIconPacks: {
+      fass: {
+        iconPrefix: 'fa-fw fa-',
+      },
+      fasr: {
+        iconPrefix: 'fa-fw fa-',
+      },
+      fab: {
+        iconPrefix: 'fa-fw fa-',
+      },
+    },
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false
@@ -384,6 +384,12 @@ importers:
 
   libs/ui:
     dependencies:
+      '@fortawesome/fontawesome-svg-core':
+        specifier: ^6.4.2
+        version: 6.4.2
+      '@fortawesome/vue-fontawesome':
+        specifier: ^3.0.5
+        version: 3.0.5(@fortawesome/fontawesome-svg-core@6.4.2)(vue@3.3.9)
       '@google/model-viewer':
         specifier: ^3.3.0
         version: 3.3.0(three@0.158.0)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #8222 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 681f47c</samp>

The pull request adds support for Font Awesome icons in the UI library and updates the NeoLoading component to use them. It also fixes some minor issues with the SCSS imports, the overlay color, and the class name for the NeoIcon component. It modifies the `pnpm-lock.yaml`, `libs/ui/package.json`, `libs/ui/src/components/NeoLoading/NeoLoading.scss`, `libs/ui/src/components/NeoLoading/NeoLoading.story.vue`, `libs/ui/src/components/NeoLoading/NeoLoading.vue`, and `libs/ui/src/histoire.setup.ts` files.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 681f47c</samp>

> _To use Font Awesome in our UI_
> _We added some deps and a script too_
> _We simplified SCSS_
> _And changed the `NeoIcon` class_
> _And updated the story for `NeoLoading` to use `active` prop, not slot_