### PR TITLE
fix: The Break drop card size

### DIFF
--- a/components/drops/DropCard.vue
+++ b/components/drops/DropCard.vue
@@ -21,7 +21,7 @@
           >
 
           <div
-            class="flex item-start sm:items-center flex-col sm:flex-row justify-between flex-wrap gap-y-4 gap-x-2">
+            class="flex item-start sm:items-center flex-col sm:flex-row justify-between flex-wrap gap-y-4 gap-x-1">
             <div class="flex justify-between items-center min-h-[34px]">
               <TimeTag
                 v-if="drop.dropStartTime || ended"

--- a/components/drops/utils.ts
+++ b/components/drops/utils.ts
@@ -5,8 +5,9 @@ export function toDropScheduledDurationString(startTime: Date) {
     start: startTime,
     end: new Date(),
   })
+  const { hours = 0 } = duration
   return formatDuration(duration, {
-    format: ['hours', 'minutes'],
+    format: hours > 0 ? ['hours'] : ['minutes'],
   })
 }
 

--- a/components/drops/utils.ts
+++ b/components/drops/utils.ts
@@ -9,6 +9,8 @@ export function toDropScheduledDurationString(startTime: Date) {
   return formatDuration(duration, {
     format: hours > 0 ? ['hours'] : ['minutes'],
   })
+    .replace('hour', 'Hr')
+    .replace('minute', 'Min')
 }
 
 export function formatDropStartTime(startTime: Date, locale: string) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #9827

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

1. Start within a day => only display hours

![image](https://github.com/kodadot/nft-gallery/assets/31397967/15ae3cba-b973-43b2-8b83-539fba639b22)


2. Start within an hour => only display mins

![image](https://github.com/kodadot/nft-gallery/assets/31397967/a777da8f-b9e7-4373-ad65-df59ecfac96d)



## Copilot Summary

copilot:summary

copilot:poem
