### PR TITLE
fix: generate button on old drops

### DIFF
--- a/components/collection/drop/GenerativePreview.vue
+++ b/components/collection/drop/GenerativePreview.vue
@@ -116,7 +116,7 @@ const { imageDataPayload, imageDataLoaded } = useGenerativeIframeData()
 const { start: startTimer } = useTimeoutFn(() => {
   // quick fix: ensure that even if the completed event is not received, the loading state of the drop can be cleared
   // only applicable if the drop is old one that missing`kodahash/render/completed` event
-  if (!props.mintCountAvailable && !imageDataLoaded.value) {
+  if (props.mintCountAvailable && !imageDataLoaded.value) {
     isLoading.value = false
     emit('generation:end')
   }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [ ] Closes #<issue_number>
- [ ] Requires deployment <snek/rubick/worker>

#### Did your issue had any of the "$" label on it?

- [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

## Screenshot 📸

- [ ] My fix has changed UI
