### PR TITLE
fix: View collection button bigger

### DIFF
--- a/components/collection/unlockable/UnlockableCollectionInfo.vue
+++ b/components/collection/unlockable/UnlockableCollectionInfo.vue
@@ -17,7 +17,7 @@
           :label="seeAllDescription ? $t('showLess') : $t('showMore')"
           @click="toggleSeeAllDescription" />
         <NeoButton
-          variant="secondary"
+          variant="outlined-rounded"
           rounded
           :tag="NuxtLink"
           :to="`/${urlPrefix}/collection/${collectionId}`"

--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -91,6 +91,22 @@
       }
     }
 
+    &--outlined-rounded {
+      @apply h-[35px] w-min rounded shadow-none border border-card-border-color-light bg-background-color;
+
+      &:hover {
+        @apply bg-background-color border border-text-color text-text-color;
+      }
+
+      &.o-btn--disabled {
+        @apply opacity-unset border border-k-grey;
+
+        & .o-btn__wrapper .o-btn__label {
+          @apply text-k-grey;
+        }
+      }
+    }
+
     &--connect-dropdown {
       @apply w-[120px] h-10 bg-background-color;
 

--- a/libs/ui/src/types.ts
+++ b/libs/ui/src/types.ts
@@ -15,3 +15,4 @@ export type NeoButtonVariant =
   | 'text'
   | 'pill'
   | 'border-icon'
+  | 'outlined-rounded'


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #9060

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="667" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/cc93ed3f-cb71-4ab0-8786-b2b3b19c2af9">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  