### PR TITLE
fix: Buy now stops working after a few redirects

### DIFF
--- a/components/shared/BreadcrumbsFilter.vue
+++ b/components/shared/BreadcrumbsFilter.vue
@@ -81,7 +81,6 @@ const { replaceUrl } = useReplaceUrl({
   resetPage: !isCollectionActivityTab.value,
 })
 const { $i18n } = useNuxtApp()
-const isItemsExplore = computed(() => route.path.includes('/explore/items'))
 
 const breads = useActiveRouterFilters()
 
@@ -129,12 +128,6 @@ const queryMapTranslation = {
   transfer: $i18n.t('filters.transfer'),
   verified: $i18n.t('filters.onlyVerifiedIdentities'),
 }
-
-onMounted(() => {
-  if (isItemsExplore.value && route.query.listed == undefined) {
-    replaceUrl({ listed: 'true' })
-  }
-})
 
 const closeTag = (key: string) => {
   replaceUrl({ [key]: false })

--- a/pages/[prefix]/explore/items.vue
+++ b/pages/[prefix]/explore/items.vue
@@ -43,6 +43,13 @@ onBeforeMount(() => checkRouteAvailability())
 
 definePageMeta({
   layout: 'explore-layout',
+  middleware: [
+    function (to) {
+      if (to.query.listed === undefined) {
+        return navigateTo({ path: to.path, query: { listed: true } })
+      }
+    },
+  ],
 })
 
 useSeoMeta({


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

Multiple searches would run one with `listed = false` and then another one with `listed = true` after the query param was added and then a watcher would tiggers a `resetPage(1)`

now that the `listed` is added inside the middleware only one call is made

- [x] Closes #9710

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [ ] My fix has changed **something** on UI; 
