### PR TITLE
fix: Teleporting max and lower amounts dont work 

### DIFF
--- a/components/teleport/Teleport.vue
+++ b/components/teleport/Teleport.vue
@@ -183,7 +183,7 @@ const unsubscribeKusamaBalance = ref()
 const teleportFee = ref()
 const insufficientEDModalOpen = ref(false)
 
-const DOT_BUFFER_FEE = 100000000 // 0.01
+const DOT_BUFFER_FEE = 150000000 // 0.015
 const KSM_BUFFER_FEE = 1000000000 // 0.001
 
 const teleportBufferFee = computed(() =>


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #8614
- [x] Closes #8733

![CleanShot 2023-12-25 at 09 22 29@2x](https://github.com/kodadot/nft-gallery/assets/44554284/8ed0b98a-3ec6-49b2-b328-643bf5ed4a75)

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=13QUj3pZyFNfYj4AM336hRdyLQbevj5H3sR4PKmLEXLdwZhh)

#### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 


https://github.com/kodadot/nft-gallery/assets/44554284/62eb0d3d-51a0-44ae-ab63-e6d09510ba8b


https://github.com/kodadot/nft-gallery/assets/44554284/e21ce272-dbc2-4583-87de-e5c7549209a8



## Copilot Summary
copilot:summary

copilot:poem


