### PR TITLE
fix: Show more/less button wrong style

### DIFF
--- a/components/collection/unlockable/UnlockableCollectionInfo.vue
+++ b/components/collection/unlockable/UnlockableCollectionInfo.vue
@@ -12,7 +12,7 @@
       <div class="flex justify-between items-center mb-6 md:!mb-4">
         <NeoButton
           v-if="hasSeeAllDescriptionOption"
-          class="no-shadow is-text text-left p-0"
+          class="no-shadow is-text underline text-left p-0"
           :label="seeAllDescription ? $t('showLess') : $t('showMore')"
           data-testid="drops-text-description-button"
           @click="toggleSeeAllDescription" />

--- a/libs/ui/src/components/NeoButton/NeoButton.scss
+++ b/libs/ui/src/components/NeoButton/NeoButton.scss
@@ -222,9 +222,14 @@
   &.is-text {
     @apply border-none w-min text-k-grey underline-offset-4;
 
+    &:focus {
+      @apply outline-0 text-k-grey bg-transparent;
+    }
+
     &:hover {
       @apply text-text-color bg-transparent;
     }
+
   }
 
   &.no-shadow {


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #10339

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://github.com/kodadot/nft-gallery/assets/31397967/d7c98074-ff33-4c4e-a315-684ffecd01dd)

![image](https://github.com/kodadot/nft-gallery/assets/31397967/c7e91c66-9f3e-4db0-a5dc-e35028247348)

![image](https://github.com/kodadot/nft-gallery/assets/31397967/d5c14a56-4b08-4b6f-8a1a-6e2d3acb4be2)
