### PR TITLE
fix: Drop page loading indicator

### DIFF
--- a/components/collection/drop/MintButton.vue
+++ b/components/collection/drop/MintButton.vue
@@ -72,7 +72,7 @@ const buttonMint = computed<{
 
   return {
     label: props.mintButton.label,
-    disabled: props.mintButton.disabled,
+    disabled: props.mintButton.disabled || loading.value,
   }
 })
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #9320

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="473" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1918e6fd-cf64-4738-a9a5-429622ea45d6">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  