### PR TITLE
fix: Paid mint modal can't `try again` after transaction error 

### DIFF
--- a/components/collection/drop/HolderOfGenerative.vue
+++ b/components/collection/drop/HolderOfGenerative.vue
@@ -29,6 +29,7 @@
     v-model="isMintModalActive"
     :action="action"
     :status="status"
+    :is-error="isTransactionError"
     @confirm="mintNft"
     @close="closeMintModal"
     @list="handleList" />

--- a/components/collection/drop/PaidGenerative.vue
+++ b/components/collection/drop/PaidGenerative.vue
@@ -5,6 +5,7 @@
     v-model="isMintModalActive"
     :action="action"
     :status="status"
+    :is-error="isError"
     @confirm="handleConfirmPaidMint"
     @close="handleMintModalClose"
     @list="handleList" />
@@ -67,6 +68,7 @@ const action = computed<AutoTeleportAction>(() => ({
 const mintNft = async () => {
   try {
     loading.value = true
+    isError.value = false
     mintingSession.value.txHash = undefined
 
     transaction({

--- a/components/collection/drop/modal/PaidMint.vue
+++ b/components/collection/drop/modal/PaidMint.vue
@@ -26,7 +26,9 @@
         v-else-if="isSigningStep"
         :title="$t('autoTeleport.steps.paid_drop.title')"
         :subtitle="transactionStatus"
-        :status="status" />
+        :status="status"
+        :failed="isError"
+        @try-again="confirm" />
 
       <SuccessfulDrop
         v-else-if="isSuccessfulDropStep"
@@ -62,6 +64,7 @@ const props = defineProps<{
   modelValue: boolean
   action: AutoTeleportAction
   status: TransactionStatus
+  isError: boolean
 }>()
 
 const { canMint, canList, isRendering } = useDropMassMintState()
@@ -169,11 +172,13 @@ const handleModalClose = (completed: boolean) => {
   }
 }
 
+const confirm = () => emit('confirm')
+
 const handleConfirm = ({
   autoteleport,
 }: AutoTeleportActionButtonConfirmEvent) => {
   if (!autoteleport) {
-    emit('confirm')
+    confirm()
     modalStep.value = ModalStep.SIGNING
   }
 }


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #10116

## Needs QA check

- @prury-temporary please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/1dbc2bb7-445f-4539-8c8c-65fa9fad52ec

