### PR TITLE
fix: One decimal in top collections for different region

### DIFF
--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -75,7 +75,7 @@ export function roundTo(value: number | string, limit = 2) {
   const number = Number(value.toString().replace(/,/g, ''))
   const hasDecimals = number % 1 !== 0
   const fractionDigits = hasDecimals ? limit : 0
-  return number.toLocaleString(undefined, {
+  return number.toLocaleString('en-GB', {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   })
@@ -99,10 +99,10 @@ export const roundAmount = (
   const number = Number(value.replace(/,/g, ''))
 
   return parseFloat(
-    (disableFilter ? number.toString() : roundTo(value, limit)).replace(
-      /,/g,
-      '',
-    ),
+    (disableFilter
+      ? number.toLocaleString('en-GB')
+      : roundTo(value, limit)
+    ).replace(/,/g, ''),
   )
 }
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #8938

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="1212" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/6b152eff-c251-41fe-ac14-028feebae9cb">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  