### PR TITLE
fix: Double information in the collection

### DIFF
--- a/components/collection/CollectionInfo.vue
+++ b/components/collection/CollectionInfo.vue
@@ -85,7 +85,7 @@
       <CollectionInfoLine
         :title="$t('series.owners')"
         :value="stats.uniqueOwners" />
-      <CollectionInfoLine title="Listed/Supply">
+      <CollectionInfoLine :title="$t('activity.listedAndMinted')">
         <span class="text-xs text-neutral-7 leading-6 font-normal mr-2"
           >{{
             Math.floor(

--- a/locales/en.json
+++ b/locales/en.json
@@ -911,6 +911,7 @@
     "volume": "Volume",
     "network": "Network",
     "creator": "Creator",
+    "listedAndMinted": "Listed/Minted",
     "owned": "Owned",
     "totalBought": "Total Bought",
     "totalSold": "Total Sold",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Context

  - [x] Closes #8702

<img width="779" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/fbf7dcbd-0dbb-46ad-9194-c48e43504b5f">


  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Copilot Summary
  copilot:summary

  copilot:poem
  