### PR TITLE
feat: collection success modal not pre-selecting collection on `Add NFTs`

### DIFF
--- a/components/create/modals/CollectionSuccessModal.vue
+++ b/components/create/modals/CollectionSuccessModal.vue
@@ -56,7 +56,9 @@ const collectionPath = computed(
   () => `/${urlPrefix.value}/collection/${props.collection?.id}`,
 )
 
-const addNftsPath = computed(() => `/${urlPrefix.value}/create/nft`)
+const addNftsPath = computed(
+  () => `/${urlPrefix.value}/create/nft?collectionId=${props.collection?.id}`,
+)
 
 const share = computed(() => ({
   text: $i18n.t('sharing.collection'),


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

I was investigating another issue and I found out that it was not using the collection prefill feature that already had implemented 

before: after clicking `add nfts` i would not prefill the newly created collection
before: now it does

## Needs QA check

- @kodadot/qa-guild please review

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/fa8a4bb9-ca0d-4d6c-866b-1946c888ceb5


