### PR TITLE
fix: Explore on other networks profile button

### DIFF
--- a/components/profile/ProfileEmptyResult.vue
+++ b/components/profile/ProfileEmptyResult.vue
@@ -8,7 +8,7 @@
     </div>
     <NeoButton
       v-if="totalChainsLength"
-      variant="pill"
+      variant="primary-rounded"
       :label="$t('profile.searchNoResultsButton', [chainNames[nextPrefix]])"
       @click="switchToPrefix(nextPrefix)" />
   </section>

--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -106,6 +106,21 @@
         }
       }
     }
+    &--primary-rounded {
+      @apply h-[40px] w-min rounded-3xl shadow-none border border-border-color bg-k-primary text-black;
+
+      &:hover {
+        @apply bg-background-color border border-text-color text-text-color;
+      }
+
+      &.o-btn--disabled {
+        @apply opacity-unset border border-k-grey bg-neutral-5;
+
+        & .o-btn__wrapper .o-btn__label {
+          @apply text-k-grey;
+        }
+      }
+    }
 
     &--connect-dropdown {
       @apply w-[120px] h-10 bg-background-color;

--- a/libs/ui/src/types.ts
+++ b/libs/ui/src/types.ts
@@ -16,3 +16,4 @@ export type NeoButtonVariant =
   | 'pill'
   | 'border-icon'
   | 'outlined-rounded'
+  | 'primary-rounded'


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #9069
  - [ ] Requires deployment <snek/rubick/worker>

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI
<img width="459" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/61299e0b-2f79-4e96-b6b2-fe284051b457">
<img width="415" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/83906fb6-563b-4614-82dc-d8c91f4169bb">




  ## Copilot Summary
  copilot:summary

  copilot:poem
  