### PR TITLE
fix: Make fullscreen iframe to fit on code-check page

### DIFF
--- a/components/codeChecker/PreviewCard.vue
+++ b/components/codeChecker/PreviewCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="border bg-background-color shadow-primary p-5 pb-6 w-full max-w-[490px] flex flex-col gap-5">
-    <div ref="fullscreenRef" class="overflow-y-scroll">
+    <div ref="fullscreenRef">
       <NeoButton
         v-if="isFullscreen"
         class="fixed top-[3rem] left-[3rem] z-[1]"
@@ -13,8 +13,7 @@
       <CodeCheckerSandboxIFrame
         v-if="render"
         v-model:count="count"
-        :is-fullscreen="isFullscreen"
-        :custom-class="isFullscreen ? 'h-fit aspect-square' : ''"
+        :custom-class="{ border: !isFullscreen }"
         :hash="hash"
         :assets="assets" />
       <BaseMediaItem v-else preview is-detail class="border" />

--- a/components/codeChecker/SandboxIFrame.vue
+++ b/components/codeChecker/SandboxIFrame.vue
@@ -1,19 +1,17 @@
 <template>
-  <iframe
-    :id="config.iframeId"
+  <NeoIFrameMedia
     :key="count"
-    title="render-preview"
-    :class="[
-      'sandbox-iframe w-full h-full sm:h-[440px] aspect-square border',
-      customClass,
-    ]"
-    sandbox="allow-scripts allow-same-origin"
+    :class="['sandbox-iframe', customClass]"
+    :iframe-id="config.iframeId"
     :src="iframeSrc"
-    @load="onIframeLoad">
-  </iframe>
+    sandbox="allow-scripts allow-same-origin"
+    title="render-preview"
+    allow=""
+    @load="onIframeLoad" />
 </template>
 
 <script setup lang="ts">
+import { NeoIFrameMedia } from '@kodadot1/brick'
 import { postAssetsToSandbox } from './utils'
 import config from './codechecker.config'
 import { AssetMessage } from './types'
@@ -22,7 +20,7 @@ const props = defineProps<{
   hash: string
   assets: Array<AssetMessage>
   count: number
-  customClass?: string
+  customClass?: string | object
 }>()
 
 const emit = defineEmits(['update:count'])

--- a/libs/ui/src/components/MediaItem/type/IFrameMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/IFrameMedia.vue
@@ -3,7 +3,7 @@
     <iframe
       :id="iframeId"
       ref="iframe"
-      title="title"
+      :title="title"
       class="absolute flex w-[1080px] h-[1080px] aspect-square origin-top-left"
       :src="iframeSrc"
       :alt="alt"
@@ -25,6 +25,7 @@ const props = withDefaults(
     src?: string
     animationSrc?: string
     alt?: string
+    title?: string
     iframeId?: string
     sandbox?: string
     allow?: string

--- a/libs/ui/src/components/MediaItem/type/IFrameMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/IFrameMedia.vue
@@ -1,13 +1,15 @@
 <template>
   <div ref="wrapper" class="relative w-full h-full aspect-square">
     <iframe
+      :id="iframeId"
       ref="iframe"
-      title="html-embed"
+      title="title"
       class="absolute flex w-[1080px] h-[1080px] aspect-square origin-top-left"
       :src="iframeSrc"
       :alt="alt"
-      sandbox="allow-scripts allow-same-origin allow-modals"
-      allow="accelerometer *; camera *; gyroscope *; microphone *; xr-spatial-tracking *;" />
+      :sandbox="sandbox"
+      :allow="allow"
+      @load="emit('load')" />
   </div>
 </template>
 
@@ -17,11 +19,23 @@ import { useElementSize } from '@vueuse/core'
 
 const IFRAME_BASE_SIZE = 1080
 
-const props = defineProps<{
-  src?: string
-  animationSrc?: string
-  alt?: string
-}>()
+const emit = defineEmits(['load'])
+const props = withDefaults(
+  defineProps<{
+    src?: string
+    animationSrc?: string
+    alt?: string
+    iframeId?: string
+    sandbox?: string
+    allow?: string
+  }>(),
+  {
+    title: 'html-embed',
+    sandbox: 'allow-scripts allow-same-origin allow-modals',
+    allow:
+      'accelerometer *; camera *; gyroscope *; microphone *; xr-spatial-tracking *;',
+  },
+)
 
 const wrapper = ref<HTMLDivElement>()
 const iframe = ref<HTMLIFrameElement>()


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

@prury pls test both `/gallery` and `/code-checker`

- [x] Closes #10133

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/95ff37ad-278b-45dc-906d-795689964bef

