### PR TITLE
fix: Sort spotlight drops strip chronologically by upcoming mint date

### DIFF
--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -71,8 +71,8 @@ export function useDrops(query?: GetDropsQuery) {
   const sortDrops = computed(() =>
     orderBy(
       drops.value,
-      [(drop) => DROP_LIST_ORDER.indexOf(drop.status), 'alias'],
-      ['asc', 'asc'],
+      [(drop) => DROP_LIST_ORDER.indexOf(drop.status)],
+      ['asc'],
     ),
   )
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #9763

The drops would be sorted by `created_at` from api. After that, they would be sorted again based on the below status.
``` 
[
  DropStatus.MINTING_LIVE,
  DropStatus.SCHEDULED_SOON,
  DropStatus.SCHEDULED,
  DropStatus.COMING_SOON,
  DropStatus.MINTING_ENDED,
  DropStatus.UNSCHEDULED,
]
```

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

before:
(production env)
![image](https://github.com/kodadot/nft-gallery/assets/31397967/b9bab88b-faba-48ed-a985-ca960c79a32d)



after:
(mock production env)

![image](https://github.com/kodadot/nft-gallery/assets/31397967/0766315b-a48b-4a3d-b17b-856c50143c1e)


## Copilot Summary

copilot:summary

copilot:poem
