### PR TITLE
fix: Limited per address on paid mint toast

### DIFF
--- a/components/collection/drop/HolderOfGenerative.vue
+++ b/components/collection/drop/HolderOfGenerative.vue
@@ -484,7 +484,7 @@ const submitMint = async (sn: string) => {
     isSuccessModalActive.value = true
     runtimeMintedCount.value += 1
   } catch (error) {
-    toast($i18n.t('drops.mintPerAddress'))
+    toast($i18n.t('drops.mintDropError', [error?.toString()]))
     isImageFetching.value = false
     $consola.error(error)
     throw error

--- a/components/collection/drop/PaidGenerative.vue
+++ b/components/collection/drop/PaidGenerative.vue
@@ -390,7 +390,7 @@ const submitMint = async (sn: string) => {
       collectionName: collectionName.value as string,
     }
   } catch (error) {
-    toast($i18n.t('drops.mintPerAddress'))
+    toast($i18n.t('drops.mintDropError', [error?.toString()]))
     isImageFetching.value = false
     closeMintModal()
     throw error

--- a/locales/en.json
+++ b/locales/en.json
@@ -1459,7 +1459,7 @@
     "mintingNow": "Minting Now",
     "comingSoon": "Coming Soon",
     "mintedBy": "Minted By",
-    "mintPerAddress": "Each address can mint only once",
+    "mintDropError": "Error encountered, please retry. {0}",
     "recentMints": "Recent NFT Mints",
     "latestMints": "Latest NFT Mints",
     "capture": "Unable to screenshot your art continuting without",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -298,7 +298,6 @@
     "mintedBy": "द्वारा MINTित",
     "mintingEnded": "समाप्त हो गई",
     "mintingLive": "MINTिंग लाइव",
-    "mintPerAddress": "प्रति पता केवल एक बार MINT कर सकता है",
     "noEmail": "कोई EMAIL नहीं है?",
     "noUpcoming": "अब तक कुछ नहीं है...",
     "paidDropWhyTooltip": "एक शेष <strong>{0}</strong> से ऊपर जरुरी है आपके खाते की गतिविधि को बनाए रखने, <strong>{1} Existential Deposit,</strong> को कवर करने, और आनंददायक भविष्य क्रियाओं को सक्षम करने के लिए।",


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix
  
  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #9698

Remove the toast message of `Each address can mint only once` and display the real error message.

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [ ] My fix has changed UI

trigger a mock error from api
<img width="638" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/1012fcc5-3a37-40a3-bcc0-8cd75aad075d">

  ## Copilot Summary
  copilot:summary

  copilot:poem
  