### PR TITLE
adding wallstreet to landing

### DIFF
--- a/components/carousel/CarouselTypeGenerative.vue
+++ b/components/carousel/CarouselTypeGenerative.vue
@@ -12,6 +12,6 @@ import { useCarouselGenerativeNftEvents } from './utils/useCarouselEvents'
 
 const { nfts, ids } = await useCarouselGenerativeNftEvents(
   ['176'],
-  ['38', '40', '46', '49, '50'],
+  ['38', '40', '46', '49', '50'],
 )
 </script>

--- a/components/carousel/CarouselTypeGenerative.vue
+++ b/components/carousel/CarouselTypeGenerative.vue
@@ -12,6 +12,6 @@ import { useCarouselGenerativeNftEvents } from './utils/useCarouselEvents'
 
 const { nfts, ids } = await useCarouselGenerativeNftEvents(
   ['176'],
-  ['38', '40', '46', '50'],
+  ['38', '40', '46', '49, '50'],
 )
 </script>

--- a/components/collection/unlockable/UnlockableLandingMobileBanner.vue
+++ b/components/collection/unlockable/UnlockableLandingMobileBanner.vue
@@ -9,7 +9,7 @@
         alt="unlockable icon" />
       <span>{{ $t('mint.unlockable.mintLive') }}</span>
     </div>
-    <nuxt-link class="has-text-weight-bold" to="/ahp/drops/motherboard">
+    <nuxt-link class="has-text-weight-bold" to="/ahp/drops/wallstreet">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>

--- a/components/collection/unlockable/UnlockableLandingTag.vue
+++ b/components/collection/unlockable/UnlockableLandingTag.vue
@@ -14,7 +14,7 @@
     <div class="separator mx-2" />
     <nuxt-link
       class="is-flex is-align-items-center has-text-weight-bold my-2"
-      to="/ahp/drops/motherboard">
+      to="/ahp/drops/wallstreet">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>

--- a/composables/popularCollections/constants.ts
+++ b/composables/popularCollections/constants.ts
@@ -55,6 +55,7 @@ export const POPULAR_COLLECTIONS = {
   ],
   ahp: [
     '50', // .motherboard
+    '49', // wallstreet
     '46', // Snowflakes
     '40', // Swirls
     '38', // Generativ Art - Pare1d0scope


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

##

adding new drop

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47e3126</samp>

The code was updated to feature the wallstreet generative NFTs in the carousel, banner, tag, and popular collections components. The code also creates links to the wallstreet drop page in the carousel, banner, and tag components.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47e3126</samp>

> _`Carousel` shows_
> _Wallstreet NFTs with code_
> _Autumn of crypto_
