### PR TITLE
:poop: make all drops free

### DIFF
--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -118,9 +118,10 @@ const correctUrlPrefix = computed(() => {
   return props.drop.chain
 })
 
-const isFreeDrop = computed(() => {
-  return !Number(props.drop?.price)
-})
+const isFreeDrop = true
+// computed(() => {
+//   return !Number(props.drop?.price)
+// })
 
 const availableCount = computed(() => {
   if (isFreeDrop.value) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Cheap fix


## Context

CONSISTENCY IS MY BFF

BEFORE:

<img width="815" alt="Screenshot 2023-12-08 at 13 02 48" src="https://github.com/kodadot/nft-gallery/assets/22471030/f177a138-ca88-47e5-a924-837934009648">

<img width="401" alt="Screenshot 2023-12-08 at 13 02 42" src="https://github.com/kodadot/nft-gallery/assets/22471030/d7fb2395-2cc2-4ae0-a10f-814a9b7cd1a6">

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

#### Community participation

- [ ] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6dd785d</samp>

Bypassed price check for free drops in `DropCard.vue` as a temporary fix for drop creation issues.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6dd785d</samp>

> _`isFreeDrop` now true_
> _Bypassing price check for drops_
> _Winter workaround_
