### PR TITLE
fix: Mobile top collections missing USD

### DIFF
--- a/components/landing/topCollections/TopCollectionsItem.vue
+++ b/components/landing/topCollections/TopCollectionsItem.vue
@@ -55,7 +55,13 @@
             <div v-if="diffPercentString" :class="color">
               {{ diffPercentString }}
             </div>
-            <div v-else :class="color">--</div>
+            <div v-else :class="color">
+              <BasicMoney
+                :value="usdValue"
+                inline
+                hide-unit
+                :round="0" />&nbsp;USD
+            </div>
           </div>
         </div>
         <div


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #9070
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="489" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/15faf596-e960-49d1-b9bd-e6a8467fa3e8">
<img width="481" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1f826021-c4de-42f9-b8ce-aecdc77c4a82">

Better than nothing, wdyt?



  ## Copilot Summary
  copilot:summary

  copilot:poem
  