### PR TITLE
fix: drop modal bugs

### DIFF
--- a/components/collection/drop/modal/DropConfirmModal.vue
+++ b/components/collection/drop/modal/DropConfirmModal.vue
@@ -36,7 +36,11 @@ import {
   useCountDown,
 } from '@/components/collection/unlockable/utils/useCountDown'
 
-type ModalStep = 'email' | 'claiming' | 'succeded'
+enum ModalStep {
+  EMAIL = 'email',
+  CLAIMING = 'claiming',
+  SUCCEEDED = 'succeded',
+}
 
 const emit = defineEmits(['confirm', 'completed', 'close', 'list'])
 const props = defineProps<{
@@ -55,7 +59,7 @@ const { $i18n } = useNuxtApp()
 
 const isModalActive = useVModel(props, 'modelValue')
 
-const modalStep = ref<ModalStep>('email')
+const modalStep = ref<ModalStep>(ModalStep.EMAIL)
 const email = ref<string>()
 const nftCoverLoaded = ref(false)
 const retry = ref(3)
@@ -125,27 +129,13 @@ watch([sanitizedMintedNft, retry], async ([mintedNft]) => {
   }
 })
 
-watch(
-  () => props.claiming,
-  (claiming: boolean) => {
-    if (claiming) {
-      modalStep.value = 'claiming'
-    }
-  },
-)
-
-watch(moveSuccessfulDrop, (value) => {
-  if (value) {
-    modalStep.value = 'succeded'
+watchEffect(() => {
+  if (props.claiming && isEmailSignupStep.value) {
+    modalStep.value = ModalStep.CLAIMING
+  } else if (moveSuccessfulDrop.value && isClaimingDropStep.value) {
+    modalStep.value = ModalStep.SUCCEEDED
+  } else if (!props.modelValue && isSuccessfulDropStep.value) {
+    modalStep.value = ModalStep.EMAIL
   }
 })
-
-watch(
-  () => props.modelValue,
-  (isOpen) => {
-    if (isOpen) {
-      modalStep.value = 'email'
-    }
-  },
-)
 </script>

--- a/components/collection/drop/modal/DropConfirmModal.vue
+++ b/components/collection/drop/modal/DropConfirmModal.vue
@@ -7,19 +7,17 @@
     content-class="modal-width"
     @close="onClose">
     <ModalBody :title="title" @close="onClose">
-      <transition name="fade">
-        <EmailSignup
-          v-if="isEmailSignupStep"
-          @confirm="handleEmailSignupConfirm" />
+      <EmailSignup
+        v-if="isEmailSignupStep"
+        @confirm="handleEmailSignupConfirm" />
 
-        <ClaimingDrop v-else-if="isClaimingDropStep" :est="displayDuration" />
+      <ClaimingDrop v-else-if="isClaimingDropStep" :est="displayDuration" />
 
-        <SuccessfulDrop
-          v-else-if="isSuccessfulDropStep"
-          :minted-nft="sanitizedMintedNft"
-          :can-list-nft="canListNft"
-          @list="$emit('list')" />
-      </transition>
+      <SuccessfulDrop
+        v-else-if="isSuccessfulDropStep"
+        :minted-nft="sanitizedMintedNft"
+        :can-list-nft="canListNft"
+        @list="$emit('list')" />
     </ModalBody>
   </NeoModal>
 </template>

--- a/components/collection/drop/modal/DropConfirmModal.vue
+++ b/components/collection/drop/modal/DropConfirmModal.vue
@@ -79,7 +79,7 @@ const moveSuccessfulDrop = computed(() => {
     return true
   }
 
-  return !(distance.value > 0) && sanitizedMintedNft.value && retry.value === 0
+  return distance.value <= 0 && sanitizedMintedNft.value && retry.value === 0
 })
 
 const title = computed(() => {

--- a/components/collection/drop/modal/DropConfirmModal.vue
+++ b/components/collection/drop/modal/DropConfirmModal.vue
@@ -139,4 +139,13 @@ watch(moveSuccessfulDrop, (value) => {
     modalStep.value = 'succeded'
   }
 })
+
+watch(
+  () => props.modelValue,
+  (isOpen) => {
+    if (isOpen) {
+      modalStep.value = 'email'
+    }
+  },
+)
 </script>

--- a/utils/dom.ts
+++ b/utils/dom.ts
@@ -1,18 +1,16 @@
 export const preloadImage = (src: string): Promise<boolean> => {
   return new Promise((resolve, reject) => {
-    try {
-      const image = new Image()
-      image.src = src
+    const image = new Image()
+    image.src = src
 
-      const onLoad = () => {
-        resolve(true)
-      }
-
-      image.addEventListener('load', onLoad, true)
-
-      image.removeEventListener('load', onLoad)
-    } catch (e) {
-      reject(e)
+    const onLoad = () => {
+      resolve(true)
     }
+
+    image.addEventListener('load', onLoad, true)
+    image.removeEventListener('load', onLoad)
+    image.addEventListener('error', (e) => {
+      reject(e)
+    })
   })
 }


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8483
- add: Multiple retries when preloading nft cover

- [x] Closes #8485
- ref: modal steps will not move back to email step if count goes to 0 seconds  

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/392e1640-577c-4571-9281-aebdcf003fdf


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ebb8a1a</samp>

Refactored the drop confirmation modal to use a more declarative approach with a `modalStep` ref and watch effects. Improved the error handling and performance of the NFT image preloading by using the `error` event and rejecting the promise in `preloadImage`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ebb8a1a</samp>

> _To show off an NFT in a modal_
> _We preload the image with a portal_
> _But if there's an `error`_
> _We don't want to terror_
> _So we reject the promise as normal_


