### PR TITLE
:technologist: max mint per hdd is one :)

### DIFF
--- a/components/collection/drop/MintStepper.vue
+++ b/components/collection/drop/MintStepper.vue
@@ -15,7 +15,18 @@ const { amountToMint, drop } = storeToRefs(useDropStore())
 
 const show = computed(() => drop.value.type !== 'free')
 
-const max = computed(() =>
-  drop.value.type === 'holder' ? availableNfts.serialNumbers.length : undefined,
-)
+const max = computed(() => {
+  const holderMax =
+    drop.value.type === 'holder'
+      ? availableNfts.serialNumbers.length
+      : undefined
+  // tmp remove when uploading to IPFS step can be skipped @see https://github.com/kodadot/nft-gallery/issues/10001#issuecomment-2041533819
+  const dropMax = DROP_MASSMINT_LIMIT[drop.value.alias] ?? undefined
+
+  if (holderMax) {
+    return dropMax ? Math.min(dropMax, holderMax) : holderMax
+  }
+
+  return dropMax
+})
 </script>

--- a/utils/drop.ts
+++ b/utils/drop.ts
@@ -17,7 +17,7 @@ export const DROP_COLLECTION_TO_ALIAS_MAP = {
 }
 
 export const DROP_MASSMINT_LIMIT = {
-  tilescape: 4,
+  hdd: 1,
 }
 
 export const AHK_GENERATIVE_DROPS = [

--- a/utils/drop.ts
+++ b/utils/drop.ts
@@ -16,6 +16,10 @@ export const DROP_COLLECTION_TO_ALIAS_MAP = {
   '95': 'echo',
 }
 
+export const DROP_MASSMINT_LIMIT = {
+  tilescape: 4,
+}
+
 export const AHK_GENERATIVE_DROPS = [
   '176', // Chained
 ]


### PR DESCRIPTION
- **fix(drops): limit tilescapes drop to max 4 pieces**
- **:wrench: set maxmint of hdd to 1**

**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring

(please remove design and QA checks below if not needed)

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [ ] Closes #<issue_number>
- [ ] Requires deployment <worker/stick/speck>

#### Before submitting pull request, please make sure:

- [ ] My contribution builds **clean without any errors or warnings**
- [ ] I've merged recent default branch -- **main** and I've no conflicts
- [ ] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality

#### Optional

- [ ] I've tested it at </ahp/collection>
- [ ] I've tested PR on mobile
- [ ] I've written unit tests 🧪
- [ ] I've found edge cases

#### Did your issue had any of the "$" label on it?

- [ ] Fill up your DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=<My_Polkadot_Address_check_https://github.com/kodadot/nft-gallery/blob/main/REWARDS.md#creating-your-dot-address>)

#### Community participation

- [ ] [Are you at Koda Ecosystem Telegram?](https://t.me/koda_eco)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
