### PR TITLE
:wrech: trigger of XCM autoteleport on ill-logical cases

### DIFF
--- a/libs/static/src/chains.ts
+++ b/libs/static/src/chains.ts
@@ -98,7 +98,7 @@ export const existentialDeposit: Record<Prefix, number> = {
   ksm: 666666666,
   rmrk: 666666666,
   ahk: 666666666,
-  dot: 14000000000,
+  dot: 15000000000,
   ahp: 5000000000,
   imx: 0, // nothing like ED in EVM :)
   base: 0,

--- a/libs/static/src/chains.ts
+++ b/libs/static/src/chains.ts
@@ -98,8 +98,8 @@ export const existentialDeposit: Record<Prefix, number> = {
   ksm: 666666666,
   rmrk: 666666666,
   ahk: 666666666,
-  dot: 15000000000,
-  ahp: 15000000000,
+  dot: 14000000000,
+  ahp: 5000000000,
   imx: 0, // nothing like ED in EVM :)
   base: 0,
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

I have a "poor" account (sub 1 DOT)
and basically everytime I am trying to do a drop I will have an autoteleport that is asking me to get all my balance from Polkadot to AssetHub.

This fix basically decreases ED so cases like that are not triggered

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ahp/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

#### Community participation

- [ ] [Are you at Koda Ecosystem Telegram?](https://t.me/koda_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
