### PR TITLE
Fix/Playwright prefix test

### DIFF
--- a/tests/e2e/prefix.spec.ts
+++ b/tests/e2e/prefix.spec.ts
@@ -44,7 +44,7 @@ test('Check if RMRK2 NFT URL is correct', async ({ page }) => {
 })
 
 test('Check if Ahk NFT URL is correct', async ({ page }) => {
-  await page.goto('/ahk/explore/items?listed=false&search=Susanne')
+  await page.goto('/ahk/explore/items?listed=false&search=pixelated')
   await page.locator('[class="infinite-scroll-item"]').click()
-  await expect(page).toHaveURL('/ahk/gallery/111-2')
+  await expect(page).toHaveURL('/ahk/gallery/224-6')
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

Quick fix since i'm not at my house

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0350979</samp>

Updated a test case in `tests/e2e/prefix.spec.ts` to use a different search term and NFT ID. This fixed a failing test due to a data change on the Ahk NFT platform.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0350979</samp>

> _`test case` updated_
> _search term and `NFT ID` changed_
> _fixing autumn bug_