### PR TITLE
fix: Numbers in search bar are bit off

### DIFF
--- a/queries/subsquid/general/topCollections.graphql
+++ b/queries/subsquid/general/topCollections.graphql
@@ -15,6 +15,6 @@ query topCollections(
     volume
     floor
     nftCount
-    ownerCount
+    ownerCount: distribution
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #9909

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

![image](https://github.com/kodadot/nft-gallery/assets/31397967/838e2569-a269-44e5-87a6-bb0975681f50)

The `owner` number on the search bar is now close to the one on the collection page. There will still be a little difference because the indexer and the front-end calculate the owner differently.

ref: https://github.com/kodadot/stick/blob/f7d0084453bf98017521ed85e5b84384df1c8608/src/mappings/utils/helper.ts#L143
