### PR TITLE
NeoTabs to tailwindcss

### DIFF
--- a/libs/ui/src/components/NeoTabs/NeoTabs.scss
+++ b/libs/ui/src/components/NeoTabs/NeoTabs.scss
@@ -1,4 +1,3 @@
-@import '../../scss/_theme.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/_expressions.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/_variables.scss';
 @import '@oruga-ui/oruga-next/src/scss/utilities/_animations.scss';
@@ -9,105 +8,82 @@ $tabs-font-size: 1rem;
 @import '@oruga-ui/oruga-next/src/scss/components/_tabs.scss';
 
 .neo-tabs--toggle {
-  @include ktheme() {
-    background: theme('background-color');
-    box-shadow: theme('primary-shadow');
-  }
+  @apply bg-background-color shadow-primary;
 
   .o-tabs__content {
-    padding: 0;
+    @apply p-0;
   }
 }
 
 .o-tabs {
   &__nav {
-    overflow: auto;
-    white-space: nowrap;
+    @apply overflow-auto whitespace-nowrap;
 
     &--toggle {
-      padding-bottom: 0;
+      @apply pb-0;
 
       & + .o-tabs__content {
-        @include ktheme() {
-          border: 1px solid theme('border-color');
-          border-top: 0;
-        }
+        @apply border-default border-border-color border-t-0;
       }
     }
 
     &-item {
       &-default {
-        @include ktheme() {
-          color: theme('text-color');
-          margin-bottom: 1.5rem;
-          border-bottom-color: theme('k-shade');
+        @apply text-text-color mb-6 border-b-k-shade;
 
-          &--active {
-            font-weight: 700;
-          }
+        &--active {
+          @apply font-bold;
+        }
 
-          &:hover:not(.o-tabs__nav-item-default--active) {
-            background-color: unset;
+        &:hover:not(.o-tabs__nav-item-default--active) {
+          @apply bg-[unset];
 
-            .o-tabs__nav-item-text,
-            span,
-            div {
-              color: theme('link-hover');
-            }
+          .o-tabs__nav-item-text,
+          span,
+          div {
+            @apply text-link-hover;
           }
         }
       }
 
       &-toggle {
-        @include ktheme() {
-          border: 1px solid theme('border-color');
-          color: theme('text-color');
-          border-right: 0;
+        @apply border-default border-border-color border-r-0 text-text-color;
 
-          &--active {
-            background-color: theme('background-color-inverse');
-            color: theme('text-color-inverse');
+        &--active {
+          @apply bg-background-color-inverse text-text-color-inverse;
+        }
+
+        &--disabled {
+          @apply cursor-auto opacity-unset text-text-color/50;
+          @apply text-text-color/50 #{!important};
+
+          .o-tip {
+            @apply pointer-events-auto;
           }
 
-          &--disabled {
-            cursor: auto;
-            opacity: unset;
-            color: rgba($color: theme('text-color'), $alpha: 0.5) !important;
-
-            .o-tip {
-              pointer-events: all;
-            }
-
-            &:hover {
-              background-color: inherit !important;
-            }
+          &:hover {
+            @apply bg-inherit #{!important};
           }
+        }
 
-          &:hover:not(.o-tabs__nav-item-toggle--active) {
-            background-color: theme('k-accentlight2');
-            border-color: theme('border-color');
-          }
+        &:hover:not(.o-tabs__nav-item-toggle--active) {
+          @apply bg-k-accent-light-2 border-border-color;
         }
       }
 
       &-wrapper:last-child {
         button.o-tabs__nav-item-toggle {
-          @include ktheme() {
-            border-right: 1px solid theme('border-color');
-          }
+          @apply border-r border-border-color;
         }
       }
     }
   }
 
   .o-tab-item__content {
-    height: 100%;
+    @apply h-full;
   }
 
-  &__content {
-    &--fixed {
-      height: 20rem;
-      overflow-y: auto;
-    }
+  &__content--fixed {
+    @apply h-[20rem] overflow-y-auto;
   }
 }

--- a/libs/ui/src/scss/tailwind.scss
+++ b/libs/ui/src/scss/tailwind.scss
@@ -11,7 +11,7 @@
 
   :root,
   :root .light-mode {
-    --text-color: var(--black);
+    --text-color: 0 0 0;
     --text-color-inverse: var(--white);
     --border-color: var(--black);
     --background-color: var(--white);
@@ -61,7 +61,7 @@
 
   .dark-mode {
     --black: #191718;
-    --text-color: var(--white);
+    --text-color: 255 255 255;
     --text-color-inverse: var(--black);
     --background-color: #191718;
     --background-color-inverse: var(--white);

--- a/libs/ui/tailwind.config.js
+++ b/libs/ui/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'text-color': 'var(--text-color)',
+        'text-color': 'rgb(var(--text-color) / <alpha-value>)',
         'text-color-inverse': 'var(--text-color-inverse)',
         'border-color': 'var(--border-color)',
         'background-color': 'var(--background-color)',


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #8222 
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [x] I've tested it at </ksm/collection>
- [x] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=16SpvdDgKNiQ3c53DxX7refnQcKUD3uRNim3Z1HBJLNGrtSP&usdamount=0)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 185b983</samp>

Refactored the NeoTabs component and updated the text color variable to use the new opacity syntax in Tailwind CSS. This improves the code readability and consistency of the UI library.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 185b983</samp>

> _We wanted to make our text fade_
> _So we changed how the `text-color` was made_
> _We used RGB values_
> _And Tailwind CSS classes_
> _And refactored the NeoTabs with a blade_