### PR TITLE
fix: gallery item genart animation not working

### DIFF
--- a/components/gallery/useGalleryItem.ts
+++ b/components/gallery/useGalleryItem.ts
@@ -101,7 +101,8 @@ export const useGalleryItem = (nftId?: string): GalleryItem => {
 
     nftImage.value = sanitizeIpfsUrl(metadata.image) || ''
     nftMimeType.value = metadata.imageMimeType || metadata.type || ''
-    nftAnimation.value = metadata.animationUrl || ''
+    nftAnimation.value =
+      sanitizeIpfsUrl(metadata.animationUrl || metadata.animation_url) || ''
     nftAnimationMimeType.value = metadata.animationUrlMimeType || ''
 
     // use cf-video & replace the video thumbnail


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #10071
- [x] Closes #10108
- [x] Rel #10117

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI;
 
## gen art 1

![CleanShot 2024-04-15 at 11 23 49](https://github.com/kodadot/nft-gallery/assets/44554284/9c577044-c272-47a8-852a-57ed40f680a3)

## gen art 2

![CleanShot 2024-04-15 at 11 23 13](https://github.com/kodadot/nft-gallery/assets/44554284/ed03007a-09dd-4324-a5be-c8a8ce22e624)

## nft with video

![CleanShot 2024-04-15 at 11 24 08](https://github.com/kodadot/nft-gallery/assets/44554284/71622ee7-1cfe-4674-bdf8-6f4f28d14386)

