### PR TITLE
fix: Mobile SkeletonDropCard doesnt match normal DropCard

### DIFF
--- a/components/drops/DropCardSkeleton.vue
+++ b/components/drops/DropCardSkeleton.vue
@@ -11,7 +11,7 @@
       </div>
 
       <div
-        class="flex items-start sm:items-center flex-col sm:flex-row justify-between flex-wrap gap-y-4 gap-x-2 w-full">
+        class="flex justify-between items-center flex-wrap gap-y-4 gap-x-2 w-full">
         <div class="w-16 flex gap-2">
           <NeoSkeleton height="28" width="100%" :rounded="false" no-margin />
           <NeoSkeleton height="28" width="100%" :rounded="false" no-margin />


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #10022

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed UI

<img width="360" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/b2fd6cd5-9a58-4de4-a562-348cb8efafb7">
