### PR TITLE
fix: Account address does not match while creating profile

### DIFF
--- a/components/profile/create/stages/Form.vue
+++ b/components/profile/create/stages/Form.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col gap-10">
     <div class="flex flex-col gap-3">
       <span>Setting your profile for</span>
-      <CollectionDropCreatedBy :address="substrateAddress" />
+      <CollectionDropCreatedBy :address="accountId" />
     </div>
     <form class="flex flex-col gap-10" @submit.prevent>
       <!-- name -->


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #10373

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://github.com/kodadot/nft-gallery/assets/31397967/d2b29462-3cba-4f9c-92ec-7c71bf7d0e0c)
