### PR TITLE
fix: Different number of items in drops page and drop iteself

### DIFF
--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -47,9 +47,9 @@
           </div>
           <div class="is-flex justify-content-space-between" style="gap: 2rem">
             <div class="is-flex is-flex-direction-column">
-              <div class="has-text-grey">Available</div>
+              <div class="has-text-grey">{{ $t('statsOverview.minted') }}</div>
 
-              <div>{{ availableCount }}/{{ drop.max }}</div>
+              <div>{{ drop.minted }}/{{ drop.max }}</div>
             </div>
             <div class="is-flex is-flex-direction-column">
               <span class="has-text-grey">{{ $t('price') }}</span>


### PR DESCRIPTION

  ## PR Type

  - [x] Bugfix
 
  ## Context

  - [x] Closes #8639

<img width="1801" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/933a1442-01bf-49eb-94a4-534dc5c58002">


  