### PR TITLE
fix: Price chart on resize error 

### DIFF
--- a/components/chart/PriceChart.vue
+++ b/components/chart/PriceChart.vue
@@ -150,11 +150,13 @@ const vApplySmoothing = useVModel(props, 'applySmoothing', emit)
 const heightStyle = computed(() =>
   props.chartHeight ? `height: ${props.chartHeight}` : '',
 )
-let chart = ref<InstanceType<typeof ChartJS> | null>(null)
+
+const chart = ref<{ chart: InstanceType<typeof ChartJS> } | null>(null)
 
 const onWindowResize = () => {
-  chart.value?.resize()
+  chart.value?.chart.resize()
 }
+
 useEventListener(window, 'resize', onWindowResize)
 
 const lineColor = computed(() => (isDarkMode.value ? '#fff' : '#181717'))


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #9083

access chart instance as per [docs](https://vue-chartjs.org/guide/#access-to-chart-instance) 

also I didn't notice any difference between before and after the fix  [docs](https://www.chartjs.org/docs/latest/developers/api.html#resize-width-height)

![CleanShot 2024-01-21 at 14 15 34@2x](https://github.com/kodadot/nft-gallery/assets/44554284/3ca7c800-540d-4008-9f80-6822205896fe)
 
did we need it to begin with?

`responsive` is set to `true` 

![CleanShot 2024-01-21 at 14 20 13@2x](https://github.com/kodadot/nft-gallery/assets/44554284/aca4c18a-1e77-4944-8b79-f84e9752a4a7)

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [ ] My fix has changed **something** on UI; 
