### PR TITLE
Revert "fix: One decimal in top collections should be enough"

### DIFF
--- a/components/landing/topCollections/TopCollectionsItem.vue
+++ b/components/landing/topCollections/TopCollectionsItem.vue
@@ -42,7 +42,7 @@
       <div class="justify-end px-2 flex w-160">
         <div class="has-text-right flex-col items-center flex is-size-7-mobile">
           <div class="no-wrap">
-            <CommonTokenMoney :value="volume" inline :round="1" />
+            <CommonTokenMoney :value="volume" inline :round="2" />
           </div>
           <div class="no-wrap is-hidden-mobile">
             <BasicMoney

--- a/components/shared/format/Money.vue
+++ b/components/shared/format/Money.vue
@@ -30,6 +30,7 @@ const props = withDefaults(
   }>(),
   {
     value: 0,
+    round: 4,
     unitSymbol: '',
     prefix: undefined,
   },
@@ -52,8 +53,8 @@ const finalValue = computed(() =>
       tokenDecimals.value,
       '',
     ),
-    props.round || 4,
-    props.round === undefined,
+    props.round,
+    true,
   ),
 )
 </script>

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -97,7 +97,10 @@ export const roundAmount = (
   disableFilter: boolean,
 ) => {
   const number = Number(value.replace(/,/g, ''))
-  return parseFloat(disableFilter ? number.toString() : roundTo(value, limit))
+  if (disableFilter) {
+    return parseFloat(number.toString())
+  }
+  return roundTo(value, limit)
 }
 
 export default format


### PR DESCRIPTION
Reverts 
- kodadot/nft-gallery#8903
- https://github.com/kodadot/nft-gallery/issues/8901

Now it does show price
![Screenshot 2024-01-10 at 09-11-55 KodaDot - One Stop Shop for Polkadot NFTs One Stop Shop for Polkadot NFTs](https://github.com/kodadot/nft-gallery/assets/9987732/c014a9c5-feef-4bc4-b88f-e5d3a487d00d)
