### PR TITLE
refactor: remove migrate button on collection page

### DIFF
--- a/components/collection/CollectionHeader/CollectionBanner.vue
+++ b/components/collection/CollectionHeader/CollectionBanner.vue
@@ -23,25 +23,6 @@
           </div>
         </div>
 
-        <!-- migration is ready -->
-        <div v-if="isMigrate && isRemark">
-          <div
-            class="rounded-full border justify-between items-center px-4 bg-background-color hidden lg:flex">
-            <div class="flex items-center">
-              <img
-                width="42"
-                height="42"
-                src="~/assets/svg/migrate/state-ready.svg"
-                alt="unlockable icon" />
-              <span> {{ $t('migrate.ready.title') }} </span>
-            </div>
-            <div class="w-4 h-[1px] bg-separator-line-color mx-2" />
-            <nuxt-link class="flex items-center font-bold my-2" to="/migrate">
-              {{ $t('migrate.cta') }}
-            </nuxt-link>
-          </div>
-        </div>
-
         <!-- related active drop -->
         <CollectionRelatedDropNotification :collection-id="collectionId" />
 
@@ -58,15 +39,11 @@ import { sanitizeIpfsUrl, toOriginalContentUrl } from '@/utils/ipfs'
 import HeroButtons from '@/components/collection/HeroButtons.vue'
 import { generateCollectionImage } from '@/utils/seoImageGenerator'
 import { convertMarkdownToText } from '@/utils/markdown'
-import { useReadyItems } from '@/composables/useMigrate'
 
 const NuxtImg = resolveComponent('NuxtImg')
 
 const collectionId = computed(() => route.params.id as string)
 const route = useRoute()
-const { entities } = useReadyItems()
-const { urlPrefix } = usePrefix()
-const { isRemark } = useIsChain(urlPrefix)
 
 const { data, refetch } = useGraphql({
   queryName: 'collectionById',
@@ -77,7 +54,6 @@ const { data, refetch } = useGraphql({
 
 const collectionAvatar = ref('')
 const collectionName = ref('--')
-const isMigrate = ref(false)
 
 const bannerImageUrl = computed(
   () => collectionAvatar.value && toOriginalContentUrl(collectionAvatar.value),
@@ -95,8 +71,6 @@ watchEffect(async () => {
   const metadata = collection?.metadata
   const image = collection?.meta?.image
   const name = collection?.name
-
-  isMigrate.value = entities[collectionId.value.toString()]?.name
 
   if (image && name) {
     collectionAvatar.value = sanitizeIpfsUrl(image)


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Refactoring


## Context

Related: https://github.com/kodadot/nft-gallery/issues/9937

| before | after |
|--------|--------|
| <img width="2168" alt="Screenshot 2024-04-03 at 21 06 07" src="https://github.com/kodadot/nft-gallery/assets/734428/08e242e7-5d0f-4075-b4a3-dd9fc45df8c6"> | <img width="2168" alt="Screenshot 2024-04-03 at 21 06 45" src="https://github.com/kodadot/nft-gallery/assets/734428/a86222ba-eed2-42d5-b9a9-1bbfbc2d35f4"> | 


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)