### PR TITLE
fix: NeoTable content dark mode

### DIFF
--- a/libs/ui/src/components/NeoTable/NeoTable.vue
+++ b/libs/ui/src/components/NeoTable/NeoTable.vue
@@ -66,8 +66,12 @@ $table-th-font-weight: 400;
   }
 
   &--hoverable {
-    tbody tr:hover td {
-      @apply bg-k-accent-light-2;
+    tbody tr {
+      @apply bg-inherit #{!important};
+
+      &:hover td {
+        @apply bg-k-accent-light-2;
+      }
     }
   }
 }


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8525

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2023-12-11 at 16 08 56@2x](https://github.com/kodadot/nft-gallery/assets/44554284/0df8c74d-ee08-490d-b4be-d4875d0f0771)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 386f657</samp>

Fixed hoverable style bug in `NeoTable` component. Added a class to inherit table background color and applied hover effect to table cells.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 386f657</samp>

> _`NeoTable` rows_
> _inherit background color_
> _cut by hover style_


