### PR TITLE
Disable buy on RMRK1/2

### DIFF
--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemBuy.vue
@@ -9,10 +9,12 @@
             class="button-height w-full"
             variant="k-accent"
             data-testid="item-buy"
+            :disabled="isRemark"
             @click="onClick" />
         </div>
 
         <NeoButton
+          v-if="!isRemark"
           class="button-height square-button-width border-l-0"
           data-testid="item-add-to-cart"
           @click="onClickShoppingCart">
@@ -53,6 +55,8 @@ const shoppingCartStore = useShoppingCartStore()
 const instance = getCurrentInstance()
 const { doAfterLogin } = useDoAfterlogin(instance)
 const showRampModal = ref(false)
+const { urlPrefix } = usePrefix()
+const { isRemark } = useIsChain(urlPrefix)
 
 enum BuyStatus {
   BUY,

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -24,7 +24,7 @@
     :media-static-video="hideVideoControls"
     media-hover-on-cover-play>
     <template v-if="!hideAction" #action>
-      <div v-if="!isOwner && Number(nft?.price)" class="flex">
+      <div v-if="!isOwner && Number(nft?.price) && !isRemark" class="flex">
         <NeoButton
           :label="buyLabel"
           data-testid="item-buy"
@@ -86,6 +86,7 @@ const listingCartStore = useListingCartStore()
 const preferencesStore = usePreferencesStore()
 const { $i18n } = useNuxtApp()
 const NuxtLink = resolveComponent('NuxtLink')
+const { isRemark } = useIsChain(urlPrefix)
 
 const props = defineProps<{
   nft: NFTWithMetadata

--- a/components/shared/BreadcrumbsFilter.vue
+++ b/components/shared/BreadcrumbsFilter.vue
@@ -70,6 +70,9 @@ import useActiveRouterFilters from '@/composables/useActiveRouterFilters'
 import { NeoField } from '@kodadot1/brick'
 import { useCollectionSearch } from '../search/utils/useCollectionSearch'
 
+const { urlPrefix } = usePrefix()
+const { isRemark } = useIsChain(urlPrefix)
+
 const route = useRoute()
 const isCollectionActivityTab = computed(
   () => route.name === 'prefix-collection-id-activity',
@@ -86,12 +89,10 @@ const collectionIdList = computed(
   () => breads.value.collections?.split(',') || [],
 )
 
-const collections = computed<Collection[]>(
-  () =>
-    collectionArray.value?.filter(
-      (collection) =>
-        collectionIdList.value?.find((id) => collection.id === id),
-    ),
+const collections = computed<Collection[]>(() =>
+  collectionArray.value?.filter((collection) =>
+    collectionIdList.value?.find((id) => collection.id === id),
+  ),
 )
 
 const { isCollectionSearchMode } = useCollectionSearch()
@@ -118,7 +119,7 @@ const clearAllFilters = () => {
 }
 
 const queryMapTranslation = {
-  listed: $i18n.t('sort.listed'),
+  listed: isRemark.value ? $i18n.t('sort.listed_RMRK') : $i18n.t('sort.listed'),
   owned: $i18n.t('sort.own'),
   art_view: $i18n.t('filters.artView'),
   sale: $i18n.t('filters.sale'),

--- a/components/shared/filters/modules/StatusFilter.vue
+++ b/components/shared/filters/modules/StatusFilter.vue
@@ -17,7 +17,7 @@
     <div class="p-4">
       <NeoField>
         <NeoCheckbox v-model="listed" data-testid="filter-checkbox-buynow">
-          {{ $t('sort.listed') }}</NeoCheckbox
+          {{ $t(ListedOrBuynow) }}</NeoCheckbox
         >
       </NeoField>
       <NeoField>
@@ -37,6 +37,8 @@ const exploreFiltersStore = useExploreFiltersStore()
 const route = useRoute()
 const { accountId } = useAuth()
 const { replaceUrl: replaceURL } = useReplaceUrl()
+const { urlPrefix } = usePrefix()
+const { isRemark } = useIsChain(urlPrefix)
 
 type DataModel = 'query' | 'store'
 
@@ -51,6 +53,10 @@ const props = withDefaults(
     dataModel: 'query',
     fluidPadding: false,
   },
+)
+
+const ListedOrBuynow = computed(() =>
+  isRemark.value ? 'sort.listed_RMRK' : 'sort.listed',
 )
 
 const emit = defineEmits(['resetPage'])

--- a/locales/en.json
+++ b/locales/en.json
@@ -428,6 +428,7 @@
     "sn_ASC": "Alphabetically",
     "instance_ASC": "Sequence",
     "listed": "Buy now",
+    "listed_RMRK": "Listed",
     "own": "Own",
     "clearAll": "Clear All",
     "collection": {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [x] Closes #9627 

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=13s37n7Y9VvoF1JcqnQzbL2b76qb9vNQQyXvpvpProdrpvBe)

no buy now on hovering cards when exploring, also changed buy now to listed on kusama: 

![image](https://github.com/kodadot/nft-gallery/assets/36627808/61692d84-e1f9-4bd6-a68a-59ac74ebea1e)

Buy button disabled and cart button hidden on gallery item: 

![image](https://github.com/kodadot/nft-gallery/assets/36627808/dd1e11d1-3e3d-4754-837b-b46da68fdc18)

