### PR TITLE
fix(carousel.ts): add optional chaining to nft.resources array access

### DIFF
--- a/utils/carousel.ts
+++ b/utils/carousel.ts
@@ -18,7 +18,7 @@ export const formatNFT = (nfts, chain?: string): CarouselNFT[] => {
   return data.map((nft) => {
     const timestamp = nft.updatedAt || nft.timestamp
     const metaImage =
-      nft.meta.image || nft.resources?.[0].thumb || nft.resources?.[0].src
+      nft.meta.image || nft.resources?.[0]?.thumb || nft.resources?.[0]?.src
     const metaAnimationUrl = nft.meta.animationUrl
     const name = nft.name || nft.meta.name
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8432

#### Had issue bounty label?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bef27ea</samp>

Improved error handling in `formatNFT` function to avoid crashes with NFTs without resources. Modified `utils/carousel.ts` file.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bef27ea</samp>

> _`formatNFT` checks_
> _`nft.resources` safely_
> _No crash in winter_