### PR TITLE
🔧 drop responsive

### DIFF
--- a/components/collection/drop/HolderOfGenerative.vue
+++ b/components/collection/drop/HolderOfGenerative.vue
@@ -55,9 +55,10 @@
                   :to="`/${urlPrefix}/gallery/${hasUserMinted}`" />
               </div>
             </div>
-            <div v-else class="is-flex is-justify-content-space-between">
-              <div class="mt-4">
+            <div v-else class="columns">
+              <div class="column">
                 <CollectionDropHolderOfCollection
+                  class="mt-4"
                   :is-holder="isHolderOfTargetCollection"
                   :collection-id="holderOfCollectionId" />
 
@@ -76,7 +77,7 @@
                 </div>
               </div>
 
-              <div class="is-flex">
+              <div class="column has-text-right">
                 <NeoButton
                   ref="root"
                   class="my-2 mint-button"
@@ -457,10 +458,15 @@ const handleDropAddModalConfirm = () => {
 </script>
 
 <style scoped lang="scss">
+@import '@/assets/styles/abstracts/variables';
+
 .unlockable-container {
   .mint-button {
     width: 14rem;
     height: 3.5rem;
+    @include mobile {
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
- close #8606 
- close #8609 

![Screenshot 2023-12-17 at 22-15-55 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/5772b9ee-f207-426d-92b6-e05aecede0dd)
![Screenshot 2023-12-17 at 22-14-07 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/4850cc9f-f364-44eb-b472-910dbc27f33d)
