### PR TITLE
Fixed low res cover in gallery

### DIFF
--- a/components/base/MediaItem.vue
+++ b/components/base/MediaItem.vue
@@ -11,6 +11,7 @@
       :original="original"
       :is-lewd="isLewd"
       :is-detail="isDetail"
+      :is-fullscreen="isFullscreen"
       :disable-operation="disableOperation"
       :player-cover="audioPlayerCover"
       :hover-on-cover-play="audioHoverOnCoverPlay"
@@ -80,6 +81,7 @@ const props = withDefaults(
     disableOperation?: boolean
     audioPlayerCover?: string
     audioHoverOnCoverPlay?: boolean
+    isFullscreen?: boolean
     // props for video component
     preview?: boolean
     autoplay?: boolean
@@ -101,6 +103,7 @@ const props = withDefaults(
     placeholder: './Koda.svg',
     disableOperation: undefined,
     audioPlayerCover: '',
+    isFullscreen: false,
     imageComponent: 'img',
   },
 )

--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -48,7 +48,8 @@
                   :animation-src="resource.animation"
                   :audio-player-cover="galleryItem.nftImage.value"
                   :image-component="NuxtImg"
-                  sizes="1000px"
+                  :is-fullscreen="isFullscreen"
+                  :sizes="sizes"
                   is-detail />
               </NeoCarouselItem>
             </NeoCarousel>
@@ -62,11 +63,12 @@
             :animation-src="nftAnimation"
             :mime-type="nftMimeType"
             :title="nftMetadata?.name"
+            :is-fullscreen="isFullscreen"
             is-detail
             :is-lewd="galleryDescriptionRef?.isLewd"
             :placeholder="placeholder"
             :image-component="NuxtImg"
-            sizes="1000px"
+            :sizes="sizes"
             :audio-player-cover="nftImage" />
         </div>
       </div>
@@ -303,6 +305,11 @@ const imgref = ref<HTMLElement | null>(null)
 const isFallbackActive = ref(false)
 const fullScreenDisabled = ref(false)
 const { toggle, isFullscreen, isSupported } = useFullscreen(imgref)
+const sizes = ref<string>('1000px')
+
+watch(isFullscreen, (value) => {
+  sizes.value = value ? 'original' : '1000px'
+})
 
 function toggleFullscreen() {
   if (!isSupported.value || fullScreenDisabled.value) {

--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -1,7 +1,8 @@
 <template>
   <figure
     :class="{
-      'relative pt-[100%]': !original,
+      'relative pt-[100%]': !original && !isFullscreen,
+      'pt-0': isFullscreen,
     }">
     <!-- load normal image -->
     <TheImage
@@ -11,7 +12,10 @@
       :src="src"
       :alt="alt"
       class="block rounded-none"
-      :class="{ 'object-cover absolute inset-0 w-full h-full': !original }"
+      :class="{
+        'object-cover absolute inset-0 w-full h-full':
+          !original && !isFullscreen,
+      }"
       data-testid="type-image"
       @error.once="() => onError('error-1')" />
     <!-- if fail, try to load original url -->
@@ -53,6 +57,7 @@ const props = withDefaults(
     alt?: string
     original: boolean
     placeholder: string
+    isFullscreen?: boolean
   }>(),
   {
     imageComponent: 'img',
@@ -60,6 +65,7 @@ const props = withDefaults(
     sizes: '450px md:350px lg:270px',
     src: '',
     alt: '',
+    isFullscreen: false,
   },
 )
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #8430 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 15e46b8</samp>

Removed `sizes` property from `MediaItem` component and improved `ImageMedia` component to handle original image size. This enhances the display of high-quality NFT images.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 15e46b8</samp>

> _`MediaItem` drops_
> _`sizes` prop for its child_
> _`ImageMedia` now_