### PR TITLE
fix: drop other cursors no decimals

### DIFF
--- a/components/collection/drop/GenerativeLayout.vue
+++ b/components/collection/drop/GenerativeLayout.vue
@@ -130,7 +130,7 @@ const { connections } = useCursorParty({
 })
 
 const labelFormatter = (connection: UserDetails) =>
-  `${formatAmountWithRound(Number(connection.spent) || 0, decimals.value)} ${chainSymbol.value}`
+  `${formatAmountWithRound(Number(connection.spent) || 0, decimals.value, chainSymbol.value === 'DOT' ? 0 : undefined)} ${chainSymbol.value}`
 
 watch(() => props.userMintedCount, getUserStats)
 </script>

--- a/utils/format/balance.ts
+++ b/utils/format/balance.ts
@@ -110,7 +110,7 @@ export const formatAmountWithRound = (
 ) =>
   roundAmount(
     format(checkInvalidBalanceFilter(value), tokenDecimals, ''),
-    round || 4,
+    round === 0 ? round : round || 4,
     round === undefined,
   )
 


### PR DESCRIPTION
prev pr got merged before I could push :d 

![CleanShot 2024-02-17 at 17 48 16@2x](https://github.com/kodadot/nft-gallery/assets/44554284/19c3d90d-f57e-4f43-8dd9-a32ef5c07112)


> rounded numbers as three decimals are useless in this case
> 
> ![telegram-cloud-photo-size-4-5947351600181919001-m](https://github.com/kodadot/nft-gallery/assets/5887929/b486bd59-dca8-4663-b55a-4ff289151622)
> 
> 

