### PR TITLE
AutoTeleportActionButton: refactoring dependencies.

### DIFF
--- a/components/common/autoTeleport/AutoTeleportActionButton.vue
+++ b/components/common/autoTeleport/AutoTeleportActionButton.vue
@@ -78,6 +78,7 @@
 import { NeoButton, NeoSwitch } from '@kodadot1/brick'
 import AutoTeleportWelcomeModal from './AutoTeleportWelcomeModal.vue'
 import useAutoTeleport from '@/composables/autoTeleport/useAutoTeleport'
+import useAutoTeleportTransitionDetails from '@/composables/autoTeleport/useAutoTeleportTransitionDetails'
 import type {
   AutoTeleportAction,
   AutoTeleportFeeParams,
@@ -128,20 +129,20 @@ const { chainSymbol, name } = useChain()
 
 const amount = ref()
 
-const {
-  isAvailable: isAutoTeleportAvailable,
-  isReady,
-  hasEnoughInCurrentChain,
-  hasEnoughInRichestChain,
-  optimalTransition,
-  transactions,
-  teleport,
-  clear,
-} = useAutoTeleport(
+const { optimalTransition, transactions, teleport, clear } = useAutoTeleport(
   computed<AutoTeleportAction[]>(() => props.actions),
   computed(() => amount.value),
   props.fees,
 )
+
+const { isAvailable: isAutoTeleportAvailable } = useTeleport()
+
+const { isReady, hasEnoughInCurrentChain, hasEnoughInRichestChain } =
+  useAutoTeleportTransitionDetails(
+    computed<AutoTeleportAction[]>(() => props.actions),
+    computed(() => amount.value),
+    props.fees,
+  )
 
 const isModalOpen = ref(false)
 const onRampActive = ref(false)

--- a/composables/autoTeleport/useAutoTeleport.ts
+++ b/composables/autoTeleport/useAutoTeleport.ts
@@ -1,6 +1,7 @@
 import useAutoTeleportTransition from '@/composables/autoTeleport/useAutoTeleportTransition'
 import useAutoTeleportWatch from '@/composables/autoTeleport/useAutoTeleportWatch'
 import useAutoTeleportTransactionActions from './useAutoTeleportTransactionActions'
+import useAutoTeleportTransitionDetails from './useAutoTeleportTransitionDetails'
 import type {
   AutoTeleportAction,
   AutoTeleportFeeParams,
@@ -23,17 +24,18 @@ export default function (
     isAvailable,
   } = useTeleport()
 
-  const {
-    hasEnoughInCurrentChain,
-    hasEnoughInRichestChain,
-    isReady,
-    optimalTransition,
-  } = useAutoTeleportTransition({
+  const { optimalTransition } = useAutoTeleportTransition({
     actions,
     neededAmount,
     fees,
     autoTeleportStarted,
   })
+
+  const { hasEnoughInCurrentChain } = useAutoTeleportTransitionDetails(
+    actions,
+    neededAmount,
+    fees,
+  )
 
   const { transactionActions, clear: clearActions } =
     useAutoTeleportTransactionActions(actions)
@@ -81,9 +83,6 @@ export default function (
   })
 
   return {
-    hasEnoughInCurrentChain,
-    hasEnoughInRichestChain,
-    isReady,
     optimalTransition,
     transactions,
     isAvailable,

--- a/composables/autoTeleport/useAutoTeleportTransition.ts
+++ b/composables/autoTeleport/useAutoTeleportTransition.ts
@@ -20,11 +20,10 @@ export default function ({
   fees: AutoTeleportFeeParams
 }) {
   const { urlPrefix } = usePrefix()
-  const { isAvailable, getChainTokenDecimals } = useTeleport()
+  const { getChainTokenDecimals } = useTeleport()
 
   const {
     amountToTeleport,
-    hasEnoughInCurrentChain,
     hasEnoughInRichestChain,
     sourceChain,
     chainSymbol,
@@ -72,10 +71,6 @@ export default function ({
   })
 
   return {
-    isAvailable,
-    isReady,
-    hasEnoughInCurrentChain,
-    hasEnoughInRichestChain,
     optimalTransition,
   }
 }


### PR DESCRIPTION
`isReady` and the chain of computed values it depends on is implemented in `useAutoTeleportTransitionDetails`. This refactor makes the code more readable by directly importing into `AutoTeleportActionButton` its dependencies from their source file.

This refactor didn't follow as stated in #9695. This is because of the explanation stated above as regards `isReady`, which also applies same to some other dependencies.  Secondly, it's not very clear if `isReady` can be seperated into its own composable as it depends on the long chain of computed values before it in the `useAutoTeleportTransitionDetails` file.

I would appreciate review on this PR, if there is a misunderstanding as regards this issue.

**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

- [x] Closes #9695
- [ ] Requires deployment <snek/rubick/worker>

#### Before submitting pull request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ksm/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=14rs1iTduAn9YrqtDwsTZxK9YDbkzDekBstqxc78M6An87fX&usdamount=0)

