### PR TITLE
fix: Clicking on connect wallet on old drops redirects you to collection

### DIFF
--- a/components/collection/drop/MintButton.vue
+++ b/components/collection/drop/MintButton.vue
@@ -73,6 +73,9 @@ const mintForLabel = computed(() =>
 )
 
 const label = computed(() => {
+  if (!mintCountAvailable.value) {
+    return $i18n.t('mint.unlockable.seeListings')
+  }
   if (!isLogIn.value) {
     return $i18n.t('general.connect_wallet')
   }
@@ -85,9 +88,6 @@ const label = computed(() => {
   }
   if (isCheckingMintRequirements.value) {
     return $i18n.t('checking')
-  }
-  if (!mintCountAvailable.value) {
-    return $i18n.t('mint.unlockable.seeListings')
   }
   if (drop.value.userAccess === false) {
     return $i18n.t('mint.unlockable.notEligibility')


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #9894
- [ ] Requires deployment <worker/stick/speck>

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/74fb3400-1b5c-4e2f-ab92-2cced028d89f)
