### PR TITLE
fix: Drop cards order on drop page

### DIFF
--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -77,6 +77,7 @@ const { urlPrefix } = usePrefix()
 const { drops, loaded } = useDrops({
   active: [true, false],
   chain: !isProduction ? [urlPrefix.value] : [],
+  limit: 100, // set limit to enable sort from backend
 })
 
 const isCreateEventModalActive = ref(false)

--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -39,8 +39,8 @@ export enum DropStatus {
 }
 
 const DROP_LIST_ORDER = [
-  DropStatus.MINTING_LIVE,
   DropStatus.SCHEDULED_SOON,
+  DropStatus.MINTING_LIVE,
   DropStatus.SCHEDULED,
   DropStatus.COMING_SOON,
   DropStatus.MINTING_ENDED,


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #9844

new order would be the same as on the landing page - newest minting live drop to the oldest minting live drop
put scheduled - under 24hours that get to the top part first

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI
![image](https://github.com/kodadot/nft-gallery/assets/31397967/389539e7-bee8-4b70-a351-10a051bb7b96)



## Copilot Summary

copilot:summary

copilot:poem
