### PR TITLE
chore: add screenshot to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/QUICK_PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/QUICK_PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,6 @@
 
 - [ ] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)
 
+## Screenshot 📸
+
+- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Context

 As we have deleted two kinds of PR templates by #10147, it's better to have a screenshot option for the quick PR template
