### PR TITLE
fix: Single/mass buy success modal followup

### DIFF
--- a/components/buy/SuccessfulBuyModal.vue
+++ b/components/buy/SuccessfulBuyModal.vue
@@ -21,7 +21,7 @@
             'max-h-[390px] overflow-y-auto': expanded,
           }">
           <div
-            v-for="item in items"
+            v-for="item in displayItems"
             :key="item.id"
             class="flex flex-row items-center gap-3">
             <BaseMediaItem
@@ -66,7 +66,7 @@
 <script setup lang="ts">
 import { ShoppingCartItem } from '@/components/common/shoppingCart/types'
 
-const COLLAPSED_ITEMS_COUNT = 6
+const COLLAPSED_ITEMS_COUNT = 5
 
 defineEmits(['modelValue'])
 const props = defineProps<{
@@ -91,6 +91,12 @@ const singleBuy = computed(() => props.items.length === 1)
 const firsItem = computed(() => props.items[0])
 const moreItems = computed(() => props.items.length - COLLAPSED_ITEMS_COUNT)
 const showMore = computed(() => props.items.length > COLLAPSED_ITEMS_COUNT)
+const displayItems = computed(() =>
+  props.items.slice(
+    0,
+    showMore.value && !expanded.value ? COLLAPSED_ITEMS_COUNT : undefined,
+  ),
+)
 
 const shareText = computed(() => {
   if (singleBuy.value) {

--- a/components/common/successfulModal/SingleItemMedia.vue
+++ b/components/common/successfulModal/SingleItemMedia.vue
@@ -1,6 +1,10 @@
 <template>
-  <div>
-    <BaseMediaItem class="border border-k-shade" :src="src" preview is-detail />
+  <div class="flex flex-col items-center">
+    <BaseMediaItem
+      class="border border-k-shade w-[200px] h-[200px]"
+      :src="src"
+      preview
+      is-detail />
 
     <div class="mt-5 border-b-k-shade">
       <p class="text-base capitalize font-bold text-center">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #9274

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI


<img width="369" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/53e41840-00ec-405f-8bd9-d7beb1326b78">

<img width="505" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/2a112ffd-cf14-414a-a737-7109f5a9ea9c">

<img width="433" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/d0e270df-00a3-4d29-8f3f-56be2da790db">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  