### PR TITLE
fix: Retry transaction is not displayed after canceling signing

### DIFF
--- a/components/shared/SigningModal/SigningModal.vue
+++ b/components/shared/SigningModal/SigningModal.vue
@@ -31,7 +31,7 @@ const props = defineProps<{
   isLoading: boolean
   status: TransactionStatus
   title: string
-  isError: boolean
+  isError?: boolean
 }>()
 
 const { $i18n } = useNuxtApp()
@@ -70,24 +70,16 @@ const onClose = () => {
   isCancelled.value = false
 }
 
-watch(
-  [() => props.status, () => props.isLoading],
-  ([status, loading], [prevStatus, wasLoading]) => {
-    if (loading) {
-      isModalActive.value = true
-    }
+watch([() => props.status, () => props.isLoading], ([status, loading]) => {
+  if (loading) {
+    isModalActive.value = true
+  }
 
-    if (status === TransactionStatus.Finalized) {
-      isModalActive.value = false
-      return
-    }
+  if (status === TransactionStatus.Finalized) {
+    isModalActive.value = false
+    return
+  }
 
-    isCancelled.value = Boolean(
-      !loading &&
-        wasLoading &&
-        prevStatus === TransactionStatus.Unknown &&
-        status === TransactionStatus.Unknown,
-    )
-  },
-)
+  isCancelled.value = status === TransactionStatus.Cancelled
+})
 </script>

--- a/composables/autoTeleport/useAutoTeleportTransactionActions.ts
+++ b/composables/autoTeleport/useAutoTeleportTransactionActions.ts
@@ -4,29 +4,6 @@ import type {
   AutoteleportInteraction,
 } from './types'
 
-const isCancelled = (
-  action: AutoTeleportAction,
-  prevAction?: AutoTeleportAction,
-) => {
-  const loading = action.details.isLoading
-  const status = action.details.status
-
-  let prevLoading = false
-  let prevStatus = ''
-
-  if (prevAction) {
-    prevLoading = prevAction.details.isLoading
-    prevStatus = prevAction.details.status
-  }
-
-  return (
-    !loading &&
-    prevLoading &&
-    prevStatus === TransactionStatus.Unknown &&
-    status === TransactionStatus.Unknown
-  )
-}
-
 export const getAutoTeleportActionInteraction = (
   autoTeleportAction: AutoTeleportAction,
 ): AutoteleportInteraction =>
@@ -58,9 +35,9 @@ export default function (actions: ComputedRef<AutoTeleportAction[]>) {
 
   watch(
     actions,
-    (newActions, prevActions) => {
-      newActions.forEach((action, index) => {
-        const cancelled = isCancelled(action, prevActions?.[index])
+    (actions) => {
+      actions.forEach((action) => {
+        const cancelled = action.details.status === TransactionStatus.Cancelled
         actionsCancelled.value.set(
           getAutoTeleportActionInteraction(action),
           cancelled,


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #9632

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 


https://github.com/kodadot/nft-gallery/assets/44554284/75e645aa-9d15-4fad-85a4-efda1b0410fd

