### PR TITLE
ref: Improve process adding new drop on landing

### DIFF
--- a/components/carousel/CarouselTypeGenerative.vue
+++ b/components/carousel/CarouselTypeGenerative.vue
@@ -9,9 +9,13 @@
 
 <script lang="ts" setup>
 import { useCarouselGenerativeNftEvents } from './utils/useCarouselEvents'
+import {
+  AHK_GENERATIVE_DROPS,
+  AHP_GENERATIVE_DROPS,
+} from '@/components/collection/drop/const'
 
 const { nfts, ids } = await useCarouselGenerativeNftEvents(
-  ['176'],
-  ['38', '40', '46', '49', '50'],
+  AHK_GENERATIVE_DROPS,
+  AHP_GENERATIVE_DROPS,
 )
 </script>

--- a/components/carousel/CarouselTypeGenerative.vue
+++ b/components/carousel/CarouselTypeGenerative.vue
@@ -9,10 +9,6 @@
 
 <script lang="ts" setup>
 import { useCarouselGenerativeNftEvents } from './utils/useCarouselEvents'
-import {
-  AHK_GENERATIVE_DROPS,
-  AHP_GENERATIVE_DROPS,
-} from '@/components/collection/drop/const'
 
 const { nfts, ids } = await useCarouselGenerativeNftEvents(
   AHK_GENERATIVE_DROPS,

--- a/components/collection/drop/const.ts
+++ b/components/collection/drop/const.ts
@@ -4,3 +4,19 @@ const now = new Date()
 export const countDownTime = endOfWeek(now).getTime()
 
 export const MINT_ADDRESS = '15CoYMEnJhhWHvdEPXDuTBnZKXwrJzMQdcMwcHGsVx5kXYvW'
+
+export const DEFAULT_DROP = '/ahp/drops/wallstreet'
+
+export const AHK_GENERATIVE_DROPS = [
+  '176', // Chained
+]
+
+export const AHP_GENERATIVE_DROPS = [
+  '50', // .motherboard
+  '49', // wallstreet
+  '46', // Snowflakes
+  '40', // Swirls
+  '38', // Generativ Art - Pare1d0scope
+]
+
+export const AHP_POPULAR_DROP_COLLECTIONS = [...AHP_GENERATIVE_DROPS]

--- a/components/collection/drop/const.ts
+++ b/components/collection/drop/const.ts
@@ -4,19 +4,3 @@ const now = new Date()
 export const countDownTime = endOfWeek(now).getTime()
 
 export const MINT_ADDRESS = '15CoYMEnJhhWHvdEPXDuTBnZKXwrJzMQdcMwcHGsVx5kXYvW'
-
-export const DEFAULT_DROP = '/ahp/drops/wallstreet'
-
-export const AHK_GENERATIVE_DROPS = [
-  '176', // Chained
-]
-
-export const AHP_GENERATIVE_DROPS = [
-  '50', // .motherboard
-  '49', // wallstreet
-  '46', // Snowflakes
-  '40', // Swirls
-  '38', // Generativ Art - Pare1d0scope
-]
-
-export const AHP_POPULAR_DROP_COLLECTIONS = [...AHP_GENERATIVE_DROPS]

--- a/components/collection/unlockable/UnlockableLandingMobileBanner.vue
+++ b/components/collection/unlockable/UnlockableLandingMobileBanner.vue
@@ -14,6 +14,3 @@
     </nuxt-link>
   </div>
 </template>
-<script lang="ts" setup>
-import { DEFAULT_DROP } from '@/components/collection/drop/const'
-</script>

--- a/components/collection/unlockable/UnlockableLandingMobileBanner.vue
+++ b/components/collection/unlockable/UnlockableLandingMobileBanner.vue
@@ -9,8 +9,11 @@
         alt="unlockable icon" />
       <span>{{ $t('mint.unlockable.mintLive') }}</span>
     </div>
-    <nuxt-link class="has-text-weight-bold" to="/ahp/drops/wallstreet">
+    <nuxt-link class="has-text-weight-bold" :to="DEFAULT_DROP">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>
 </template>
+<script lang="ts" setup>
+import { DEFAULT_DROP } from '@/components/collection/drop/const'
+</script>

--- a/components/collection/unlockable/UnlockableLandingTag.vue
+++ b/components/collection/unlockable/UnlockableLandingTag.vue
@@ -14,13 +14,15 @@
     <div class="separator mx-2" />
     <nuxt-link
       class="is-flex is-align-items-center has-text-weight-bold my-2"
-      to="/ahp/drops/wallstreet">
+      :to="DEFAULT_DROP">
       {{ $t('mint.unlockable.takeMe') }}
     </nuxt-link>
   </div>
 </template>
 
 <script lang="ts" setup>
+import { DEFAULT_DROP } from '@/components/collection/drop/const'
+
 const isUnlockableLandingTagVisible = true
 const { $i18n } = useNuxtApp()
 

--- a/components/collection/unlockable/UnlockableLandingTag.vue
+++ b/components/collection/unlockable/UnlockableLandingTag.vue
@@ -21,8 +21,6 @@
 </template>
 
 <script lang="ts" setup>
-import { DEFAULT_DROP } from '@/components/collection/drop/const'
-
 const isUnlockableLandingTagVisible = true
 const { $i18n } = useNuxtApp()
 

--- a/composables/popularCollections/constants.ts
+++ b/composables/popularCollections/constants.ts
@@ -1,3 +1,5 @@
+import { AHP_POPULAR_DROP_COLLECTIONS } from '@/components/collection/drop/const'
+
 export const POPULAR_COLLECTIONS = {
   ksm: [
     'be15890524c6e9b359-WIZARD', // Manta Wizard
@@ -54,11 +56,7 @@ export const POPULAR_COLLECTIONS = {
     'u-31848', // Ajuna Network Promo Collection
   ],
   ahp: [
-    '50', // .motherboard
-    '49', // wallstreet
-    '46', // Snowflakes
-    '40', // Swirls
-    '38', // Generativ Art - Pare1d0scope
+    ...AHP_POPULAR_DROP_COLLECTIONS,
     '10', // Kodachain - Berlin Onchain Exhibition
     '11', // Kodachain - Sub0 Opening Party 2023
     '13', // The sub0 2023 Biodiversity Collection

--- a/composables/popularCollections/constants.ts
+++ b/composables/popularCollections/constants.ts
@@ -1,5 +1,3 @@
-import { AHP_POPULAR_DROP_COLLECTIONS } from '@/components/collection/drop/const'
-
 export const POPULAR_COLLECTIONS = {
   ksm: [
     'be15890524c6e9b359-WIZARD', // Manta Wizard

--- a/utils/drop.ts
+++ b/utils/drop.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_DROP = '/ahp/drops/wallstreet'
+
+export const AHK_GENERATIVE_DROPS = [
+  '176', // Chained
+]
+
+export const AHP_GENERATIVE_DROPS = [
+  '50', // .motherboard
+  '49', // wallstreet
+  '46', // Snowflakes
+  '40', // Swirls
+  '38', // Generativ Art - Pare1d0scope
+]
+
+export const AHP_POPULAR_DROP_COLLECTIONS = [...AHP_GENERATIVE_DROPS]


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #8461

based on [changes](https://github.com/kodadot/nft-gallery/pull/8460/files)
![CleanShot 2023-12-12 at 15 25 28@2x](https://github.com/kodadot/nft-gallery/assets/44554284/8f4fd64c-77d1-42cf-9d60-16c6688176d1)

unified generative drop const 

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e67cdbc</samp>

Refactored and improved the code for the unlockable and generative NFT features by using shared constants for the drop IDs. This enhances the code quality, readability, and maintainability.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e67cdbc</samp>

> _Sing, O Muse, of the skillful refactorers of code_
> _Who made the carousel of generative NFTs shine_
> _With constant values for the drops, like a golden node_
> _That links the artful works of the divine._


