### PR TITLE
fix: prioritize nft.metadata rather than nft.meta.id

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -304,7 +304,7 @@ const { isUnlockable, unlockLink } = useUnlockable(collection)
 
 const title = computed(() =>
   nameWithIndex(
-    nft.value?.name || nftMetadata.value?.name || '',
+    nftMetadata.value?.name || nft.value?.name || '',
     nft.value?.sn,
   ),
 )


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- Fix #9987

`nft.metadata` and `nft.meta.id` return different results:

```json
{
  "data": {
    "nftEntityById": {
      "id": "115-2404377033",
      "metadata": "https://fxart-beta.kodadot.workers.dev/metadata/v1/json?chain=ahp&collection=115&nft=2404377033&metadata=ipfs:%2F%2Fbafybeid6qweu5csznxnfa26aundrrdejg3l3sfiyhotpbokbt5hvm347ze%2F2.json",
      "meta": {
        "id": "ipfs://bafkreih2bq7dqqmtz4xqhfdjbo6wsyr6ozfhtvn4dyqkeokggmtrrrrw3i"
      }
    }
  }
}
```

the correct one is `nft.metadata`. in this PR prioritize fetch `nft.metadata` instead of `nft.meta.id`

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p)


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="960" alt="Screenshot 2024-04-04 at 22 39 57" src="https://github.com/kodadot/nft-gallery/assets/734428/1b8f57c2-d148-4f6a-ac71-d701a16c0212">
