### PR TITLE
Footer test fix

### DIFF
--- a/tests/e2e/footer.spec.ts
+++ b/tests/e2e/footer.spec.ts
@@ -28,7 +28,7 @@ const footerLinks = [
   },
   {
     linkName: 'Tutorial',
-    linkAddress: 'https://hello.kodadot.xyz/tutorial/',
+    linkAddress: 'https://hello.kodadot.xyz/tutorial',
   },
   {
     linkName: 'Tutorials & Guides',
@@ -95,7 +95,7 @@ test('Check Footer links', async ({ page }) => {
     const newTabPromise = page.waitForEvent('popup')
     await footer.getByRole('link', { name: data.linkName }).first().click()
     const newTab = await newTabPromise
-    await expect(newTab).toHaveURL(new RegExp(`${data.linkAddress}`))
+    expect(newTab.url()).toMatch(new RegExp(`${data.linkAddress}`))
     await newTab.close()
   }
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Test fix

## Context

- [x] Closes #9694 

issue was happening because the https://hello.kodadot.xyz/tutorial page has a hydration problem: 

https://github.com/kodadot/nft-gallery/assets/36627808/23019dff-b631-4fe1-9fde-6849a25b2778



