### PR TITLE
:tada: Capturing of WebGL art

### DIFF
--- a/composables/drop/useGenerativeDropMint.ts
+++ b/composables/drop/useGenerativeDropMint.ts
@@ -66,7 +66,10 @@ export default ({
 
   const tryCapture = async () => {
     try {
-      const imgFile = await makeScreenshot(sanitizeIpfsUrl(selectedImage.value))
+      const imgFile = await makeScreenshot(
+        sanitizeIpfsUrl(selectedImage.value),
+        { webgl: true },
+      )
       const imageHash = await pinFileToIPFS(imgFile)
       return imageHash
     } catch (error) {

--- a/services/capture.ts
+++ b/services/capture.ts
@@ -1,16 +1,23 @@
 import { $fetch, FetchError } from 'ofetch'
 const CAPTURE_BASE_URL = 'https://capture.kodadot.workers.dev'
+const WEBGL_CAPTURE_BASE_URL = 'https://capturegl.vercel.app/api'
 
 const api = $fetch.create({
   baseURL: CAPTURE_BASE_URL,
 })
 
+const vercel = $fetch.create({
+  baseURL: WEBGL_CAPTURE_BASE_URL,
+})
+
 type Settings = {
   delay?: number
+  webgl?: boolean
 }
 
 export const makeScreenshot = async (url: string, settings?: Settings) => {
-  const value = await api<any>('/screenshot', {
+  const finalApi = settings?.webgl ? vercel : api
+  const value = await finalApi<'blob'>('/screenshot', {
     method: 'POST',
     body: {
       url,

--- a/services/capture.ts
+++ b/services/capture.ts
@@ -17,7 +17,7 @@ type Settings = {
 
 export const makeScreenshot = async (url: string, settings?: Settings) => {
   const finalApi = settings?.webgl ? vercel : api
-  const value = await finalApi<'blob'>('/screenshot', {
+  const value = await finalApi<any, 'blob'>('/screenshot', {
     method: 'POST',
     body: {
       url,

--- a/utils/drop.ts
+++ b/utils/drop.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_DROP = {
-  alias: 'genera',
-  id: '63',
+  alias: 'split',
+  id: '66',
   chain: 'ahp',
 }
 
@@ -17,6 +17,7 @@ export const AHK_GENERATIVE_DROPS = [
 ]
 
 export const AHP_GENERATIVE_DROPS = [
+  '66', // Split
   '63', // Genera
   '60', // Christmas City
   '52', // Whirls


### PR DESCRIPTION
- :zap: use WebGL API if needed
- :bug: :label: should return blob
- :zap: use webgl for next drop
- :wrench: next drop is split

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

WebGL is possible to screenshot

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Screenshot 📸

- [ ] My fix has changed UI
