### PR TITLE
fix: Mint button state when wallet is not connected

### DIFF
--- a/components/collection/drop/HolderOfGenerative.vue
+++ b/components/collection/drop/HolderOfGenerative.vue
@@ -301,7 +301,7 @@ const mintButtonLabel = computed(() => {
             `${withoutDecimals({ value: Number(props.drop?.price), prefix: props.drop?.chain })} ${chainSymbol.value}`,
           ])
         : $i18n.t('mint.unlockable.notEligibility')
-      : $i18n.t('mint.unlockable.checkEligibility')
+      : $i18n.t('general.connect_wallet')
 })
 const mintButtonDisabled = computed<boolean>(
   () =>

--- a/components/collection/drop/MintButton.vue
+++ b/components/collection/drop/MintButton.vue
@@ -36,6 +36,7 @@ const emit = defineEmits(['mint'])
 
 const { $i18n } = useNuxtApp()
 const { urlPrefix } = usePrefix()
+const { isLogIn } = useAuth()
 
 const loading = computed(
   () => props.isImageFetching || props.isWalletConnecting || props.isLoading,
@@ -43,9 +44,11 @@ const loading = computed(
 
 const isMintedOut = computed(() => !props.mintCountAvailable)
 const showHolderOfCollection = computed(() => !!props.holderOfCollection?.id)
+
 const isCheckingMintRequirements = computed(
   () =>
     showHolderOfCollection.value &&
+    isLogIn.value &&
     (props.holderOfCollection?.isLoading || props.minimumFunds.isLoading),
 )
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix

  ## Needs Design check

  - @exezbcz please review

  ## Context

  - [x] Closes #9489

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="994" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/49e02005-2941-4d3c-9760-91c172b7b023">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  