### PR TITLE
fix: When transaction failed, opening modal resets the state weirdly

### DIFF
--- a/components/common/autoTeleport/AutoTeleportModal.vue
+++ b/components/common/autoTeleport/AutoTeleportModal.vue
@@ -154,8 +154,10 @@ const steps = computed<TransactionStep[]>(() => {
     props.transactions.actions.map((action) => {
       return {
         title: getActionDetails(action.interaction).title,
-        status: action.status.value,
-        isError: action.isError.value,
+        status: hasCompletedActionPreSteps.value
+          ? action.status.value
+          : TransactionStatus.Unknown,
+        isError: action.isError.value && hasCompletedActionPreSteps.value,
         txId: action.txId.value,
         blockNumber: action.blockNumber?.value,
         isLoading: action.isLoading.value,
@@ -251,6 +253,10 @@ const onClose = () => {
   emit('close', autoteleportFinalized.value)
 }
 
+const clearModal = () => {
+  balanceCheckState.value = TransactionStepStatus.WAITING
+}
+
 watch(
   [isTeleportTransactionFinalized, () => props.canDoAction],
   ([telportFinalized, canDoAction]) => {
@@ -275,6 +281,16 @@ watch(autoteleportFinalized, () => {
     }
   }
 })
+
+watchDebounced(
+  () => props.modelValue,
+  (isOpen) => {
+    if (!isOpen) {
+      clearModal()
+    }
+  },
+  { debounce: 500 }, // wait for the modal closing animation to finish
+)
 </script>
 
 <style lang="scss" scoped>

--- a/composables/autoTeleport/useAutoTeleport.ts
+++ b/composables/autoTeleport/useAutoTeleport.ts
@@ -35,11 +35,9 @@ export default function (
     autoTeleportStarted,
   })
 
-  const { transactionActions, clear: clearActions } =
-    useAutoTeleportTransactionActions(actions)
+  const { transactionActions } = useAutoTeleportTransactionActions(actions)
 
   const clear = () => {
-    clearActions()
     teleportStatus.value = TransactionStatus.Unknown
     teleportIsError.value = false
     teleportTxId.value = ''

--- a/composables/useTeleport.ts
+++ b/composables/useTeleport.ts
@@ -26,6 +26,7 @@ export default function (fetchBalancePeriodically: boolean = false) {
     useTransactionStatus()
   const { accountId } = useAuth()
   const { assets } = usePrefix()
+  const { $i18n } = useNuxtApp()
   const { decimalsOf } = useChain()
   const { urlPrefix } = usePrefix()
   const { fetchMultipleBalance, chainBalances } = useMultipleBalance(
@@ -93,7 +94,7 @@ export default function (fetchBalancePeriodically: boolean = false) {
     )
 
     const errorHandler = () => {
-      warningMessage('Cancelled')
+      warningMessage($i18n.t('general.tx.cancelled'), { reportable: false })
 
       isLoading.value = false
       status.value = TransactionStatus.Cancelled


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #10224

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/8c89d5dc-cf7e-4524-8f1a-3c5ef9fd5440

