### PR TITLE
fix: Missing NFT #serial numbers when listing

### DIFF
--- a/components/common/listingCart/shared/ListingCartItemDetails.vue
+++ b/components/common/listingCart/shared/ListingCartItemDetails.vue
@@ -14,7 +14,7 @@
           <div
             class="font-bold line-height-1 whitespace-nowrap is-clipped is-ellipsis"
             :class="[discarded ? 'text-k-grey' : 'text-text-color']">
-            {{ nft.name }}
+            {{ nameWithIndex(nft.name, nft.sn) }}
           </div>
           <div
             class="line-height-1 whitespace-nowrap is-clipped is-ellipsis"

--- a/components/common/shoppingCart/types.ts
+++ b/components/common/shoppingCart/types.ts
@@ -17,4 +17,5 @@ export type ShoppingCartItem = {
   addedAt: number
   meta?: NFTMetadata
   metadata: string
+  sn: string
 }

--- a/components/common/shoppingCart/utils.ts
+++ b/components/common/shoppingCart/utils.ts
@@ -60,6 +60,7 @@ export const nftToShoppingCartItem = (nft: NFT): ShoppingCartItem => {
     addedAt: new Date().getTime(),
     metadata: nft.metadata,
     meta: nft.meta,
+    sn: nft.sn,
   }
 }
 
@@ -82,6 +83,7 @@ export const nftToListingCartItem = (
     metadata: nft.metadata,
     meta: nft.meta,
     token: nft.token,
+    sn: nft.sn,
   }
 }
 

--- a/stores/listingCart.ts
+++ b/stores/listingCart.ts
@@ -13,6 +13,7 @@ type ListCartItemInternal = {
   urlPrefix: string
   price: string
   listPrice?: number
+  sn: string
   collection: EntityWithId
   meta?: NFTMetadata
   metadata?: string


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

  👇 __ Let's make a quick check before the contribution.

  ## PR Type

  - [x] Bugfix


  ## Needs QA check

  - @kodadot/qa-guild please review

  ## Context

  - [x] Closes #9734

  #### Did your issue had any of the "$" label on it?

  - [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

  ## Screenshot 📸

  - [x] My fix has changed UI

<img width="409" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/5b88b772-ebf5-45ae-85c1-7bae0256a54a">


  ## Copilot Summary
  copilot:summary

  copilot:poem
  