### PR TITLE
fix: Replace small text with 14px in autoteleport tooltip

### DIFF
--- a/components/common/autoTeleport/AutoTeleportPopover.vue
+++ b/components/common/autoTeleport/AutoTeleportPopover.vue
@@ -3,7 +3,7 @@
     <NeoIcon icon="fa-info-circle" pack="fa-regular" class="ml-2 text-k-grey" />
 
     <template #content>
-      <div class="w-[16rem] bg-background-color text-xs border p-4">
+      <div class="w-[16rem] bg-background-color text-sm border p-4">
         <div class="flex text-base mb-3">
           <NeoIcon icon="fa-info-circle" pack="fa-regular" class="mr-2" />
 
@@ -49,7 +49,7 @@
         <div class="flex justify-start mt-5">
           <a
             href="https://hello.kodadot.xyz/tutorial/teleport/auto-teleport"
-            class="text-k-blue hover:text-k-blue-hover text-xs"
+            class="text-k-blue hover:text-k-blue-hover text-sm"
             target="_blank"
             rel="nofollow noopener noreferrer"
             >{{ $t('helper.learnMore') }}</a


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Context

- [x] Closes #10222

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.


![image](https://github.com/kodadot/nft-gallery/assets/31397967/192b4303-4502-4844-b0fc-6a9ec6656704)
