### PR TITLE
Remove footer on Drop page

### DIFF
--- a/pages/[prefix]/drops/index.vue
+++ b/pages/[prefix]/drops/index.vue
@@ -10,4 +10,8 @@ useSeoMeta({
   description: 'View all drops',
   ogUrl: route.path,
 })
+
+definePageMeta({
+  layout: 'no-footer',
+})
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #8542 

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/36627808/04aabf5d-15b0-4701-b8a9-d5c729f15641)


## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d852dde</samp>

Added a `definePageMeta` function to `pages/[prefix]/drops/index.vue` to use the 'no-footer' layout. This improves the UI of the drops page by removing the unnecessary footer component.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d852dde</samp>

> _`definePageMeta`_
> _No footer for drops layout_
> _A fresh spring cleaning_