### PR TITLE
fix: AHK drops should be visible only on canary

### DIFF
--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -11,6 +11,7 @@ import { existentialDeposit } from '@kodadot1/static'
 import { chainPropListOf } from '@/utils/config/chain.config'
 import { DropItem } from '@/params/types'
 import { FUTURE_DROP_DATE } from '@/utils/drop'
+import { isProduction } from '@/utils/chain'
 
 export interface Drop {
   collection: CollectionWithMeta
@@ -31,21 +32,23 @@ export function useDrops() {
   onMounted(async () => {
     const dropsList = await getDrops()
 
-    dropsList.forEach((drop) => {
-      const { result: collectionData } = useQuery(
-        unlockableCollectionById,
-        { id: drop.collection },
-        { clientId: drop.chain },
-      )
+    dropsList
+      .filter((drop) => !isProduction || drop.chain !== 'ahk')
+      .forEach((drop) => {
+        const { result: collectionData } = useQuery(
+          unlockableCollectionById,
+          { id: drop.collection },
+          { clientId: drop.chain },
+        )
 
-      watchEffect(async () => {
-        if (collectionData.value?.collectionEntity) {
-          const { collectionEntity } = collectionData.value
-          const newDrop = await getFormattedDropItem(collectionEntity, drop)
-          drops.value.push(newDrop)
-        }
+        watchEffect(async () => {
+          if (collectionData.value?.collectionEntity) {
+            const { collectionEntity } = collectionData.value
+            const newDrop = await getFormattedDropItem(collectionEntity, drop)
+            drops.value.push(newDrop)
+          }
+        })
       })
-    }, [])
   })
 
   return drops


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Context

  - [x] Closes #8844

Please note that currently, the api does not return any drop of ahk. Once we merged this PR, we could return the testing drop from api. 

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Copilot Summary
  copilot:summary

  copilot:poem
  