### PR TITLE
Revert "Revert "fix: One decimal in top collections should be enough""

### DIFF
--- a/components/landing/topCollections/TopCollectionsItem.vue
+++ b/components/landing/topCollections/TopCollectionsItem.vue
@@ -42,7 +42,7 @@
       <div class="justify-end px-2 flex w-160">
         <div class="has-text-right flex-col items-center flex is-size-7-mobile">
           <div class="no-wrap">
-            <CommonTokenMoney :value="volume" inline :round="2" />
+            <CommonTokenMoney :value="volume" inline :round="1" />
           </div>
           <div class="no-wrap is-hidden-mobile">
             <BasicMoney

--- a/components/shared/format/Money.vue
+++ b/components/shared/format/Money.vue
@@ -30,7 +30,6 @@ const props = withDefaults(
   }>(),
   {
     value: 0,
-    round: 4,
     unitSymbol: '',
     prefix: undefined,
   },
@@ -53,8 +52,8 @@ const finalValue = computed(() =>
       tokenDecimals.value,
       '',
     ),
-    props.round,
-    true,
+    props.round || 4,
+    props.round === undefined,
   ),
 )
 </script>

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -97,7 +97,13 @@ export const roundAmount = (
   disableFilter: boolean,
 ) => {
   const number = Number(value.replace(/,/g, ''))
-  return parseFloat(disableFilter ? number.toString() : roundTo(value, limit))
+
+  return parseFloat(
+    (disableFilter ? number.toString() : roundTo(value, limit)).replace(
+      /,/g,
+      '',
+    ),
+  )
 }
 
 export default format

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -97,10 +97,7 @@ export const roundAmount = (
   disableFilter: boolean,
 ) => {
   const number = Number(value.replace(/,/g, ''))
-  if (disableFilter) {
-    return parseFloat(number.toString())
-  }
-  return roundTo(value, limit)
+  return parseFloat(disableFilter ? number.toString() : roundTo(value, limit))
 }
 
 export default format


### PR DESCRIPTION
- [x] Reverts kodadot/nft-gallery#8932 fix incorrect data due to decimal handler

Here is why it is broken.
<img width="244" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/9c4b2b7c-1df3-44b7-b868-8ff874336d55">

- [x] Closed #8901

<img width="1819" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/62e0d147-b116-4e84-a154-de3e09e4850d">
