### PR TITLE
feat: Show on Drops profile pictures instead of polkadot wallet

### DIFF
--- a/components/collection/drop/CollectedByAvatar.vue
+++ b/components/collection/drop/CollectedByAvatar.vue
@@ -3,7 +3,7 @@
     :class="{ 'h-[28px]': size === 'small', 'h-[38px]': size === 'medium' }"
     :show-popover="props.size !== 'small'">
     <template #content>
-      <Avatar :size="size === 'small' ? 26 : 38" :value="address" />
+      <ProfileAvatar :size="size === 'small' ? 26 : 38" :address="address" />
     </template>
   </IdentityModuleIdentityPopover>
 </template>

--- a/components/shared/ProfileAvatar.vue
+++ b/components/shared/ProfileAvatar.vue
@@ -5,7 +5,7 @@
     :style="{
       width: `${size}px`,
       height: `${size}px`,
-      padding: `${size / 16}px`,
+      padding: `${Math.round(size / 16)}px`,
     }">
     <BaseMediaItem
       :src="profile?.image"


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Feature

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #10422

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
![image](https://github.com/kodadot/nft-gallery/assets/31397967/385cb30c-19bf-4cb7-9615-f82390154697)
![image](https://github.com/kodadot/nft-gallery/assets/31397967/73b57134-78e3-4675-ba32-4eeacb9cb92c)

