### PR TITLE
fix: free mint stuck on the first step 

### DIFF
--- a/components/collection/drop/modal/DropConfirmModal.vue
+++ b/components/collection/drop/modal/DropConfirmModal.vue
@@ -77,7 +77,6 @@ const dropStore = useDropStore()
 const preferencesStore = usePreferencesStore()
 const { $i18n } = useNuxtApp()
 const isModalActive = useVModel(props, 'modelValue')
-const subscriptionEmail = preferencesStore.getNewsletterSubscription.email
 
 const {
   checkingSubscription,
@@ -121,6 +120,9 @@ const mintingSession = computed<MintingSession>(() => ({
   txHash: undefined, // free mint does not have a txHash
 }))
 
+const subscriptionEmail = computed(
+  () => preferencesStore.getNewsletterSubscription.email,
+)
 const isEmailSignupStep = computed(() => modalStep.value === ModalStep.EMAIL)
 const isEmailConfirmStep = computed(
   () => modalStep.value === ModalStep.CONFIRM_EMAIL,
@@ -194,17 +196,17 @@ watchEffect(() => {
   const claiming = dropStore.loading
   const alreadyConfirmed = emailConfirmed.value && !email.value
   const alreadySubscribed =
-    subscriptionEmail && !email.value && !changeEmail.value
+    subscriptionEmail.value && !email.value && !changeEmail.value
 
   if (alreadyConfirmed && isEmailSignupStep.value) {
     modalStep.value = ModalStep.CLAIMING
   } else if (alreadySubscribed && isEmailSignupStep.value) {
-    email.value = subscriptionEmail
+    email.value = subscriptionEmail.value
     modalStep.value = ModalStep.CONFIRM_EMAIL
   } else if (
     email.value &&
     isEmailSignupStep.value &&
-    subscriptionEmail &&
+    subscriptionEmail.value &&
     !subscribingToNewsletter.value
   ) {
     modalStep.value = ModalStep.CONFIRM_EMAIL


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

free mint would get stuck on the first step after adding your email and pressing confirm 

it wouldn't move to the next step (confirm email)


## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 


https://github.com/kodadot/nft-gallery/assets/44554284/f07666ad-0a83-438d-8e83-4f70dc848223

https://github.com/kodadot/nft-gallery/assets/44554284/1f6a0902-801e-4e45-8fae-a3533bd9edce

![CleanShot 2024-03-28 at 17 51 14@2x](https://github.com/kodadot/nft-gallery/assets/44554284/6fe074f3-32f2-4964-89bd-68e10377ca72)
