### PR TITLE
fix: redirect to correct prefix according to drop

### DIFF
--- a/pages/[prefix]/drops/[id].vue
+++ b/pages/[prefix]/drops/[id].vue
@@ -19,7 +19,16 @@ definePageMeta({
   layout: 'unlockable-mint-layout',
 })
 const { params } = useRoute()
+const { redirectAfterChainChange } = useChainRedirect()
+const { urlPrefix, setUrlPrefix } = usePrefix()
 
 const drop = await useDrop(params.id.toString())
 const dropType = computed(() => drop?.type)
+
+onMounted(() => {
+  if (drop?.chain && urlPrefix.value !== drop?.chain) {
+    setUrlPrefix(drop?.chain)
+    redirectAfterChainChange(drop?.chain)
+  }
+})
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8716


auto-redirect
/ahk/drops/christmascity -> /ahp/drops/christmascity 

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI



  ## Copilot Summary
  copilot:summary

  copilot:poem
  