### PR TITLE
fix: Autoteleport modal closing when clicking outside

### DIFF
--- a/components/common/autoTeleport/AutoTeleportModal.vue
+++ b/components/common/autoTeleport/AutoTeleportModal.vue
@@ -1,7 +1,7 @@
 <template>
   <NeoModal
     :value="isModalActive"
-    :can-cancel="['outside', 'escape']"
+    :can-cancel="canCancel"
     class="z-[1000]"
     @close="onClose">
     <div class="sm:w-[25rem]">
@@ -201,6 +201,10 @@ const autoteleportFinalized = computed(() =>
   hasActions.value
     ? hasCompletedActionPreSteps.value && actionsFinalized.value
     : hasCompletedActionPreSteps.value,
+)
+
+const canCancel = computed(() =>
+  autoteleportFinalized.value ? ['outside', 'escape'] : false,
 )
 
 const btnLabel = computed<string>(() => {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

Clicking outside to close the modal will only work if all steps are completed 

- [x] Closes #10158

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/b99abc15-56ee-47a5-a87c-67e472196a0a




