### PR TITLE
feat: Drop brackets from usd price in item trading history

### DIFF
--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -25,7 +25,7 @@
         <p v-if="Number(props.row.meta)">
           {{ formatPrice(props.row.meta)[0] }}
           <span class="has-text-grey">
-            (${{ formatPrice(props.row.meta)[1] }})</span
+            ~${{ formatPrice(props.row.meta)[1] }}</span
           >
         </p>
       </NeoTableColumn>

--- a/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
+++ b/components/gallery/GalleryItemTabsPanel/GalleryItemActivityTable.vue
@@ -25,7 +25,7 @@
         <p v-if="Number(props.row.meta)">
           {{ formatPrice(props.row.meta)[0] }}
           <span class="has-text-grey">
-            ~${{ formatPrice(props.row.meta)[1] }}</span
+            ${{ formatPrice(props.row.meta)[1] }}</span
           >
         </p>
       </NeoTableColumn>


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #8365

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2023-12-11 at 10 31 39@2x](https://github.com/kodadot/nft-gallery/assets/44554284/4c72163c-da02-44c0-90ad-c1b69c1c77e7)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 822e16e</samp>

Added a tilde symbol to USD prices in `GalleryItemActivityTable.vue` to show that they are estimates based on the original currency.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 822e16e</samp>

> _`~` for USD_
> _A subtle tweak for clarity_
> _Autumn leaves fall fast_


