### PR TITLE
fix: Search by #number in  collections not working

### DIFF
--- a/components/items/ItemsGrid/utils/useSearchParams.ts
+++ b/components/items/ItemsGrid/utils/useSearchParams.ts
@@ -12,13 +12,19 @@ export const useItemsGridQueryParams = () => {
 // search items by keywords
 function useSearchKeywords() {
   const { search, searchBySn } = useItemsGridQueryParams()
+  const { urlPrefix } = usePrefix()
+  const { isAssetHub } = useIsChain(urlPrefix)
 
   return {
     keywords: computed(() => {
-      const conditions = [{ name_containsInsensitive: search.value }]
+      const conditions = [{ name_containsInsensitive: search.value }] as Record<
+        string,
+        string | undefined
+      >[]
 
       if (searchBySn.value) {
-        conditions.push({ sn_contains: search.value })
+        const key = isAssetHub.value ? 'id_contains' : 'sn_contains'
+        conditions.push({ [key]: search.value })
       }
 
       return search.value?.length

--- a/components/items/ItemsGrid/utils/useSearchParams.ts
+++ b/components/items/ItemsGrid/utils/useSearchParams.ts
@@ -23,7 +23,7 @@ function useSearchKeywords() {
       >[]
 
       if (searchBySn.value) {
-        const key = isAssetHub.value ? 'id_contains' : 'sn_contains'
+        const key = isAssetHub.value ? 'sn_eq' : 'sn_contains'
         conditions.push({ [key]: search.value })
       }
 

--- a/tests/e2e/collection.spec.ts
+++ b/tests/e2e/collection.spec.ts
@@ -64,6 +64,20 @@ test('Collection interactions', async ({ page, Commands }) => {
       .click()
   })
 
+  //collection search
+  await test.step('Use collection search', async () => {
+    await page.getByTestId('filter-checkbox-buynow').nth(1).click()
+    await page
+      .locator('[data-testid="search-bar-input"] >> visible = true')
+      .fill('34')
+    await page.keyboard.press('Enter')
+    await Commands.scrollDownSlow()
+    await expect(
+      page.locator('[class="infinite-scroll-item"]').first(),
+    ).toBeVisible()
+    await expect(page.getByTestId('nft-name')).toHaveText('Pare1d0scope #34')
+  })
+
   //art view
   await test.step('Activates art view and check if NFT name was hidden', async () => {
     await page.getByTestId('advanced-filter-collapsible').first().click()


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

`sq_contains` is not  present in **speck** using `sq_eq` instate 

- [x] Closes #9352

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [ ] My fix has changed **something** on UI; 
