### PR TITLE
(Fix): Drop (name) + (max)

### DIFF
--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -131,6 +131,7 @@ const props = defineProps({
 const collectionId = computed(() => props.drop?.collection)
 const disabledByBackend = computed(() => props.drop?.disabled)
 const defaultImage = computed(() => props.drop?.image)
+const defaultName = computed(() => props.drop?.name)
 const { currentAccountMintedToken, mintedDropCount, fetchDropStatus } =
   useDropStatus(props.drop.alias)
 
@@ -258,7 +259,7 @@ const submitMint = async (email: string) => {
     const hash = await createUnlockableMetadata(
       imageHash,
       description.value,
-      collectionName.value,
+      collectionName.value || defaultName.value,
       'text/html',
       selectedImage.value,
     )

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -132,6 +132,7 @@ const collectionId = computed(() => props.drop?.collection)
 const disabledByBackend = computed(() => props.drop?.disabled)
 const defaultImage = computed(() => props.drop?.image)
 const defaultName = computed(() => props.drop?.name)
+const defaultMax = computed(() => props.drop?.max || 255)
 const { currentAccountMintedToken, mintedDropCount, fetchDropStatus } =
   useDropStatus(props.drop.alias)
 
@@ -161,7 +162,7 @@ const { data: collectionData } = useGraphql({
 })
 
 const maxCount = computed(
-  () => collectionData.value?.collectionEntity?.max || 200,
+  () => collectionData.value?.collectionEntity?.max || defaultMax.value,
 )
 const totalAvailableMintCount = computed(
   () => maxCount.value - mintedCount.value,

--- a/components/collection/unlockable/utils.ts
+++ b/components/collection/unlockable/utils.ts
@@ -19,7 +19,7 @@ export const unlockableDesc = (value: number) => `
 export async function createUnlockableMetadata(
   imageHash: string,
   description: string,
-  name: string = UNLOCKABLE_NAME,
+  name: string,
   mimeType: string = 'image/png',
   animationUrl?: string,
 ) {

--- a/params/types.ts
+++ b/params/types.ts
@@ -70,4 +70,5 @@ export type DropItem = {
   type: DropType
   meta: string
   disabled: number
+  max?: number
 }


### PR DESCRIPTION
- :bug: Berlin (Blockchain) Waifus is always good default
- :zap: use default name from D1
- :label: minted
- :zap: use optionally max from D1

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

Won't mint Berlin (Blockchain) Waifu

## Screenshot 📸

- [ ] My fix has changed UI

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0155f47</samp>

This pull request enhances the generative drop item feature by allowing custom names and max values for each item. It also removes some unused or redundant code from `utils.ts` and `types.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0155f47</samp>

> _No more `UNLOCKABLE_NAME`, we set our own destiny_
> _We add a `max` property to limit the scarcity_
> _We make the `Generative.vue` more dynamic and clear_
> _We create the drop items that will make them all fear_
