### PR TITLE
fix: Profile colour change

### DIFF
--- a/libs/ui/src/components/NeoModalHead/NeoModalHead.scss
+++ b/libs/ui/src/components/NeoModalHead/NeoModalHead.scss
@@ -9,15 +9,25 @@
   @include touch {
     & {
       padding: 1.5rem 1.25rem;
+
+      .modal-card-title {
+        font-size: 1rem;
+        line-height: 1.5;
+      }
+
+      @include ktheme {
+        background: theme('background-color-inverse');
+
+        .modal-card-close-button, .modal-card-title {
+          color: theme('text-color-inverse');
+        }
+      }
+
       @include mobile {
         display: flex;
         align-items: center;
         padding: 0 1.25rem !important;
         min-height: $navbar-mobile-min-height !important;
-      }
-      .modal-card-title {
-        font-size: 1rem;
-        line-height: 1.5;
       }
     }
   }

--- a/libs/ui/src/components/NeoModalHead/NeoModalHead.scss
+++ b/libs/ui/src/components/NeoModalHead/NeoModalHead.scss
@@ -15,15 +15,9 @@
         padding: 0 1.25rem !important;
         min-height: $navbar-mobile-min-height !important;
       }
-      @include ktheme {
-        background: theme('background-color-inverse');
-      }
       .modal-card-title {
         font-size: 1rem;
         line-height: 1.5;
-        @include ktheme {
-          color: theme('text-color-inverse');
-        }
       }
     }
   }

--- a/libs/ui/src/components/NeoModalHead/NeoModalHead.scss
+++ b/libs/ui/src/components/NeoModalHead/NeoModalHead.scss
@@ -23,12 +23,13 @@
         }
       }
 
-      @include mobile {
-        display: flex;
-        align-items: center;
-        padding: 0 1.25rem !important;
-        min-height: $navbar-mobile-min-height !important;
-      }
+
     }
+  }
+  @include mobile {
+    display: flex;
+    align-items: center;
+    padding: 0 1.25rem !important;
+    min-height: $navbar-mobile-min-height !important;
   }
 }

--- a/libs/ui/src/components/NeoModalHead/NeoModalHead.vue
+++ b/libs/ui/src/components/NeoModalHead/NeoModalHead.vue
@@ -14,7 +14,7 @@
       {{ title }}
     </span>
     <NeoButton
-      class="py-1 px-2"
+      class="py-1 px-2 modal-card-close-button"
       variant="text"
       no-shadow
       icon="xmark"


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #8513
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="370" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/68e8bfd4-59f9-4675-8ede-1b12cf7a8bbc">

<img width="432" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/e32415eb-6586-4afa-abaa-ad419007bcd4">






  ## Copilot Summary
  <!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 899e788</samp>

Removed theme mixins from `NeoModalHead.scss` to fix modal header color on dark mode. This was part of a UI bug fix pull request.

  <!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 899e788</samp>

> _`ktheme` blocks gone_
> _Modal header color fixed_
> _Dark mode in winter_
  