### PR TITLE
fix: Deduplicate drop information - Total available items

### DIFF
--- a/components/collection/drop/DropContainer.vue
+++ b/components/collection/drop/DropContainer.vue
@@ -14,12 +14,6 @@
             :collection-id="collectionId"
             :description="description" />
           <hr class="mb-4" />
-
-          <div
-            class="is-flex is-justify-content-space-between is-align-items-center my-5">
-            <div>Total available items</div>
-            <div>{{ totalAvailableMintCount }} / {{ totalCount }}</div>
-          </div>
           <UnlockableTag :collection-id="collectionId" />
 
           <div>

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -14,11 +14,6 @@
             :description="description" />
           <hr class="mb-4" />
 
-          <div
-            class="is-flex is-justify-content-space-between is-align-items-center my-5">
-            <div>{{ $t('mint.unlockable.totalAvailableItem') }}</div>
-            <div>{{ totalAvailableMintCount }} / {{ maxCount }}</div>
-          </div>
           <UnlockableTag :collection-id="collectionId" />
 
           <div>
@@ -161,9 +156,6 @@ const { data: collectionData } = useGraphql({
 
 const maxCount = computed(
   () => collectionData.value?.collectionEntity?.max || 200,
-)
-const totalAvailableMintCount = computed(
-  () => maxCount.value - mintedCount.value,
 )
 
 const hasUserMinted = computed(() =>

--- a/components/collection/unlockable/UnlockableContainer.vue
+++ b/components/collection/unlockable/UnlockableContainer.vue
@@ -15,11 +15,6 @@
             :description="description" />
           <hr class="mb-4" />
 
-          <div
-            class="is-flex is-justify-content-space-between is-align-items-center my-5">
-            <span class="">Total available items</span>
-            <span class="">{{ totalAvailableMintCount }} / {{ maxCount }}</span>
-          </div>
           <UnlockableTag :collection-id="collectionId" />
 
           <div>
@@ -133,8 +128,9 @@ const isLoading = ref(false)
 const { isLogIn } = useAuth()
 const { hours, minutes, seconds } = useCountDown(countDownTime)
 const justMinted = ref('')
-const { currentAccountMintedToken, mintedDropCount, fetchDropStatus } =
-  useDropStatus(props.drop.alias)
+const { currentAccountMintedToken, fetchDropStatus } = useDropStatus(
+  props.drop.alias,
+)
 
 onMounted(async () => {
   const res = await getLatestWaifuImages()
@@ -159,24 +155,10 @@ const handleSelectImage = (image: string) => {
   selectedImage.value = image
 }
 
-const { data: collectionData } = useGraphql({
-  queryName: 'unlockableCollectionById',
-  variables: {
-    id: collectionId.value,
-  },
-})
-
 const hasUserMinted = computed(() =>
   currentAccountMintedToken.value
     ? `${collectionId.value}-${currentAccountMintedToken.value.id}`
     : justMinted.value,
-)
-
-const maxCount = computed(
-  () => collectionData.value?.collectionEntity?.max || 300,
-)
-const totalAvailableMintCount = computed(
-  () => maxCount.value - Math.min(mintedDropCount.value, maxCount.value),
 )
 
 const { data, refetch } = useGraphql({

--- a/components/collection/voteDrop/DropContainer.vue
+++ b/components/collection/voteDrop/DropContainer.vue
@@ -15,11 +15,6 @@
             :description="VOTE_DROP_DESCRIPTION" />
           <hr class="mb-4" />
 
-          <div
-            class="is-flex is-justify-content-space-between is-align-items-center my-5">
-            <span> {{ $t('mint.unlockable.totalAvailableItem') }}</span>
-            <span>{{ totalAvailableMintCount }} / {{ totalCount }}</span>
-          </div>
           <UnlockableTag :collection-id="collectionId" />
 
           <div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -616,7 +616,6 @@
       },
       "open": "Open",
       "phase": "Mint Phase",
-      "totalAvailableItem": "Total available items",
       "ayeVotersOnly": "For Aye Voters Only",
       "eligible": "You Are Eligible",
       "exclusive": "Exclusive Access Only",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8441
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="721" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/3fd6c3ae-c354-4132-9b00-783a4c319b47">

<img width="739" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/fedd5bee-8866-4197-b251-3f06ef9f56bc">


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f5e1fe</samp>

Removed the display of the total available items and the total count of the drop from various drop components, such as `Generative.vue`, `UnlockableContainer.vue`, `DropContainer.vue`, and `voteDrop/DropContainer.vue`. This simplifies the UI and avoids confusion for the users. Also removed the unused translation key `mint.unlockable.totalAvailableItem` from `en.json`.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f5e1fe</samp>

> _Oh we're the coders of the drop feature_
> _And we like to keep our UI neat_
> _We don't need no total count or items_
> _We just `DropContainer.vue` and repeat_
  