### PR TITLE
Fix/multiple-reloads

### DIFF
--- a/components/collection/drop/GenerativeLayout.vue
+++ b/components/collection/drop/GenerativeLayout.vue
@@ -27,7 +27,7 @@
           <hr class="hidden md:block mt-7 mb-0" />
 
           <CollectionDropGenerativePreview
-            class="md:hidden mt-7"
+            v-if="width < mdBreakpoint"
             :minted="userMintedCount"
             :drop="drop"
             :collection-id="collectionId"
@@ -57,7 +57,9 @@
           <CollectionUnlockableTag :collection-id="collectionId" />
         </div>
 
-        <div class="column hidden md:flex justify-end mt-[-213px]">
+        <div
+          v-if="width >= mdBreakpoint"
+          class="column md:flex justify-end mt-[-213px]">
           <CollectionDropGenerativePreview
             :minted="userMintedCount"
             :drop="drop"
@@ -102,6 +104,7 @@ import type {
 import { useCollectionMinimal } from '@/components/collection/utils/useCollectionDetails'
 import useCursorDropEvents from '@/composables/party/useCursorDropEvents'
 import { DropEventType } from '@/composables/party/types'
+import { useWindowSize } from '@vueuse/core'
 
 const props = withDefaults(
   defineProps<{
@@ -126,6 +129,9 @@ const props = withDefaults(
     holderOfCollection: undefined,
   },
 )
+
+const { width } = useWindowSize()
+const mdBreakpoint = 768
 
 const { emitEvent, completeLastEvent } = useCursorDropEvents(props.drop.alias)
 const { collection: collectionInfo } = useCollectionMinimal({

--- a/components/collection/drop/GenerativePreview.vue
+++ b/components/collection/drop/GenerativePreview.vue
@@ -180,15 +180,11 @@ watch(imageDataLoaded, () => {
   }
 })
 
-watch(
-  accountId,
-  () => {
-    generateNft()
-  },
-  {
-    immediate: true,
-  },
-)
+watch(accountId, generateNft)
+
+onMounted(() => {
+  setTimeout(generateNft, 1000)
+})
 
 watchDebounced(
   [imageDataPayload],

--- a/components/collection/drop/GenerativePreview.vue
+++ b/components/collection/drop/GenerativePreview.vue
@@ -183,7 +183,7 @@ watch(imageDataLoaded, () => {
 watch(accountId, generateNft)
 
 onMounted(() => {
-  setTimeout(generateNft, 1000)
+  setTimeout(generateNft, 100)
 })
 
 watchDebounced(


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #9648

## Links
[monotifs](https://deploy-preview-9655--koda-canary.netlify.app/ahk/drops/monotifs)
[alteration](https://deploy-preview-9655--koda-canary.netlify.app/ahk/drops/alteration)

## Notes
1. Usually it is better to use css to toggle visibilty, but not in this case. `GenerativePreview` is emitting messages, having 2 instances in the page is causing unexpcted behviours
2. yes, it is ugly to use `setTimeout` but in makes the first variation of the art to load consistently, i guess the code in the iframe needs a moment to load


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [ ] My fix has changed UI