### PR TITLE
fix: modals broken on mobile screen size 

### DIFF
--- a/components/shared/modals/ModalBody.vue
+++ b/components/shared/modals/ModalBody.vue
@@ -88,6 +88,10 @@ $b-padding: 1.25rem;
 .modal-width {
   width: v-bind(modalWidth);
   max-width: v-bind(modalMaxHeight);
+
+  @include mobile {
+    width: unset;
+  }
 }
 
 .limit-height {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8584

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2023-12-15 at 12 22 30@2x](https://github.com/kodadot/nft-gallery/assets/44554284/21bba550-4474-4151-8512-efd52e445dba)

![CleanShot 2023-12-15 at 12 21 42@2x](https://github.com/kodadot/nft-gallery/assets/44554284/528a0341-0019-41ae-9776-20b70bca130c)

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f1a5da</samp>

Refactor modal layout and design for responsiveness. Add responsive width rule to `ModalBody.vue`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f1a5da</samp>

> _`modal` gets a rule_
> _responsive on mobile screens_
> _autumn leaves design_


