### PR TITLE
:bug: drop is not ended when drop is disabled

### DIFF
--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -20,7 +20,7 @@
 
             <TimeTag
               :drop-start-time="drop.dropStartTime"
-              :ended="Boolean(drop.disabled) || availableCount === 0" />
+              :ended="availableCount === 0" />
           </div>
         </section>
       </div>

--- a/utils/drop.ts
+++ b/utils/drop.ts
@@ -31,4 +31,4 @@ export const AHP_GENERATIVE_DROPS = [
 export const AHP_POPULAR_DROP_COLLECTIONS = [...AHP_GENERATIVE_DROPS]
 
 export const FALLBACK_DROP_COLLECTION_MAX = 300
-export const FUTURE_DROP_DATE = new Date(2023, 28, 12, 17)
+export const FUTURE_DROP_DATE = new Date(2023, 12, 28, 17)


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

Drop was marked as ended when it is just disabled 

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

