### PR TITLE
perf: improve drop first load speed

### DIFF
--- a/components/carousel/CarouselTypeRelated.vue
+++ b/components/carousel/CarouselTypeRelated.vue
@@ -1,10 +1,8 @@
 <template>
   <div>
-    <div ref="target"></div>
-    <CarouselIndex
-      v-if="nfts && targetIsVisible"
-      :title="`${$t('nft.related')}`"
-      :nfts="nfts" />
+    <LoadLazly>
+      <CarouselIndex v-if="nfts" :title="`${$t('nft.related')}`" :nfts="nfts" />
+    </LoadLazly>
   </div>
 </template>
 
@@ -16,7 +14,4 @@ const props = defineProps<{
 }>()
 
 const { nfts } = await useCarouselRelated({ collectionId: props.collectionId })
-
-const target = ref<HTMLHtmlElement>()
-const targetIsVisible = useOnceIsVisible(target)
 </script>

--- a/components/carousel/CarouselTypeRelated.vue
+++ b/components/carousel/CarouselTypeRelated.vue
@@ -17,13 +17,6 @@ const props = defineProps<{
 
 const { nfts } = await useCarouselRelated({ collectionId: props.collectionId })
 
-const target = ref(null)
-const targetIsVisible = ref(false)
-
-useIntersectionObserver(target, ([{ isIntersecting }]) => {
-  // set visible only once
-  if (!targetIsVisible.value && isIntersecting) {
-    targetIsVisible.value = isIntersecting
-  }
-})
+const target = ref<HTMLHtmlElement>()
+const targetIsVisible = useOnceIsVisible(target)
 </script>

--- a/components/carousel/CarouselTypeRelated.vue
+++ b/components/carousel/CarouselTypeRelated.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <LoadLazly>
+    <LoadLazily>
       <CarouselIndex v-if="nfts" :title="`${$t('nft.related')}`" :nfts="nfts" />
-    </LoadLazly>
+    </LoadLazily>
   </div>
 </template>
 

--- a/components/collection/drop/GenerativeLayout.vue
+++ b/components/collection/drop/GenerativeLayout.vue
@@ -54,12 +54,12 @@
 
       <hr ref="divider" class="my-20" />
 
-      <LoadLazly :target="divider">
+      <LoadLazily :target="divider">
         <CollectionDropItemsGrid
           v-if="drop?.collection"
           class="mb-14"
           :collection-id="drop?.collection" />
-      </LoadLazly>
+      </LoadLazily>
     </div>
   </div>
 

--- a/components/collection/drop/GenerativeLayout.vue
+++ b/components/collection/drop/GenerativeLayout.vue
@@ -52,7 +52,9 @@
 
       <CollectionUnlockableItemInfo :collection-id="drop?.collection" />
 
-      <LoadLazly target-is="hr" target-class="my-20">
+      <hr ref="divider" class="my-20" />
+
+      <LoadLazly :target="divider">
         <CollectionDropItemsGrid
           v-if="drop?.collection"
           class="mb-14"
@@ -95,6 +97,8 @@ const { emitEvent, completeLastEvent } = useCursorDropEvents()
 const { collection: collectionInfo } = useCollectionMinimal({
   collectionId: computed(() => drop.value?.collection ?? ''),
 })
+
+const divider = ref()
 
 const address = computed(() => collectionInfo.value?.currentOwner)
 

--- a/components/collection/drop/GenerativeLayout.vue
+++ b/components/collection/drop/GenerativeLayout.vue
@@ -52,20 +52,20 @@
 
       <CollectionUnlockableItemInfo :collection-id="drop?.collection" />
 
-      <hr class="my-20" />
+      <hr ref="divider" class="my-20" />
 
-      <LazyCollectionDropItemsGrid
-        v-if="drop?.collection"
+      <CollectionDropItemsGrid
+        v-if="drop?.collection && dividerIsVisible"
         class="mb-14"
         :collection-id="drop?.collection" />
     </div>
   </div>
 
-  <CollectionDropCursorParty
+  <LazyCollectionDropCursorParty
     :drop-alias="drop.alias"
     :user-minted-count="mintedAmountForCurrentUser" />
 
-  <CollectionDropPartyModal />
+  <LazyCollectionDropPartyModal />
 </template>
 
 <script setup lang="ts">
@@ -82,18 +82,23 @@ import { useWindowSize } from '@vueuse/core'
 import { useCollectionEntity } from '@/composables/drop/useGenerativeDropMint'
 import { DropItem } from '@/params/types'
 
+const mdBreakpoint = 768
+
+const emit = defineEmits(['mint'])
+
 const { drop } = useDrop()
 const { previewItem } = storeToRefs(useDropStore())
 const { mintedAmountForCurrentUser, description } = useCollectionEntity()
 const { width } = useWindowSize()
-const mdBreakpoint = 768
+
+const divider = ref<HTMLHtmlElement>()
+const dividerIsVisible = useOnceIsVisible(divider)
 
 const { emitEvent, completeLastEvent } = useCursorDropEvents()
 const { collection: collectionInfo } = useCollectionMinimal({
   collectionId: computed(() => drop.value?.collection ?? ''),
 })
 
-const emit = defineEmits(['mint'])
 const address = computed(() => collectionInfo.value?.currentOwner)
 
 const { owners } = useCollectionActivity({

--- a/components/collection/drop/GenerativeLayout.vue
+++ b/components/collection/drop/GenerativeLayout.vue
@@ -52,12 +52,12 @@
 
       <CollectionUnlockableItemInfo :collection-id="drop?.collection" />
 
-      <hr ref="divider" class="my-20" />
-
-      <CollectionDropItemsGrid
-        v-if="drop?.collection && dividerIsVisible"
-        class="mb-14"
-        :collection-id="drop?.collection" />
+      <LoadLazly target-is="hr" target-class="my-20">
+        <CollectionDropItemsGrid
+          v-if="drop?.collection"
+          class="mb-14"
+          :collection-id="drop?.collection" />
+      </LoadLazly>
     </div>
   </div>
 
@@ -90,9 +90,6 @@ const { drop } = useDrop()
 const { previewItem } = storeToRefs(useDropStore())
 const { mintedAmountForCurrentUser, description } = useCollectionEntity()
 const { width } = useWindowSize()
-
-const divider = ref<HTMLHtmlElement>()
-const dividerIsVisible = useOnceIsVisible(divider)
 
 const { emitEvent, completeLastEvent } = useCursorDropEvents()
 const { collection: collectionInfo } = useCollectionMinimal({

--- a/components/common/LoadLazily.vue
+++ b/components/common/LoadLazily.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="target" />
+  <div v-if="!props.target" ref="target" />
 
   <template v-if="targetIsVisible">
     <slot />

--- a/components/common/LoadLazly.vue
+++ b/components/common/LoadLazly.vue
@@ -1,22 +1,22 @@
 <template>
-  <component :is="targetIs" ref="target" :class="targetClass" />
+  <div ref="target" />
 
   <template v-if="targetIsVisible">
     <slot />
   </template>
 </template>
 <script lang="ts" setup>
-withDefaults(
+const props = withDefaults(
   defineProps<{
-    targetIs?: string
-    targetClass?: string
+    target?: HTMLHtmlElement
   }>(),
   {
-    targetIs: 'div',
-    targetClass: '',
+    target: undefined,
   },
 )
 
 const target = ref<HTMLHtmlElement>()
-const targetIsVisible = useOnceIsVisible(target)
+const targetIsVisible = useOnceIsVisible(
+  computed(() => props.target || target.value),
+)
 </script>

--- a/components/common/LoadLazly.vue
+++ b/components/common/LoadLazly.vue
@@ -1,0 +1,22 @@
+<template>
+  <component :is="targetIs" ref="target" :class="targetClass" />
+
+  <template v-if="targetIsVisible">
+    <slot />
+  </template>
+</template>
+<script lang="ts" setup>
+withDefaults(
+  defineProps<{
+    targetIs?: string
+    targetClass?: string
+  }>(),
+  {
+    targetIs: 'div',
+    targetClass: '',
+  },
+)
+
+const target = ref<HTMLHtmlElement>()
+const targetIsVisible = useOnceIsVisible(target)
+</script>

--- a/composables/useOnceIsVisible.ts
+++ b/composables/useOnceIsVisible.ts
@@ -1,0 +1,12 @@
+export default function (target: Ref<HTMLHtmlElement | undefined>) {
+  const targetIsVisible = ref(false)
+
+  useIntersectionObserver(target, ([{ isIntersecting }]) => {
+    // set visible only once
+    if (!targetIsVisible.value && isIntersecting) {
+      targetIsVisible.value = isIntersecting
+    }
+  })
+
+  return targetIsVisible
+}

--- a/pages/[prefix]/drops/[id].vue
+++ b/pages/[prefix]/drops/[id].vue
@@ -21,8 +21,6 @@ const { drop, fetchDrop } = useDrop()
 
 const dropType = computed(() => drop.value.type)
 
-onMounted(() => fetchDrop().then(fixPrefix))
-
 onBeforeUnmount(reset)
 
 const fixPrefix = () => {
@@ -35,4 +33,6 @@ const fixPrefix = () => {
     redirectAfterChainChange(drop.value?.chain)
   }
 }
+
+fetchDrop().then(fixPrefix)
 </script>


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring


## Context

- fetching the drop a little before inside the `setup` 
- made some components lazy 
- drop gallery item is loaded once the divider is seen  

- [x] Ref #10307

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [ ] My fix has changed **something** on UI; 
