### PR TITLE
Replace the implementation of royalty tooltip with tippy

### DIFF
--- a/assets/styles/components/_tippy.scss
+++ b/assets/styles/components/_tippy.scss
@@ -5,3 +5,69 @@
   }
   @apply inline-block text-left p-0;
 }
+
+.tippy-arrow {
+  width: 10px;
+  height: 10px;
+
+  &:before {
+    content: "";
+    position: absolute;
+    border-color: transparent;
+    border-style: solid;
+  }
+}
+
+.tippy-box[data-placement^=top] {
+  & > .tippy-arrow {
+    bottom: 0;
+
+    &:before {
+      bottom: -5px;
+      left: 0;
+      border-width: 5px 5px 0;
+      border-top-color: initial;
+      transform-origin: center top;
+    }
+  }
+}
+
+.tippy-box[data-placement^=bottom] {
+  & > .tippy-arrow {
+    top: 0;
+
+    &:before {
+      top: -5px;
+      left: 0;
+      border-width: 0 5px 5px;
+      border-bottom-color: initial;
+      transform-origin: center bottom;
+    }
+  }
+}
+
+.tippy-box[data-placement^=left] {
+  & > .tippy-arrow {
+    right: 0;
+
+    &:before {
+      border-width: 5px 0 5px 5px;
+      border-left-color: initial;
+      right: -5px;
+      transform-origin: center left;
+    }
+  }
+}
+
+.tippy-box[data-placement^=right] {
+  & > .tippy-arrow {
+    left: 0;
+
+    &:before {
+      left: -5px;
+      border-width: 5px 5px 5px 0;
+      border-right-color: initial;
+      transform-origin: center right;
+    }
+  }
+}

--- a/components/collection/CollectionInfo.vue
+++ b/components/collection/CollectionInfo.vue
@@ -18,25 +18,27 @@
         <span v-if="recipient" class="inline">
           <span class="capitalize text-neutral-7">{{ $t('royalty') }}</span>
           &nbsp;{{ royalty }}%
-          <NeoTooltip
-            multiline
-            position="bottom"
-            :auto-close="['outside', 'inside']"
-            class="text-neutral-7">
+          <tippy
+            :arrow="true"
+            placement="bottom"
+            class="text-neutral-7"
+            :append-to="body">
             <NeoIcon class="icon" icon="info-circle" />
 
             <template #content>
-              Recipient Address:
-              <nuxt-link
-                :to="`/${urlPrefix}/u/${recipient}`"
-                class="has-text-link">
-                <IdentityIndex
-                  ref="identity"
-                  :address="recipient"
-                  show-clipboard />
-              </nuxt-link>
+              <div class="bg-background-color border py-2 px-4 text-xs">
+                Recipient Address:
+                <nuxt-link
+                  :to="`/${urlPrefix}/u/${recipient}`"
+                  class="has-text-link">
+                  <IdentityIndex
+                    ref="identity"
+                    :address="recipient"
+                    show-clipboard />
+                </nuxt-link>
+              </div>
             </template>
-          </NeoTooltip>
+          </tippy>
           <span class="text-neutral-5 mx-2">•</span>
         </span>
         <span>
@@ -102,13 +104,14 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon, NeoTooltip } from '@kodadot1/brick'
+import { NeoButton, NeoIcon } from '@kodadot1/brick'
 
 import {
   useCollectionDetails,
   useCollectionMinimal,
 } from './utils/useCollectionDetails'
 
+const body = ref(document.body)
 const route = useRoute()
 const { urlPrefix } = usePrefix()
 const { availableChains } = useChain()

--- a/plugins/vueTippy.ts
+++ b/plugins/vueTippy.ts
@@ -18,6 +18,7 @@ setDefaultProps({
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueTippy, {
     defaultProps: {
+      arrow: false,
       interactive: true,
       animateFill: false,
       animation: 'shift-away',


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #9068 
- [ ] Requires deployment <snek/rubick/worker>

The issue stems from the Oruga tooltip component's lack of support for properties such as "close delay," which prevents the tooltip from auto-closing when hovered over. The PR resolved this by switching our implementation from Oruga to Tippy, which supports this feature.

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer?target=1CAv6Zq3yVxL3eKhC94GWTWVwp1w4jZbqeZ6wXx1rPAhrce&usdamount=0&donation=true)

#### Community participation

- [x] [Are you at KodaDot Ecosystem Telegram?](https://t.me/kodadot_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
