### PR TITLE
fix: generate variants on fails base64 image

### DIFF
--- a/components/collection/drop/GenerativePreview.vue
+++ b/components/collection/drop/GenerativePreview.vue
@@ -178,4 +178,14 @@ watch(
     immediate: true,
   },
 )
+
+watchDebounced(
+  [imageDataPayload],
+  () => {
+    if (imageDataPayload.value?.image === 'data:,') {
+      generateNft()
+    }
+  },
+  { debounce: 1000 },
+)
 </script>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Fix failed to load image https://github.com/kodadot/nft-gallery/issues/9559#issuecomment-1968954266. This PR will trigger "new variants" again if base64 on the image only returns `'data:,'`

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)


## Screenshot 📸

- [ ] My fix has changed UI
