### PR TITLE
fix: drop calendar small visual things

### DIFF
--- a/components/drops/BasicDropCard.vue
+++ b/components/drops/BasicDropCard.vue
@@ -10,7 +10,7 @@
         :to="to"
         @click="emit('click')">
         <img
-          :src="image"
+          :src="image || placeholder"
           :alt="name"
           class="group-hover:opacity-[0.85] aspect-video object-cover w-full" />
 
@@ -22,10 +22,12 @@
           >
           <div
             class="h-[28px] flex justify-between items-center flex-wrap gap-y-4 gap-x-2">
-            <div>
-              <span>{{ minted }}</span
-              ><span class="text-k-grey">/{{ dropMax }}</span>
-            </div>
+            <slot name="supply">
+              <div>
+                <span>{{ minted }}</span
+                ><span class="text-k-grey">/{{ dropMax }}</span>
+              </div>
+            </slot>
             <CollectionDropCollectedBy
               v-if="ownerAddresses.length"
               :addresses="ownerAddresses"
@@ -52,7 +54,7 @@ import { DropStatus } from '@/components/drops/useDrops'
 const emit = defineEmits(['click'])
 withDefaults(
   defineProps<{
-    image: string
+    image: string | undefined
     name: string
     dropStartTime?: Date | null
     dropStatus: DropStatus
@@ -77,6 +79,8 @@ withDefaults(
     ownerAddresses: () => [],
   },
 )
+
+const { placeholder } = useTheme()
 </script>
 <style scoped lang="scss">
 @import '@/assets/styles/abstracts/variables';

--- a/components/drops/CreateCalendarEventModal.vue
+++ b/components/drops/CreateCalendarEventModal.vue
@@ -90,14 +90,14 @@ const addGoogleEvent = () => {
   window.open(calendarURL.toString(), '_blank')
 }
 
-const formattedDate = computed(() =>
-  props.dropStartTime
-    ? format(
-        props.dropStartTime,
-        props.useTimeFromDate ? 'dd/MM/yyyy - h:mm aa' : 'dd/MM/yyyy',
-      )
-    : $i18n.t('drops.everyThursday'),
-)
+const formattedDate = computed(() => {
+  const dateFormat = props.useTimeFromDate
+    ? 'dd/MM/yyyy - h:mm aa'
+    : 'dd/MM/yyyy'
+  return props.dropStartTime
+    ? format(props.dropStartTime, dateFormat)
+    : $i18n.t('drops.everyThursday')
+})
 
 const addEvent = (provider: CalendarProvider) => {
   if (provider === 'google') {

--- a/components/drops/CreateCalendarEventModal.vue
+++ b/components/drops/CreateCalendarEventModal.vue
@@ -8,7 +8,9 @@
         {{ title }}
       </p>
 
-      <p class="text-k-grey mt-3">{{ formattedDate }} - 3pm CET</p>
+      <p class="text-k-grey mt-3">
+        {{ formattedDate }} <span v-if="!useTimeFromDate">- 3pm CET</span>
+      </p>
 
       <div class="flex !mt-6 flex-col gap-6">
         <NeoButton
@@ -38,6 +40,7 @@ const props = defineProps<{
   modelValue: boolean
   title: string
   dropStartTime?: Date
+  useTimeFromDate?: boolean
 }>()
 
 const { $i18n } = useNuxtApp()
@@ -89,7 +92,10 @@ const addGoogleEvent = () => {
 
 const formattedDate = computed(() =>
   props.dropStartTime
-    ? format(props.dropStartTime, 'dd/MM/yyyy')
+    ? format(
+        props.dropStartTime,
+        props.useTimeFromDate ? 'dd/MM/yyyy - h:mm aa' : 'dd/MM/yyyy',
+      )
     : $i18n.t('drops.everyThursday'),
 )
 

--- a/components/drops/DropsGrid.vue
+++ b/components/drops/DropsGrid.vue
@@ -11,7 +11,7 @@
       :key="`${isDrop(drop) ? drop.collection?.id : drop.id}=${index}`"
       class="w-full h-full"
       :data-testid="index">
-      <slot name="card" :item="drop as DropCalendar">
+      <slot name="card" :item="drop as InternalDropCalendar">
         <DropCard :drop="drop as Drop" />
       </slot>
     </div>
@@ -19,8 +19,8 @@
 </template>
 <script lang="ts" setup>
 import DropCard from '@/components/drops/DropCard.vue'
-import { DropCalendar } from '@/services/fxart'
 import { Drop } from './useDrops'
+import { InternalDropCalendar } from './calendar/DropsCalendar.vue'
 
 const GRID_DEFAULT_WIDTH = {
   small: 0,
@@ -29,13 +29,13 @@ const GRID_DEFAULT_WIDTH = {
 }
 
 defineProps<{
-  drops: Drop[] | DropCalendar[]
+  drops: Drop[] | InternalDropCalendar[]
   loaded: boolean
   defaultSkeletonCount: number
   skeletonKey: string
   clickable?: boolean
 }>()
 
-const isDrop = (item: Drop | DropCalendar): item is Drop =>
+const isDrop = (item: Drop | InternalDropCalendar): item is Drop =>
   (item as Drop).collection !== undefined
 </script>

--- a/components/drops/calendar/DropPreviewModal.vue
+++ b/components/drops/calendar/DropPreviewModal.vue
@@ -30,18 +30,18 @@
 
         <div class="flex justify-between !mt-6">
           <div>
-            <span
+            <span :class="{ 'text-k-grey': !dropCalendar.twitter_handle }"
               >{{ $t('artist') }}:
-              <a
-                v-safe-href="
-                  `https://twitter.com/${dropCalendar.twitter_handle}`
-                "
-                class="has-text-link"
-                target="_blank"
-                rel="nofollow noopener noreferrer"
-                >{{ dropCalendar.twitter_handle }}</a
-              ></span
+            </span>
+            <a
+              v-if="dropCalendar.twitter_handle"
+              v-safe-href="`https://twitter.com/${dropCalendar.twitter_handle}`"
+              class="has-text-link"
+              target="_blank"
+              rel="nofollow noopener noreferrer"
+              >{{ dropCalendar.twitter_handle }}</a
             >
+            <span v-else> {{ placeholder }}</span>
           </div>
 
           <div v-if="dropCalendar.royalty">
@@ -52,6 +52,7 @@
         </div>
 
         <CarouselModuleCarouselAgnostic
+          v-if="dropCalendar.items.length"
           v-slot="{ item }"
           class="!mt-10"
           :items="dropCalendar.items"

--- a/components/drops/calendar/DropPreviewModal.vue
+++ b/components/drops/calendar/DropPreviewModal.vue
@@ -117,6 +117,7 @@
       v-model="isCreateEventModalActive"
       :title="`Drop: ${dropCalendar.name}`"
       :drop-start-time="dropCalendar.dropStartTime ?? undefined"
+      use-time-from-date
       @close="isCreateEventModalActive = false" />
   </div>
 </template>

--- a/components/drops/calendar/DropPreviewModal.vue
+++ b/components/drops/calendar/DropPreviewModal.vue
@@ -21,7 +21,7 @@
             @click="emit('close')" />
         </header>
 
-        <div v-if="dropStartTime" class="!mt-6">
+        <div v-if="dropCalendar.dropStartTime" class="!mt-6">
           <NeoButton no-shadow rounded @click="isCreateEventModalActive = true">
             {{ $t('scheduled') }}<span class="text-neutral-5 mx-2">•</span
             >{{ formattedDate }}
@@ -116,21 +116,21 @@
       v-if="dropCalendar"
       v-model="isCreateEventModalActive"
       :title="`Drop: ${dropCalendar.name}`"
-      :drop-start-time="dropStartTime"
+      :drop-start-time="dropCalendar.dropStartTime ?? undefined"
       @close="isCreateEventModalActive = false" />
   </div>
 </template>
 <script lang="ts" setup>
 import { NeoButton, NeoModal } from '@kodadot1/brick'
 import { format } from 'date-fns'
-import { DropCalendar } from '@/services/fxart'
 import { useCollectionMinimal } from '~/components/collection/utils/useCollectionDetails'
+import type { InternalDropCalendar } from './DropsCalendar.vue'
 
 const placeholder = 'TBA'
 const MOBILE_BREAKPOINT = 768
 
 const emit = defineEmits(['close'])
-const props = defineProps<{ dropCalendar?: DropCalendar }>()
+const props = defineProps<{ dropCalendar?: InternalDropCalendar }>()
 
 const { $i18n } = useNuxtApp()
 const { decimalsOf } = useChain()
@@ -162,15 +162,9 @@ const price = computed(() =>
 const isModalActive = computed(() => Boolean(props.dropCalendar))
 
 const formattedDate = computed(() =>
-  dropStartTime.value
-    ? `${format(dropStartTime.value, 'd. MMMM h:mm')} CET`
+  props.dropCalendar?.dropStartTime
+    ? `${format(props.dropCalendar.dropStartTime, 'd. MMMM h:mm aa')}`
     : '',
-)
-
-const dropStartTime = computed(() =>
-  props.dropCalendar?.date
-    ? new Date(`${props.dropCalendar.date} ${props.dropCalendar.time || ''}`)
-    : undefined,
 )
 
 const withPlaceholder = (nullableValue: unknown, or: unknown) =>

--- a/components/drops/calendar/DropsCalendar.vue
+++ b/components/drops/calendar/DropsCalendar.vue
@@ -43,8 +43,14 @@
               :image="sanitizeIpfsUrl(item.items[0]?.image)"
               :drop-start-time="getDropStartTime(item)"
               :drop-status="DropStatus.SCHEDULED"
+              :drop-max="item.supply as number"
               :time-tag-with-time="Boolean(item.time)"
               @click="() => handleClick(item)">
+              <template v-if="item.supply === null" #supply>
+                <span class="text-k-grey">
+                  {{ $t('helper.supplyNotSet') }}
+                </span>
+              </template>
             </DropsBasicDropCard>
           </template>
         </DropsGrid>

--- a/components/drops/calendar/DropsCalendar.vue
+++ b/components/drops/calendar/DropsCalendar.vue
@@ -37,14 +37,14 @@
           :loaded="!pending"
           :default-skeleton-count="defaultSkeletonCount"
           skeleton-key="current-drops-skeleton">
-          <template #card="{ item }: { item: DropCalendar }">
+          <template #card="{ item }: { item: InternalDropCalendar }">
             <DropsBasicDropCard
               :name="item.name"
               :image="sanitizeIpfsUrl(item.items[0]?.image)"
-              :drop-start-time="getDropStartTime(item)"
+              :drop-start-time="item.dropStartTime"
               :drop-status="DropStatus.SCHEDULED"
               :drop-max="item.supply as number"
-              :time-tag-with-time="Boolean(item.time)"
+              :time-tag-with-time="calendarHasTime(item)"
               @click="() => handleClick(item)">
               <template v-if="item.supply === null" #supply>
                 <span class="text-k-grey">
@@ -69,15 +69,28 @@ import { addMonths, format } from 'date-fns'
 import DropPreviewModal from './DropPreviewModal.vue'
 import { DropCalendar, getDropCalendar } from '@/services/fxart'
 import groupBy from 'lodash/groupBy'
-import { formatCETDate } from '@/components/drops/utils'
+import {
+  dateHasTime,
+  formatCETDate,
+  parseCETDate,
+} from '@/components/drops/utils'
+
+export type InternalDropCalendar = DropCalendar & { dropStartTime: Date | null }
 
 defineProps<{
   defaultSkeletonCount: number
 }>()
 
-const { data, pending } = useAsyncData<DropCalendar[]>(() => getDropCalendar())
+const { data, pending } = useAsyncData(() => getDropCalendar(), {
+  transform: (items) => {
+    return items.map((item) => ({
+      ...item,
+      dropStartTime: getDropStartTime(item),
+    })) as InternalDropCalendar[]
+  },
+})
 
-const previewDropCalendar = ref<DropCalendar>()
+const previewDropCalendar = ref<InternalDropCalendar>()
 const body = ref(document.body)
 
 const scheduledDropCalendars = computed(() =>
@@ -122,17 +135,37 @@ const grouppedDropCalendars = computed(() => {
 
 const formatDate = (date: string) => format(new Date(date), 'dd. MMMM')
 
+const calendarHasTime = (calendar: DropCalendar): boolean =>
+  calendar.date ? dateHasTime(calendar.date) : Boolean(calendar.time)
+
+const getCalendarParsedDate = ({
+  date,
+  time,
+}: {
+  date: string
+  time: string | null
+}): Date | null => {
+  if (dateHasTime(date)) {
+    return parseCETDate(date)
+  }
+
+  if (time) {
+    const [dateDate] = date!.split(' ')
+    return formatCETDate(dateDate, time)
+  }
+
+  return new Date(date)
+}
+
 const getDropStartTime = (calendar: DropCalendar): Date | null => {
   if (!calendar.date) {
     return null
   }
 
-  return calendar.time
-    ? formatCETDate(calendar.date, calendar.time)
-    : new Date(calendar.date)
+  return getCalendarParsedDate({ date: calendar.date, time: calendar.time })
 }
 
-const handleClick = (dropCalendar: DropCalendar) => {
+const handleClick = (dropCalendar: InternalDropCalendar) => {
   previewDropCalendar.value = dropCalendar
 }
 </script>

--- a/components/drops/utils.ts
+++ b/components/drops/utils.ts
@@ -38,3 +38,5 @@ export const parseCETDate = (datetime: string): Date => {
   const [date, time] = datetime.split(' ')
   return formatCETDate(date, time)
 }
+
+export const dateHasTime = (datetime: string): boolean => /:/.test(datetime)

--- a/locales/en.json
+++ b/locales/en.json
@@ -1010,7 +1010,7 @@
   "helper": {
     "tryAgain": "Try again",
     "viewTx": "View Tx",
-    "priceNotSet": "Price Not Set",
+    "supplyNotSet": "Supply Not Set",
     "seeMore": "See More",
     "learnMore": "Learn More",
     "learnMoreAboutEd": "Learn more about Existential deposit",


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

can be tested after https://github.com/kodadot/private-workers/pull/96

- [x] calendar cards: v2 update provide `supply` 
- [x] add placeholder image when no  calendar items are set
- [X] calendar preview: only show carousel if  `calendar` has  `calendar_items` 
- [x] make twitter handle nullable 

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2024-03-25 at 14 35 20@2x](https://github.com/kodadot/nft-gallery/assets/44554284/f290a412-38ac-4237-b63f-f9f1c5c73abf)

