### PR TITLE
🔧 nft-card border color

### DIFF
--- a/assets/styles/components/_nft-card.scss
+++ b/assets/styles/components/_nft-card.scss
@@ -3,13 +3,9 @@
 }
 
 .nft-card {
-  position: relative;
-  height: 100%;
+  @apply relative h-full bg-background-color border border-card-border-color;
 
   @include ktheme() {
-    background: theme('background-color');
-    border: 1px solid theme('k-grey');
-
     .border-stacked {
       border-color: theme('card-border-color-light') !important;
     }


### PR DESCRIPTION
- close #9015 

![Screenshot 2024-02-02 at 14-57-11 KodaDot - NFT Market Explorer](https://github.com/kodadot/nft-gallery/assets/9987732/35ae37b8-a5af-41de-bb9e-f9e0805acd0b)
