### PR TITLE
NeoNotification to tailwindcss

### DIFF
--- a/libs/ui/src/components/NeoNotification/NeoNotification.vue
+++ b/libs/ui/src/components/NeoNotification/NeoNotification.vue
@@ -8,7 +8,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../scss/_theme.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/_expressions.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/_variables.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/_animations.scss';
@@ -16,33 +15,24 @@ export default {
 @import '@oruga-ui/oruga-next/src/scss/components/_notification.scss';
 
 .o-notices {
-  top: 4.5rem;
+  @apply top-[4.5rem];
 
   .o-notification {
-    padding: 1rem 2rem;
+    @apply py-4 px-8;
 
     &--component {
-      padding: 0 !important;
-      background-color: unset;
+      @apply p-0 #{!important};
+      @apply bg-[unset];
     }
   }
 }
 
 .is-neo-toast {
-  font-size: 12px;
-  border-radius: 0;
-  padding: 0.5rem 1rem !important;
+  @apply text-xs rounded-none bg-background-color border-default border-border-color shadow-primary text-text-color;
+  @apply py-2 px-4 #{!important};
 
-  @include ktheme() {
-    background-color: theme('background-color');
-    border: 1px solid theme('border-color');
-    box-shadow: theme('primary-shadow');
-    color: theme('text-color');
-    -webkit-box-shadow: theme('primary-shadow');
-
-    &:hover {
-      background-color: theme('k-accentlight');
-    }
+  &:hover {
+    @apply bg-k-accent-light;
   }
 }
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #8222 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f9c20d1</samp>

Refactored `NeoNotification` component to use Tailwind CSS instead of theme scss. This enhances the UI design system.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f9c20d1</samp>

> _We're sailing on the web with a mighty fine design_
> _We've ditched the theme scss and we're using Tailwind_
> _So heave away, me hearties, and refactor as you go_
> _We'll make the `NeoNotification` component shine and glow_