### PR TITLE
fix: Top Collection representation "streched" (only Base)

### DIFF
--- a/composables/useDynamicGrid.ts
+++ b/composables/useDynamicGrid.ts
@@ -19,8 +19,9 @@ export default ({
 }: UseDynamicGridParams) => {
   const containerWidth = ref(0)
 
-  const isMobile = computed(() => containerWidth.value <= 768)
-  const isMobileVariant = computed(() => mobileVariant && isMobile.value)
+  const isMobileVariant = computed(
+    () => mobileVariant && containerWidth.value <= 768,
+  )
 
   const getColsFilledByAllRows = (cols: number): number => {
     if (!fillRows?.value || cols === 1) {
@@ -44,7 +45,7 @@ export default ({
 
     if (fillRows) {
       const filledCols = getColsFilledByAllRows(getCols)
-      return filledCols === 1 && !isMobile.value ? getCols : filledCols
+      return filledCols === 1 && !isMobileVariant.value ? getCols : filledCols
     }
 
     return getCols


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

>The button to choose time period also disappears:

atm  volume on base is not tracked, that's why it was decided to hide the period buttons 

- [x] Closes #10412

## Needs QA check

- @kodadot/qa-guild please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2024-06-06 at 13 08 49@2x](https://github.com/kodadot/nft-gallery/assets/44554284/a6beb091-ff9f-4f54-9206-5ca433fdbaaa)
