### PR TITLE
fix: At Success modal is a preview of iterated art (good), and on the listing is the default. (bad)

### DIFF
--- a/components/common/listingCart/shared/ListingCartItemDetails.vue
+++ b/components/common/listingCart/shared/ListingCartItemDetails.vue
@@ -3,11 +3,22 @@
     <div class="flex justify-between">
       <div class="flex">
         <div>
+          <BaseMediaItem
+            v-if="nft.animationUrl"
+            class="border border-k-shade image is-48x48"
+            :class="{ 'opacity-50': discarded }"
+            :alt="nft?.name"
+            :animation-src="sanitizeIpfsUrl(nft.animationUrl)"
+            mime-type="text/html"
+            preview
+            is-detail />
+          <!-- keeping BasicImage since its has a skeleton laoder -->
           <BasicImage
+            v-else
             :src="avatar"
             :alt="nft?.name"
             class="border image is-48x48"
-            :class="{ 'is-50-percent': discarded }" />
+            :class="{ 'opacity-50': discarded }" />
         </div>
 
         <div class="flex flex-col justify-between ml-4 limit-width">
@@ -49,7 +60,9 @@ const getAvatar = async () => {
 }
 
 onMounted(() => {
-  getAvatar()
+  if (!props.nft.animationUrl) {
+    getAvatar()
+  }
 })
 </script>
 
@@ -65,9 +78,5 @@ onMounted(() => {
 
 .line-height-1 {
   line-height: 1;
-}
-
-.is-50-percent {
-  opacity: 50%;
 }
 </style>

--- a/components/common/listingCart/shared/ListingCartItemDetails.vue
+++ b/components/common/listingCart/shared/ListingCartItemDetails.vue
@@ -8,8 +8,8 @@
             class="border border-k-shade image is-48x48"
             :class="{ 'opacity-50': discarded }"
             :alt="nft?.name"
-            :animation-src="sanitizeIpfsUrl(nft.animationUrl)"
-            mime-type="text/html"
+            :animation-src="sanitizeIpfsUrl(nft.animationUrl.url)"
+            :mime-type="nft.animationUrl.mimeType"
             preview
             is-detail />
           <!-- keeping BasicImage since its has a skeleton laoder -->

--- a/components/common/shoppingCart/utils.ts
+++ b/components/common/shoppingCart/utils.ts
@@ -68,6 +68,7 @@ export const nftToShoppingCartItem = (nft: NFT): ShoppingCartItem => {
 export const nftToListingCartItem = (
   nft: NFT & TokenId,
   floor = '',
+  animationUrl?: string,
 ): ListCartItem => {
   const { urlPrefix } = usePrefix()
 
@@ -85,6 +86,7 @@ export const nftToListingCartItem = (
     meta: nft.meta,
     token: nft.token,
     sn: nft.sn,
+    animationUrl: animationUrl,
   }
 }
 

--- a/components/common/shoppingCart/utils.ts
+++ b/components/common/shoppingCart/utils.ts
@@ -1,5 +1,5 @@
 import { calculateExactUsdFromToken } from '@/utils/calculation'
-import { ListCartItem } from '@/stores/listingCart'
+import { ListCartItem, ListCartItemAnimationUrl } from '@/stores/listingCart'
 import { ShoppingCartItem } from './types'
 import { useFiatStore } from '@/stores/fiat'
 import { sum } from '@/utils/math'
@@ -68,7 +68,7 @@ export const nftToShoppingCartItem = (nft: NFT): ShoppingCartItem => {
 export const nftToListingCartItem = (
   nft: NFT & TokenId,
   floor = '',
-  animationUrl?: string,
+  animationUrl?: ListCartItemAnimationUrl,
 ): ListCartItem => {
   const { urlPrefix } = usePrefix()
 

--- a/composables/drop/massmint/useDropMassMintListing.ts
+++ b/composables/drop/massmint/useDropMassMintListing.ts
@@ -33,7 +33,10 @@ export default () => {
       const mintinSessionNft = mintingSession.value.items.find(
         (nft) => nft.id === withMetadataNFT.id,
       )
-      listNftByNftWithMetadata(withMetadataNFT, mintinSessionNft?.image)
+      listNftByNftWithMetadata(withMetadataNFT, {
+        url: mintinSessionNft?.image as string,
+        mimeType: 'text/html',
+      })
     })
   }
 

--- a/composables/drop/massmint/useDropMassMintListing.ts
+++ b/composables/drop/massmint/useDropMassMintListing.ts
@@ -5,7 +5,7 @@ export default () => {
   const { client } = usePrefix()
   const { listNftByNftWithMetadata } = useListingCartModal()
 
-  const { mintedNFTs } = storeToRefs(useDropStore())
+  const { mintedNFTs, mintingSession } = storeToRefs(useDropStore())
 
   const subscribeForNftsWithMetadata = (nftIds: string[]) => {
     subscribeToNfts(nftIds, async (data) => {
@@ -29,7 +29,12 @@ export default () => {
   }
 
   const listMintedNFTs = () => {
-    mintedNFTs.value.forEach(listNftByNftWithMetadata)
+    mintedNFTs.value.forEach((withMetadataNFT: NFTWithMetadata) => {
+      const mintinSessionNft = mintingSession.value.items.find(
+        (nft) => nft.id === withMetadataNFT.id,
+      )
+      listNftByNftWithMetadata(withMetadataNFT, mintinSessionNft?.image)
+    })
   }
 
   return {

--- a/composables/useListingCartModal.ts
+++ b/composables/useListingCartModal.ts
@@ -4,6 +4,7 @@ import {
 } from '@/components/common/shoppingCart/utils'
 import { ShoppingCartItem } from '@/components/common/shoppingCart/types'
 import { NFTWithMetadata } from './useNft'
+import { ListCartItemAnimationUrl } from '@/stores/listingCart'
 
 export default ({
   clearItemsOnModalClose = false,
@@ -35,7 +36,7 @@ export default ({
 
   const listNftByNftWithMetadata = (
     nftWithMetadata: NFTWithMetadata,
-    animationUrl?: string,
+    animationUrl?: ListCartItemAnimationUrl,
   ) => {
     tryAddingItemToListingCart(
       nftToListingCartItem(

--- a/composables/useListingCartModal.ts
+++ b/composables/useListingCartModal.ts
@@ -33,9 +33,16 @@ export default ({
     )
   }
 
-  const listNftByNftWithMetadata = (nftWithMetadata: NFTWithMetadata) => {
+  const listNftByNftWithMetadata = (
+    nftWithMetadata: NFTWithMetadata,
+    animationUrl?: string,
+  ) => {
     tryAddingItemToListingCart(
-      nftToListingCartItem(nftWithMetadata, getFloorPrice(nftWithMetadata)),
+      nftToListingCartItem(
+        nftWithMetadata,
+        getFloorPrice(nftWithMetadata),
+        animationUrl,
+      ),
     )
   }
 

--- a/stores/listingCart.ts
+++ b/stores/listingCart.ts
@@ -7,6 +7,8 @@ import {
 import { ComputedRef } from 'vue'
 import type { Prefix } from '@kodadot1/static'
 
+export type ListCartItemAnimationUrl = { url: string; mimeType?: string }
+
 type ListCartItemInternal = {
   id: string
   name: string
@@ -18,7 +20,7 @@ type ListCartItemInternal = {
   meta?: NFTMetadata
   metadata?: string
   discarded?: boolean
-  animationUrl?: string // used inside the drop page to show the actual nft image before the metadata is updated
+  animationUrl?: ListCartItemAnimationUrl // used inside the drop page to show the actual nft image before the metadata is updated
 }
 
 export type ListCartItem = ListCartItemInternal & TokenId

--- a/stores/listingCart.ts
+++ b/stores/listingCart.ts
@@ -18,7 +18,9 @@ type ListCartItemInternal = {
   meta?: NFTMetadata
   metadata?: string
   discarded?: boolean
+  animationUrl?: string // used inside the drop page to show the actual nft image before the metadata is updated
 }
+
 export type ListCartItem = ListCartItemInternal & TokenId
 
 type ID = string


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

fix until https://github.com/kodadot/private-workers/issues/87 is implemented and  "setMetadata" is done earlier  as @preschian  mentioned

> But, I think it can solve the problem if we also put metadata in our minting step. Since it works on the "success modal". In https://github.com/kodadot/private-workers/issues/87#issuecomment-1997444473, I put "setMetadata" in the steps 2 and 6

- [x] Closes #9804

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/1b84cd9e-203e-42af-acd5-72b796794fa8

