### PR TITLE
add modal to layout

### DIFF
--- a/components/common/listingCart/ListingCartModal.vue
+++ b/components/common/listingCart/ListingCartModal.vue
@@ -58,7 +58,7 @@
             ref="autoteleportButton"
             :actions="actions"
             :disabled="confirmButtonDisabled"
-            :fees="{ actionLazyFetch: true, pesimistic: true }"
+            :fees="{ actionLazyFetch: true }"
             :label="confirmListingLabel"
             @confirm="confirm" />
         </div>

--- a/layouts/generative-mint-layout.vue
+++ b/layouts/generative-mint-layout.vue
@@ -27,7 +27,6 @@
     <LazyTheFooter />
     <LazyCookieBanner />
     <Buy />
-    <ListingCartModal />
   </div>
 </template>
 

--- a/layouts/unlockable-mint-layout.vue
+++ b/layouts/unlockable-mint-layout.vue
@@ -7,5 +7,6 @@
     </main>
     <LazyCookieBanner />
     <Buy />
+    <ListingCartModal />
   </div>
 </template>


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #9670

### Where it came from?

* #9650

removed `<ListingCartModal />` from `Generative` and `PaidGenerative`
but did not replace it with   `<ListingCartModal />` in  `unlockable-mint-layout`


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1cAsKZYNRb8dkSCpn4eVkEn6ycNZTGoDo5dGDgB8J1UUWK8)

## Screenshot 📸

- [ ] My fix has changed UI