### PR TITLE
fix: preheat on massmint

### DIFF
--- a/composables/drop/massmint/useDropMassMintUploader.ts
+++ b/composables/drop/massmint/useDropMassMintUploader.ts
@@ -4,7 +4,6 @@ import {
 } from '@/composables/transaction/mintToken/constructDirectoryMeta'
 import { makeUnlockableMetadata } from '@/components/collection/unlockable/utils'
 import { useCollectionEntity } from '@/composables/drop/useGenerativeDropMint'
-import { GenerativePreviewItem } from '../useGenerativePreview'
 
 export default () => {
   const { toMintNFTs, drop } = storeToRefs(useDropStore())

--- a/composables/transaction/mintToken/constructDirectoryMeta.ts
+++ b/composables/transaction/mintToken/constructDirectoryMeta.ts
@@ -35,10 +35,8 @@ export const uploadMediaAndMetadataDirectories = async (
   const metaDirectoryCid = await pinDirectory(metadataFiles)
 
   // Preheat and upload files
-  await Promise.all(
-    mediaFiles.map((media, index) =>
-      preheatAndDirectUpload(media, imageHashes[index]),
-    ),
+  mediaFiles.map((_, index) =>
+    preheatFileFromIPFS(extractCid(imageHashes[index])),
   )
 
   return metadataFiles.map((_, index) =>
@@ -125,18 +123,7 @@ const createTokenMetadata = (
   return makeJsonFile(meta, String(index))
 }
 
-export const makeJsonFile = (data: any, name: string) =>
+export const makeJsonFile = (data: unknown, name: string) =>
   new File([JSON.stringify(data, null, 2)], `${name}.json`, {
     type: 'application/json',
   })
-
-const preheatAndDirectUpload = async (
-  media: File,
-  primaryHash: string,
-): Promise<void> => {
-  const { $consola } = useNuxtApp()
-  preheatFileFromIPFS(primaryHash)
-  const filePair: [File, File | null] = [media, null]
-  const hashPair: [string, string | undefined] = [primaryHash, undefined]
-  await uploadDirectWhenMultiple(filePair, hashPair).catch($consola.warn)
-}


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] Fix #9712. extract the cid to fix the path. and, preheat with image.w.kodadot.xyz will automatically upload files to cf-images/cf-r2, no need to call direct-upload

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)
