### PR TITLE
fix: teleport with  existential deposit

### DIFF
--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -103,7 +103,12 @@
       "
       target="_blank"
       class="has-text-danger">
-      {{ $t('teleport.insufficientExistentialDeposit') }}
+      {{
+        $t('teleport.insufficientExistentialDeposit', [
+          targetExistentialDepositAmount,
+          currency,
+        ])
+      }}
     </a>
 
     <NeoButton
@@ -187,6 +192,12 @@ const nativeAmount = computed(() =>
   Math.floor(amount.value * Math.pow(10, currentTokenDecimals.value)),
 )
 
+const targetExistentialDepositAmount = computed(() =>
+  Number(
+    targetExistentialDeposit.value / Math.pow(10, targetTokenDecimals.value),
+  ),
+)
+
 const amountToTeleport = computed(() =>
   Math.max(nativeAmount.value - teleportFee.value, 0),
 )
@@ -197,11 +208,15 @@ const recieveAmount = computed(() =>
   formatBalance(amountToTeleport.value, currentTokenDecimals.value, false),
 )
 
-const insufficientExistentialDeposit = computed(() => {
-  const deposit = existentialDeposit[chainToPrefixMap[toChain.value]]
+const targetExistentialDeposit = computed(
+  () => existentialDeposit[chainToPrefixMap[toChain.value]],
+)
 
+const insufficientExistentialDeposit = computed(() => {
   return Boolean(
-    deposit && amountToTeleport.value && deposit > amountToTeleport.value,
+    targetExistentialDeposit.value &&
+      amountToTeleport.value &&
+      targetExistentialDeposit.value > amountToTeleport.value,
   )
 })
 
@@ -307,6 +322,8 @@ const toNetworks = [
 const currentTokenDecimals = computed(() =>
   getChainTokenDecimals(fromChain.value),
 )
+
+const targetTokenDecimals = computed(() => getChainTokenDecimals(toChain.value))
 
 const toChainLabel = computed(() =>
   getChainName(chainToPrefixMap[toChain.value]),

--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -96,6 +96,16 @@
       >
     </div>
 
+    <a
+      v-if="insufficientExistentialDeposit"
+      v-safe-href="
+        `https://support.polkadot.network/support/solutions/articles/65000168651-what-is-the-existential-deposit`
+      "
+      target="_blank"
+      class="has-text-danger">
+      {{ $t('teleport.insufficientExistentialDeposit') }}
+    </a>
+
     <NeoButton
       :label="teleportLabel"
       size="large"
@@ -146,6 +156,7 @@ import { NeoButton, NeoField } from '@kodadot1/brick'
 import { blockExplorerOf } from '@/utils/config/chain.config'
 import { simpleDivision } from '@/utils/balance'
 import { useFiatStore } from '@/stores/fiat'
+import { existentialDeposit } from '@kodadot1/static'
 
 const {
   chainBalances,
@@ -185,6 +196,14 @@ const insufficientAmountAfterFees = computed(() => amountToTeleport.value === 0)
 const recieveAmount = computed(() =>
   formatBalance(amountToTeleport.value, currentTokenDecimals.value, false),
 )
+
+const insufficientExistentialDeposit = computed(() => {
+  const deposit = existentialDeposit[chainToPrefixMap[toChain.value]]
+
+  return Boolean(
+    deposit && amountToTeleport.value && deposit > amountToTeleport.value,
+  )
+})
 
 const teleportLabel = computed(() => {
   if (insufficientBalance.value) {

--- a/libs/static/src/chains.ts
+++ b/libs/static/src/chains.ts
@@ -87,10 +87,11 @@ export const chainList = (): Option[] => {
   }))
 }
 
-export const existentialDeposit: Record<'ksm' | 'ahk' | 'dot' | 'ahp', number> =
-  {
-    ksm: 333333333,
-    ahk: 33333333,
-    dot: 10000000000,
-    ahp: 1000000000,
-  }
+export const existentialDeposit: Record<Prefix, number> = {
+  ksm: 333333333,
+  rmrk: 333333333,
+  ahk: 33333333,
+  dot: 10000000000,
+  ahp: 1000000000,
+  bsx: 1000000000000,
+}

--- a/libs/static/src/chains.ts
+++ b/libs/static/src/chains.ts
@@ -86,3 +86,11 @@ export const chainList = (): Option[] => {
     value: prefix,
   }))
 }
+
+export const existentialDeposit: Record<'ksm' | 'ahk' | 'dot' | 'ahp', number> =
+  {
+    ksm: 333333333,
+    ahk: 33333333,
+    dot: 10000000000,
+    ahp: 1000000000,
+  }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1085,7 +1085,7 @@
     "tweetDonation": "Tweet about your awesome donation",
     "donationSentTo": "Your donation will be sent to:",
     "ownerMessage": "(You Are Owner)",
-    "insufficientExistentialDeposit": "Due to the upcoming funds being below the Existential Deposit, there is a risk of potential loss."
+    "insufficientExistentialDeposit": "Sending less funds Existential Deposit will result in loss, min value to send is [ {0} + fees ] {1}"
   },
   "preferences": {
     "basic": "basic user interface",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1084,7 +1084,8 @@
     "congratsSupport": "Congratulations for supporting",
     "tweetDonation": "Tweet about your awesome donation",
     "donationSentTo": "Your donation will be sent to:",
-    "ownerMessage": "(You Are Owner)"
+    "ownerMessage": "(You Are Owner)",
+    "insufficientExistentialDeposit": "Due to the upcoming funds being below the Existential Deposit, there is a risk of potential loss."
   },
   "preferences": {
     "basic": "basic user interface",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1085,7 +1085,7 @@
     "tweetDonation": "Tweet about your awesome donation",
     "donationSentTo": "Your donation will be sent to:",
     "ownerMessage": "(You Are Owner)",
-    "insufficientExistentialDeposit": "Sending less funds Existential Deposit will result in loss, min value to send is [ {0} + fees ] {1}"
+    "insufficientExistentialDeposit": "Sending less than the required Existential Deposit amount will result in fund loss, min value to send is [ {0} + fees ] {1}"
   },
   "preferences": {
     "basic": "basic user interface",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
 
  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8359
  - [x] Closes #8416

<img width="1001" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/24b8a0d0-63ef-4108-8a5b-df4152cbae54">


  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="721" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/68dc8499-e14e-4d71-a8fb-d7e0aa354e19">

When clicking on the warning text, it would open the url for more details: https://support.polkadot.network/support/solutions/articles/65000168651-what-is-the-existential-deposit

  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 848271d</samp>

This pull request adds a feature to warn users who try to teleport below the existential deposit of the target chain. It uses the `existentialDeposit` object from the `@kodadot1/static` library and adds a translation key and value for the link text.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 848271d</samp>

> _To teleport funds across chains_
> _You need to avoid certain pains_
> _If you send too low_
> _A warning will show_
> _Or else you might lose all your Plancks_
  