### PR TITLE
Perf: avoid invalid requests when loading drop page

### DIFF
--- a/components/collection/activity/events/Events.vue
+++ b/components/collection/activity/events/Events.vue
@@ -121,9 +121,14 @@ const eventsAddresses = computed(() => {
 })
 
 const { data: profiles } = useQuery<Profile[] | null>({
-  queryKey: ['profiles', `${eventsAddresses.value.sort().join(',')}`],
-  queryFn: () => fetchProfilesByIds(eventsAddresses.value),
-  enabled: !!eventsAddresses.value.length,
+  queryKey: [
+    'profiles',
+    computed(() => `${eventsAddresses.value.sort().join(',')}`),
+  ],
+  queryFn: () =>
+    eventsAddresses.value.length
+      ? fetchProfilesByIds(eventsAddresses.value)
+      : null,
   staleTime: 1000 * 60 * 5,
 })
 

--- a/components/drops/useDrops.ts
+++ b/components/drops/useDrops.ts
@@ -79,7 +79,7 @@ export function useDrops(query?: GetDropsQuery) {
 export const getFormattedDropItem = async (collection, drop: DropItem) => {
   const chainMax = collection?.max ?? FALLBACK_DROP_COLLECTION_MAX
 
-  let count = drop.minted
+  let count = drop.minted ?? collection.nftCount
   if (!count) {
     count = await fetchDropMintedCount(drop)
   }

--- a/composables/collectionActivity/useCollectionActivity.ts
+++ b/composables/collectionActivity/useCollectionActivity.ts
@@ -38,7 +38,7 @@ export const useCollectionActivity = ({
             clientName: prefix,
           })
         : null,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 1000 * 10,
   })
 
   watch(

--- a/composables/useFetchProfile.ts
+++ b/composables/useFetchProfile.ts
@@ -8,9 +8,11 @@ export default function useFetchProfile(address?: string) {
     isPending,
     refetch,
   } = useQuery<Profile | null>({
-    queryKey: ['user-profile', address && toSubstrateAddress(address)],
-    queryFn: () => fetchProfileByAddress(address!),
-    enabled: !!address,
+    queryKey: [
+      'user-profile',
+      computed(() => address && toSubstrateAddress(address)),
+    ],
+    queryFn: () => (address ? fetchProfileByAddress(address!) : null),
     staleTime: 1000 * 60 * 5,
   })
 

--- a/composables/useUnlockable.ts
+++ b/composables/useUnlockable.ts
@@ -1,31 +1,24 @@
 import { EntityWithId } from '@/components/rmrk/service/scheme'
 import { getValue } from '@/services/keywise'
 import { Ref } from 'vue'
-
+import { useQuery } from '@tanstack/vue-query'
 export function useUnlockable(
   entity: Ref<Pick<EntityWithId, 'id'> | undefined>,
 ) {
   const { urlPrefix } = usePrefix()
   const unlockLink = ref('')
 
-  const fetchUnlockLink = async () => {
-    const id = entity.value?.id
-    if (id) {
-      const url = await getValue(urlPrefix.value, id)
-      unlockLink.value = url
-    }
+  const fetchUnlockLink = async (id) => {
+    const url = await getValue(urlPrefix.value, id)
+    unlockLink.value = url
   }
 
-  onMounted(() => {
-    fetchUnlockLink()
+  useQuery({
+    queryKey: ['unlockable-link', urlPrefix, computed(() => entity.value?.id)],
+    queryFn: () =>
+      entity.value?.id ? fetchUnlockLink(entity.value?.id) : null,
+    staleTime: 1000 * 60 * 5,
   })
-
-  watch(
-    () => entity.value?.id,
-    () => {
-      fetchUnlockLink()
-    },
-  )
 
   const isUnlockable = computed(() => Boolean(unlockLink.value))
 


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [x] Refactoring

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #10342


#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [ ] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

Before:  https://canary.kodadot.xyz/ahp/drops/aeroloom

![image](https://github.com/kodadot/nft-gallery/assets/31397967/762164ce-4f85-403e-bff6-20842b858f40)
  
![image](https://github.com/kodadot/nft-gallery/assets/31397967/5e039120-530f-41e5-80b3-97c5645d6d1e)
![image](https://github.com/kodadot/nft-gallery/assets/31397967/d31ca6d7-835e-4362-9c75-4c1ecd5bde59)

There are three invalid requests with empty id and also two duplicate requests. It takes about 1~2 seconds to load these unnecessary requests.



After fix: 
Remove all invalid requests.

![image](https://github.com/kodadot/nft-gallery/assets/31397967/59899f46-5ed0-4fcd-b72c-a650c7e7dcb1)




