### PR TITLE
:bug: isFreeDrop is accessed via computed

### DIFF
--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -118,10 +118,9 @@ const correctUrlPrefix = computed(() => {
   return props.drop.chain
 })
 
-const isFreeDrop = true
-// computed(() => {
-//   return !Number(props.drop?.price)
-// })
+const isFreeDrop = computed(() => {
+  return true // !Number(props.drop?.price)
+})
 
 const availableCount = computed(() => {
   if (isFreeDrop.value) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

isFreeDrop is accessed as computed


#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Copilot Summary
copilot:summary

copilot:poem
