### PR TITLE
fix: One decimal in top collections should be enough

### DIFF
--- a/components/landing/topCollections/TopCollectionsItem.vue
+++ b/components/landing/topCollections/TopCollectionsItem.vue
@@ -42,7 +42,7 @@
       <div class="justify-end px-2 flex w-160">
         <div class="has-text-right flex-col items-center flex is-size-7-mobile">
           <div class="no-wrap">
-            <CommonTokenMoney :value="volume" inline :round="2" />
+            <CommonTokenMoney :value="volume" inline :round="1" />
           </div>
           <div class="no-wrap is-hidden-mobile">
             <BasicMoney

--- a/components/shared/format/Money.vue
+++ b/components/shared/format/Money.vue
@@ -30,7 +30,6 @@ const props = withDefaults(
   }>(),
   {
     value: 0,
-    round: 4,
     unitSymbol: '',
     prefix: undefined,
   },
@@ -53,8 +52,8 @@ const finalValue = computed(() =>
       tokenDecimals.value,
       '',
     ),
-    props.round,
-    true,
+    props.round || 4,
+    props.round === undefined,
   ),
 )
 </script>

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -97,10 +97,7 @@ export const roundAmount = (
   disableFilter: boolean,
 ) => {
   const number = Number(value.replace(/,/g, ''))
-  if (disableFilter) {
-    return parseFloat(number.toString())
-  }
-  return roundTo(value, limit)
+  return parseFloat(disableFilter ? number.toString() : roundTo(value, limit))
 }
 
 export default format


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context


  - [x] Closes #8901
  - [x] Fix: decimal props does not work on Money component

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI
<img width="472" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/49f34601-e7d4-43d0-8c6f-208498633e93">




  ## Copilot Summary
  copilot:summary

  copilot:poem
  