### PR TITLE
fix: Unable to mint Tilescapes: Stuck on loading to ipfs

### DIFF
--- a/components/collection/drop/MintStepper.vue
+++ b/components/collection/drop/MintStepper.vue
@@ -15,7 +15,18 @@ const { amountToMint, drop } = storeToRefs(useDropStore())
 
 const show = computed(() => drop.value.type !== 'free')
 
-const max = computed(() =>
-  drop.value.type === 'holder' ? availableNfts.serialNumbers.length : undefined,
-)
+const max = computed(() => {
+  const holderMax =
+    drop.value.type === 'holder'
+      ? availableNfts.serialNumbers.length
+      : undefined
+  // tmp remove when uploading to IPFS step can be skipped @see https://github.com/kodadot/nft-gallery/issues/10001#issuecomment-2041533819
+  const dropMax = DROP_MASSMINT_LIMIT[drop.value.alias] ?? undefined
+
+  if (holderMax) {
+    return dropMax ? Math.min(dropMax, holderMax) : holderMax
+  }
+
+  return dropMax
+})
 </script>

--- a/utils/drop.ts
+++ b/utils/drop.ts
@@ -16,6 +16,10 @@ export const DROP_COLLECTION_TO_ALIAS_MAP = {
   '95': 'echo',
 }
 
+export const DROP_MASSMINT_LIMIT = {
+  tilescape: 4,
+}
+
 export const AHK_GENERATIVE_DROPS = [
   '176', // Chained
 ]


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

>  limit tilescapes drop to max 4 pieces 

- [x]  #10001

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [ ] My fix has changed **something** on UI; 
