### PR TITLE
fix: Bigger previews in the success modal

### DIFF
--- a/components/base/MediaItem.vue
+++ b/components/base/MediaItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="mediaItem" class="media-object" style="height: fit-content">
+  <div ref="mediaItem" class="media-object h-fit">
     <component
       :is="resolveComponent"
       :src="properSrc"

--- a/components/common/successfulModal/MultiItemMedia.vue
+++ b/components/common/successfulModal/MultiItemMedia.vue
@@ -10,7 +10,7 @@
       :key="item.id"
       class="flex flex-row items-center gap-4">
       <BaseMediaItem
-        class="border border-k-shade aspect-square w-8"
+        class="border border-k-shade aspect-square w-10 !h-10"
         :src="sanitizeIpfsUrl(item.image)"
         :mime-type="mediaMimeType"
         preview


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #9988

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


![image](https://github.com/kodadot/nft-gallery/assets/31397967/04ec2aa8-7cea-4e8b-8295-00587f5b1e58)
