### PR TITLE
fix: Make claim button active when wallet is not connected

### DIFF
--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -169,7 +169,7 @@
     }
 
     &::after {
-      @apply relative left-0 top-0 border-2 border-k-grey rounded-full border-r-transparent border-t-transparent h-[1em] w-[1.11em] #{!important};
+      @apply relative left-0 top-0 border-2 border-k-grey rounded-full border-r-transparent border-t-transparent #{!important};
     }
   }
 

--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -165,7 +165,7 @@
     }
 
     &::after {
-      @apply relative left-0 border-2 border-k-grey rounded-full border-r-transparent border-t-transparent h-[1em] w-[1.11em] #{!important};
+      @apply relative left-0 top-0 border-2 border-k-grey rounded-full border-r-transparent border-t-transparent h-[1em] w-[1.11em] #{!important};
     }
   }
 

--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -164,6 +164,10 @@
       @apply mr-3 #{!important};
     }
 
+    .o-btn__wrapper {
+      @apply w-auto #{!important};
+    }
+
     &::after {
       @apply relative left-0 top-0 border-2 border-k-grey rounded-full border-r-transparent border-t-transparent h-[1em] w-[1.11em] #{!important};
     }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #8444
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

![Kapture 2023-12-07 at 13 29 25](https://github.com/kodadot/nft-gallery/assets/31397967/9f6e9f61-b0ef-46c8-b5a2-5c214d23c735)


  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 56a9db7</samp>

This pull request enhances the minting process of generative NFTs and fixes a minor style issue with the `NeoButton` component. It uses a custom hook to handle the wallet modal and the button state in `Generative.vue`, and adjusts the loading spinner alignment in `NeoButton.scss`.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 56a9db7</samp>

> _We are the minters of the generative art_
> _We defy the chaos with our `useDoAfterLogin` hook_
> _We align the spinner with the `NeoButton` style_
> _We purge the code of the unnecessary parts_
  