### PR TITLE
fix: typo prefix endpoints

### DIFF
--- a/libs/static/src/indexers.ts
+++ b/libs/static/src/indexers.ts
@@ -9,7 +9,7 @@ export const INDEXERS: Config<SquidEndpoint> = {
   rmrk: 'https://squid.subsquid.io/rubick/graphql',
   ksm: 'https://ksm.gql.api.kodadot.xyz/',
   ahk: 'https://ahk.gql.api.kodadot.xyz/',
-  ahp: 'https://ahk.gql.api.kodadot.xyz/',
+  ahp: 'https://ahp.gql.api.kodadot.xyz/',
   dot: 'https://squid.subsquid.io/rubick/graphql', // TODO: change to dot indexer when available
   // ahr: 'https://squid.subsquid.io/snack/graphql',
   // movr: 'https://squid.subsquid.io/antick/v/001-rc0/graphql',


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Related https://github.com/kodadot/nft-gallery/pull/9484#issuecomment-1953457302

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Screenshot 📸

- [ ] My fix has changed UI
