### PR TITLE
fix: Multiple listing modals being opened at once

### DIFF
--- a/components/buy/SuccessfulBuyModal.vue
+++ b/components/buy/SuccessfulBuyModal.vue
@@ -58,8 +58,6 @@
         </div>
       </template>
     </SuccessfulModal>
-
-    <ListingCartModal />
   </div>
 </template>
 

--- a/components/collection/drop/Generative.vue
+++ b/components/collection/drop/Generative.vue
@@ -42,8 +42,6 @@
     free
     @close="closeAddFundModal"
     @confirm="handleDropAddModalConfirm" />
-
-  <ListingCartModal />
 </template>
 
 <script setup lang="ts">
@@ -51,7 +49,6 @@ import { createUnlockableMetadata } from '../unlockable/utils'
 import { DropItem } from '@/params/types'
 import { useDropMinimumFunds, useDropStatus } from '@/components/drops/useDrops'
 import DropConfirmModal from './modal/DropConfirmModal.vue'
-import ListingCartModal from '@/components/common/listingCart/ListingCartModal.vue'
 import { fetchNft } from '@/components/items/ItemsGrid/useNftActions'
 import useGenerativeDropMint, {
   type UnlockableCollectionById,

--- a/components/collection/drop/PaidGenerative.vue
+++ b/components/collection/drop/PaidGenerative.vue
@@ -53,7 +53,6 @@
     @confirm="handleConfirmPaidMint"
     @close="closeMintModal"
     @list="handleList" />
-  <ListingCartModal />
 </template>
 
 <script setup lang="ts">

--- a/layouts/generative-mint-layout.vue
+++ b/layouts/generative-mint-layout.vue
@@ -27,6 +27,7 @@
     <LazyTheFooter />
     <LazyCookieBanner />
     <Buy />
+    <ListingCartModal />
   </div>
 </template>
 


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [x] Refactoring


## Context

`<ListingCartModal />`  is already present in the explore layout and profile page

- [x] Closes #9640

## Needs QA check

- open the listing modal in the explore page or profile page , now only one will be opened 

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/dc654a4a-b534-4d50-acf7-ef5e58b6c8b5

