### PR TITLE
fix: Article card default state

### DIFF
--- a/libs/ui/src/components/CardArticle/CardArticle.vue
+++ b/libs/ui/src/components/CardArticle/CardArticle.vue
@@ -1,11 +1,11 @@
 <template>
   <a
     v-safe-href="link"
-    class="group block h-full no-underline border-default border-border-border-color bg-background-color hover:border-border-color"
+    class="group block h-full no-underline border-default border-card-border-color bg-background-color hover:border-border-color"
     target="_blank"
     rel="nofollow noopener noreferrer">
     <img
-      class="w-full object-cover h-56 border-b border-b-border-border-color group-hover:opacity-card-hover-opacity"
+      class="w-full object-cover h-56 border-b border-b-card-border-color group-hover:opacity-card-hover-opacity"
       :src="image"
       :alt="title" />
     <div class="p-4">


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #9544

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

default:
<img width="338" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1fcf3cba-c775-4656-8272-d77811aac1a1">

hover:
<img width="320" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/343b1655-c5ce-4386-b5b7-1320e546dd53">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  