### PR TITLE
fix: Ensure that Drop API is called only when tx is successful

### DIFF
--- a/components/collection/drop/HolderOfGenerative.vue
+++ b/components/collection/drop/HolderOfGenerative.vue
@@ -3,6 +3,7 @@
     :title="$t('mint.nft.minting')"
     :is-loading="isLoading"
     :status="status"
+    :is-error="isTransactionError"
     @try-again="mintNft" />
 
   <NeoModal
@@ -144,6 +145,7 @@ const {
   isLoading: isTransactionLoading,
   initTransactionLoader,
   status,
+  isError: isTransactionError,
 } = useMetaTransaction()
 
 const handleSelectImage = (image: string) => {
@@ -264,7 +266,7 @@ const mintButtonProps = computed<MintButtonProp>(() => ({
 const mintNft = async () => {
   try {
     isLoading.value = true
-
+    isTransactionError.value = false
     const { apiInstance } = useApi()
     const api = await apiInstance.value
 
@@ -293,6 +295,11 @@ const mintNft = async () => {
 
 watch(status, (curStatus) => {
   if (curStatus === TransactionStatus.Block) {
+    if (isTransactionError.value) {
+      isLoading.value = false
+      isTransactionLoading.value = false
+      return
+    }
     submitMint(mintNftSN.value)
   }
 })

--- a/components/shared/SigningModal/SigningModal.vue
+++ b/components/shared/SigningModal/SigningModal.vue
@@ -8,7 +8,7 @@
       <SigningModalBody
         :title="title"
         :subtitle="subtitle"
-        :failed="isCancelled"
+        :failed="isCancelled || isError"
         :show-subtitle-dots="isLoading"
         @try-again="() => $emit('tryAgain')">
         <template v-if="isTransactionInProgress" #footer>
@@ -31,6 +31,7 @@ const props = defineProps<{
   isLoading: boolean
   status: TransactionStatus
   title: string
+  isError: boolean
 }>()
 
 const { $i18n } = useNuxtApp()


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #9399

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

Mock tx error
![Kapture 2024-02-15 at 14 34 53](https://github.com/kodadot/nft-gallery/assets/31397967/4f56ee55-3f71-4c16-816f-cb0cd7e209c1)


  ## Copilot Summary
  copilot:summary

  copilot:poem
  