### PR TITLE
NeoTooltip to tailwindcss

### DIFF
--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.scss
@@ -2,7 +2,6 @@
 @import '@oruga-ui/oruga-next/src/scss/utilities/variables.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/animations.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/helpers.scss';
-@import '../../scss/variable.scss';
 
 $tooltip-content-zindex: 101;
 $tooltip-content-font-size: var(--font-size, 1rem);
@@ -16,47 +15,9 @@ $tooltip-arrow-margin: 1rem;
 @import '@oruga-ui/oruga-next/src/scss/components/tooltip.scss';
 
 .o-tip__content {
-  @include ktheme() {
-    color: theme('text-color');
-    border-color: theme('text-color');
-    background: theme('background-color');
-
-    .o-tip__arrow {
-      color: theme('text-color');
-    }
-  }
+  @apply text-xs py-2 px-4 text-text-color border-default border-text-color bg-background-color;
 }
 
-.o-tip__trigger > * {
-  font-size: inherit !important;
-  font-family: inherit !important;
-  height: 100%;
-}
-
-.o-tip {
-  &__content {
-    font-size: 0.75rem;
-    padding: 0.5rem 1rem;
-
-    @include ktheme() {
-      color: theme('text-color');
-      border: 1px solid theme('border-color');
-      background: theme('background-color');
-    }
-  }
-
-  &__arrow {
-    @include ktheme() {
-      color: theme('text-color');
-    }
-  }
-}
-
-.wrapper {
-  height: 100%;
-  > * {
-    font-size: inherit !important;
-    font-family: inherit !important;
-    height: inherit !important;
-  }
+.o-tip__arrow {
+  @apply text-text-color;
 }

--- a/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
+++ b/libs/ui/src/components/NeoTooltip/NeoTooltip.vue
@@ -26,7 +26,7 @@
       <div />
     </slot>
   </o-tooltip>
-  <div v-else class="wrapper">
+  <div v-else class="h-full">
     <slot>
       <div />
     </slot>
@@ -110,6 +110,5 @@ const handleClick = (event: MouseEvent) => {
 </script>
 
 <style lang="scss">
-// @import '@oruga-ui/oruga-next/dist/oruga.min.css';
 @import './NeoTooltip.scss';
 </style>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #8222 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 58e87f4</samp>

Refactored `NeoTooltip` component to use TailwindCSS instead of custom CSS. This improved the component's performance, style consistency, and code readability.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 58e87f4</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `NeoTooltip` component with a nimble mind._
> _He cast away the needless `import` and the `CSS` vars_
> _And clothed the element in `TailwindCSS` like a star._
