### PR TITLE
feat: verification for Polkadot address

### DIFF
--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -425,7 +425,7 @@ const { replaceUrl } = useReplaceUrl()
 const { accountId } = useAuth()
 const { urlPrefix, client } = usePrefix()
 const { shareOnX, shareOnFarcaster } = useSocialShare()
-const { getSignedMessage } = useVerifyAccount()
+const { getSignaturePair } = useVerifyAccount()
 
 const { isRemark, isSub } = useIsChain(urlPrefix)
 const listingCartStore = useListingCartStore()
@@ -481,14 +481,15 @@ const followConfig = computed<ButtonConfig>(() => ({
   icon: 'plus',
   disabled: !accountId.value,
   onClick: async () => {
-    const signature: string = await getSignedMessage().catch((e) => {
+    const signaturePair = await getSignaturePair().catch((e) => {
       toast(e.message)
       return
     })
     await follow({
       initiatorAddress: accountId.value,
       targetAddress: id.value as string,
-      signature,
+      signature: signaturePair.signature,
+      message: signaturePair.message,
     }).catch(() => {
       openProfileCreateModal()
     })
@@ -505,14 +506,15 @@ const followingConfig: ButtonConfig = {
 const unfollowConfig = computed<ButtonConfig>(() => ({
   label: $i18n.t('profile.unfollow'),
   onClick: async () => {
-    const signature: string = await getSignedMessage().catch((e) => {
+    const signaturePair = await getSignaturePair().catch((e) => {
       toast(e.message)
       return
     })
     unfollow({
       initiatorAddress: accountId.value,
       targetAddress: id.value as string,
-      signature,
+      signature: signaturePair.signature,
+      message: signaturePair.message,
     })
       .then(refresh)
       .catch((e) => {

--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -55,6 +55,7 @@
         <div class="flex gap-3 max-sm:flex-wrap">
           <div class="flex gap-3 flex-wrap xs:flex-nowrap">
             <NeoButton
+              v-if="isSub"
               ref="buttonRef"
               rounded
               no-shadow
@@ -479,7 +480,7 @@ const createProfileConfig: ButtonConfig = {
 const followConfig = computed<ButtonConfig>(() => ({
   label: $i18n.t('profile.follow'),
   icon: 'plus',
-  disabled: !accountId.value,
+  disabled: !accountId.value || !isSub.value,
   onClick: async () => {
     const signaturePair = await getSignaturePair().catch((e) => {
       toast(e.message)
@@ -504,6 +505,7 @@ const followingConfig: ButtonConfig = {
 }
 
 const unfollowConfig = computed<ButtonConfig>(() => ({
+  disabled: !isSub.value,
   label: $i18n.t('profile.unfollow'),
   onClick: async () => {
     const signaturePair = await getSignaturePair().catch((e) => {

--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -425,6 +425,7 @@ const { replaceUrl } = useReplaceUrl()
 const { accountId } = useAuth()
 const { urlPrefix, client } = usePrefix()
 const { shareOnX, shareOnFarcaster } = useSocialShare()
+const { getSignedMessage } = useVerifyAccount()
 
 const { isRemark, isSub } = useIsChain(urlPrefix)
 const listingCartStore = useListingCartStore()
@@ -480,9 +481,14 @@ const followConfig = computed<ButtonConfig>(() => ({
   icon: 'plus',
   disabled: !accountId.value,
   onClick: async () => {
+    const signature: string = await getSignedMessage().catch((e) => {
+      toast(e.message)
+      return
+    })
     await follow({
       initiatorAddress: accountId.value,
       targetAddress: id.value as string,
+      signature,
     }).catch(() => {
       openProfileCreateModal()
     })
@@ -498,11 +504,20 @@ const followingConfig: ButtonConfig = {
 
 const unfollowConfig = computed<ButtonConfig>(() => ({
   label: $i18n.t('profile.unfollow'),
-  onClick: () => {
+  onClick: async () => {
+    const signature: string = await getSignedMessage().catch((e) => {
+      toast(e.message)
+      return
+    })
     unfollow({
       initiatorAddress: accountId.value,
       targetAddress: id.value as string,
-    }).then(refresh)
+      signature,
+    })
+      .then(refresh)
+      .catch((e) => {
+        e && toast(e.message)
+      })
   },
   classes: 'hover:!border-k-red',
 }))

--- a/components/profile/create/Modal.vue
+++ b/components/profile/create/Modal.vue
@@ -42,6 +42,7 @@ import { rateLimitedPinFileToIPFS } from '@/services/nftStorage'
 import { appClient, createChannel } from '@/services/farcaster'
 import { StatusAPIResponse } from '@farcaster/auth-client'
 import { useDocumentVisibility } from '@vueuse/core'
+import { SIGNATURE_MESSAGE } from '@/utils/constants'
 
 const props = defineProps<{
   modelValue: boolean
@@ -115,6 +116,7 @@ const processProfile = async (
     banner: bannerUrl,
     socials: constructSocials(profileData),
     signature,
+    message: SIGNATURE_MESSAGE,
   }
 
   return hasProfile.value

--- a/components/profile/create/Modal.vue
+++ b/components/profile/create/Modal.vue
@@ -57,7 +57,7 @@ const hasProfile = computed(() => profile?.hasProfile.value)
 const initialStep = computed(() => (hasProfile.value ? 2 : 1))
 
 const emit = defineEmits(['close', 'success'])
-
+const { getSignedMessage } = useVerifyAccount()
 const vOpen = useVModel(props, 'modelValue')
 const stage = ref(initialStep.value)
 const farcasterUserData = ref<StatusAPIResponse>()
@@ -95,7 +95,10 @@ const constructSocials = (profileData: ProfileFormData): SocialLink[] => {
   ].filter((social) => Boolean(social.handle))
 }
 
-const processProfile = async (profileData: ProfileFormData) => {
+const processProfile = async (
+  profileData: ProfileFormData,
+  signature: string,
+) => {
   const imageUrl = profileData.image
     ? await uploadImage(profileData.image)
     : profileData.imagePreview
@@ -111,6 +114,7 @@ const processProfile = async (profileData: ProfileFormData) => {
     image: imageUrl,
     banner: bannerUrl,
     socials: constructSocials(profileData),
+    signature,
   }
 
   return hasProfile.value
@@ -121,7 +125,9 @@ const processProfile = async (profileData: ProfileFormData) => {
 const handleFormSubmition = async (profileData: ProfileFormData) => {
   stage.value = 4 // Go to loading stage
   try {
-    await processProfile(profileData)
+    const signature = await getSignedMessage()
+
+    await processProfile(profileData, signature as string)
     emit('success')
     stage.value = 5 // Go to success stage
   } catch (error) {

--- a/components/profile/follow/UserRow.vue
+++ b/components/profile/follow/UserRow.vue
@@ -68,6 +68,7 @@ const isHovered = useElementHover(buttonRef)
 const showFollowing = ref(false)
 
 const { urlPrefix } = usePrefix()
+const { isSub } = useIsChain(urlPrefix)
 
 const { data: followersCount, refresh: refreshCount } = useAsyncData(
   `followerCountOf/${props.user.address}`,
@@ -109,6 +110,7 @@ const followConfig: ButtonConfig = {
     refresh()
   },
   disabled:
+    !isSub.value ||
     !accountId.value ||
     props.user.address === toSubstrateAddress(accountId.value),
   classes: 'hover:!bg-transparent',
@@ -135,6 +137,7 @@ const unfollowConfig: ButtonConfig = {
       }).then(refresh)
   },
   classes: 'hover:!border-k-red',
+  disabled: !isSub.value,
 }
 
 const buttonConfig = computed((): ButtonConfig => {

--- a/components/profile/follow/UserRow.vue
+++ b/components/profile/follow/UserRow.vue
@@ -53,11 +53,10 @@ import {
 import { ButtonConfig } from '@/components/profile/types'
 import { getss58AddressByPrefix } from '@/utils/account'
 import { openProfileCreateModal } from '@/components/profile/create/openProfileModal'
-import { SIGNATURE_MESSAGE } from '@/utils/constants'
 const { accountId } = useAuth()
 const { $i18n } = useNuxtApp()
 const { toast } = useToast()
-const { getSignedMessage } = useVerifyAccount()
+const { getSignaturePair } = useVerifyAccount()
 
 const props = defineProps<{
   user: Follower
@@ -92,19 +91,20 @@ const followConfig: ButtonConfig = {
   label: $i18n.t('profile.follow'),
   icon: 'plus',
   onClick: async () => {
-    const signature: string = await getSignedMessage().catch((e) => {
+    const signaturePair = await getSignaturePair().catch((e) => {
       toast(e.message)
       return
     })
 
-    await follow({
-      initiatorAddress: accountId.value,
-      targetAddress: props.user.address,
-      signature,
-      message: SIGNATURE_MESSAGE,
-    }).catch(() => {
-      openProfileCreateModal()
-    })
+    signaturePair &&
+      (await follow({
+        initiatorAddress: accountId.value,
+        targetAddress: props.user.address,
+        signature: signaturePair.signature,
+        message: signaturePair.message,
+      }).catch(() => {
+        openProfileCreateModal()
+      }))
     showFollowing.value = true
     refresh()
   },
@@ -121,17 +121,18 @@ const followingConfig: ButtonConfig = {
 const unfollowConfig: ButtonConfig = {
   label: $i18n.t('profile.unfollow'),
   onClick: async () => {
-    const signature: string = await getSignedMessage().catch((e) => {
+    const signaturePair = await getSignaturePair().catch((e) => {
       toast(e.message)
       return
     })
 
-    unfollow({
-      initiatorAddress: accountId.value,
-      targetAddress: props.user.address,
-      signature,
-      message: SIGNATURE_MESSAGE,
-    }).then(refresh)
+    signaturePair &&
+      unfollow({
+        initiatorAddress: accountId.value,
+        targetAddress: props.user.address,
+        signature: signaturePair.signature,
+        message: signaturePair.message,
+      }).then(refresh)
   },
   classes: 'hover:!border-k-red',
 }

--- a/components/profile/follow/UserRow.vue
+++ b/components/profile/follow/UserRow.vue
@@ -56,6 +56,8 @@ import { openProfileCreateModal } from '@/components/profile/create/openProfileM
 
 const { accountId } = useAuth()
 const { $i18n } = useNuxtApp()
+const { toast } = useToast()
+const { getSignedMessage } = useVerifyAccount()
 
 const props = defineProps<{
   user: Follower
@@ -90,9 +92,15 @@ const followConfig: ButtonConfig = {
   label: $i18n.t('profile.follow'),
   icon: 'plus',
   onClick: async () => {
+    const signature: string = await getSignedMessage().catch((e) => {
+      toast(e.message)
+      return
+    })
+
     await follow({
       initiatorAddress: accountId.value,
       targetAddress: props.user.address,
+      signature,
     }).catch(() => {
       openProfileCreateModal()
     })
@@ -111,10 +119,16 @@ const followingConfig: ButtonConfig = {
 
 const unfollowConfig: ButtonConfig = {
   label: $i18n.t('profile.unfollow'),
-  onClick: () => {
+  onClick: async () => {
+    const signature: string = await getSignedMessage().catch((e) => {
+      toast(e.message)
+      return
+    })
+
     unfollow({
       initiatorAddress: accountId.value,
       targetAddress: props.user.address,
+      signature,
     }).then(refresh)
   },
   classes: 'hover:!border-k-red',

--- a/components/profile/follow/UserRow.vue
+++ b/components/profile/follow/UserRow.vue
@@ -53,7 +53,7 @@ import {
 import { ButtonConfig } from '@/components/profile/types'
 import { getss58AddressByPrefix } from '@/utils/account'
 import { openProfileCreateModal } from '@/components/profile/create/openProfileModal'
-
+import { SIGNATURE_MESSAGE } from '@/utils/constants'
 const { accountId } = useAuth()
 const { $i18n } = useNuxtApp()
 const { toast } = useToast()
@@ -101,6 +101,7 @@ const followConfig: ButtonConfig = {
       initiatorAddress: accountId.value,
       targetAddress: props.user.address,
       signature,
+      message: SIGNATURE_MESSAGE,
     }).catch(() => {
       openProfileCreateModal()
     })
@@ -129,6 +130,7 @@ const unfollowConfig: ButtonConfig = {
       initiatorAddress: accountId.value,
       targetAddress: props.user.address,
       signature,
+      message: SIGNATURE_MESSAGE,
     }).then(refresh)
   },
   classes: 'hover:!border-k-red',

--- a/composables/useVerifyAccount.ts
+++ b/composables/useVerifyAccount.ts
@@ -1,6 +1,5 @@
 import { toSubstrateAddress } from '@/services/profile'
 import { isEthereumAddress } from '@polkadot/util-crypto'
-import { SIGNATURE_MESSAGE } from '@/utils/constants'
 
 const signMessage = async (address, message) => {
   const injector = await getAddress(toDefaultAddress(address))
@@ -12,6 +11,8 @@ const signMessage = async (address, message) => {
   console.log('Signed message:', { message, address, signedMessage })
   return signedMessage.signature
 }
+
+export const SIGNATURE_MESSAGE = 'Verify ownership of this account on Koda'
 
 export default function useVerifyAccount() {
   const walletStore = useWalletStore()
@@ -40,7 +41,15 @@ export default function useVerifyAccount() {
     throw new Error('You have not completed address verification')
   }
 
+  const getSignaturePair = async () => {
+    const signature = await getSignedMessage()
+    return {
+      signature,
+      message: SIGNATURE_MESSAGE,
+    }
+  }
+
   return {
-    getSignedMessage,
+    getSignaturePair,
   }
 }

--- a/composables/useVerifyAccount.ts
+++ b/composables/useVerifyAccount.ts
@@ -1,7 +1,6 @@
 import { toSubstrateAddress } from '@/services/profile'
 import { isEthereumAddress } from '@polkadot/util-crypto'
-
-const SIGNATURE_MESSAGE = 'Verify ownership of this account on Koda'
+import { SIGNATURE_MESSAGE } from '@/utils/constants'
 
 const signMessage = async (address, message) => {
   const injector = await getAddress(toDefaultAddress(address))

--- a/composables/useVerifyAccount.ts
+++ b/composables/useVerifyAccount.ts
@@ -1,0 +1,47 @@
+import { toSubstrateAddress } from '@/services/profile'
+import { isEthereumAddress } from '@polkadot/util-crypto'
+
+const SIGNATURE_MESSAGE = 'Verify ownership of this account on Koda'
+
+const signMessage = async (address, message) => {
+  const injector = await getAddress(toDefaultAddress(address))
+  const signedMessage = await injector.signer.signRaw({
+    address: address,
+    data: message,
+    type: 'bytes',
+  })
+  console.log('Signed message:', { message, address, signedMessage })
+  return signedMessage.signature
+}
+
+export default function useVerifyAccount() {
+  const walletStore = useWalletStore()
+  const { accountId } = useAuth()
+  const signedMessage = computed(() => walletStore.getSignedMessage)
+
+  const getSignedMessage = async () => {
+    if (!accountId.value || isEthereumAddress(accountId.value)) {
+      // TODO: handle EVM address verification
+      throw new Error('This address is not currently supported')
+    }
+    if (signedMessage.value) {
+      return signedMessage.value
+    }
+
+    const signature = await signMessage(
+      toSubstrateAddress(accountId.value),
+      SIGNATURE_MESSAGE,
+    )
+
+    if (signature) {
+      walletStore.setSignedMessage(signature)
+      return signature
+    }
+
+    throw new Error('You have not completed address verification')
+  }
+
+  return {
+    getSignedMessage,
+  }
+}

--- a/services/profile.ts
+++ b/services/profile.ts
@@ -1,6 +1,5 @@
 import { $fetch, FetchError } from 'ofetch'
 import { isEthereumAddress } from '@polkadot/util-crypto'
-import { SIGNATURE_MESSAGE } from '@/utils/constants'
 const BASE_URL =
   window.location.host === 'kodadot.xyz'
     ? 'https://profile.kodadot.workers.dev/'
@@ -71,7 +70,7 @@ export type FollowRequest = {
 
 const invalidSignatureErrorHandler = (error: FetchError) => {
   if (error.status === 401) {
-    useWalletStore().setSignedMessage('')
+    useWalletStore().setSignedMessage(undefined)
     throw new Error(error?.data?.message)
   }
 }
@@ -83,7 +82,7 @@ const convertToSubstrateAddress = (body: FollowRequest): FollowRequest => ({
   initiatorAddress: toSubstrateAddress(body.initiatorAddress),
   targetAddress: toSubstrateAddress(body.targetAddress),
   signature: body.signature,
-  message: SIGNATURE_MESSAGE,
+  message: body.message,
 })
 
 // API methods

--- a/services/profile.ts
+++ b/services/profile.ts
@@ -1,6 +1,6 @@
 import { $fetch, FetchError } from 'ofetch'
 import { isEthereumAddress } from '@polkadot/util-crypto'
-
+import { SIGNATURE_MESSAGE } from '@/utils/constants'
 const BASE_URL =
   window.location.host === 'kodadot.xyz'
     ? 'https://profile.kodadot.workers.dev/'
@@ -42,6 +42,7 @@ export type ProfileResponse = {
 
 export type CreateProfileRequest = {
   signature: string
+  message: string
   address: string
   name: string
   description: string
@@ -52,6 +53,7 @@ export type CreateProfileRequest = {
 
 export type UpdateProfileRequest = {
   signature: string
+  message: string
   address: string
   name?: string
   description?: string
@@ -64,6 +66,7 @@ export type FollowRequest = {
   initiatorAddress: string
   targetAddress: string
   signature: string
+  message: string
 }
 
 const invalidSignatureErrorHandler = (error: FetchError) => {
@@ -80,6 +83,7 @@ const convertToSubstrateAddress = (body: FollowRequest): FollowRequest => ({
   initiatorAddress: toSubstrateAddress(body.initiatorAddress),
   targetAddress: toSubstrateAddress(body.targetAddress),
   signature: body.signature,
+  message: SIGNATURE_MESSAGE,
 })
 
 // API methods

--- a/services/profile.ts
+++ b/services/profile.ts
@@ -41,6 +41,7 @@ export type ProfileResponse = {
 }
 
 export type CreateProfileRequest = {
+  signature: string
   address: string
   name: string
   description: string
@@ -50,6 +51,7 @@ export type CreateProfileRequest = {
 }
 
 export type UpdateProfileRequest = {
+  signature: string
   address: string
   name?: string
   description?: string
@@ -61,6 +63,14 @@ export type UpdateProfileRequest = {
 export type FollowRequest = {
   initiatorAddress: string
   targetAddress: string
+  signature: string
+}
+
+const invalidSignatureErrorHandler = (error: FetchError) => {
+  if (error.status === 401) {
+    useWalletStore().setSignedMessage('')
+    throw new Error(error?.data?.message)
+  }
 }
 
 export const toSubstrateAddress = (address: string) =>
@@ -69,6 +79,7 @@ export const toSubstrateAddress = (address: string) =>
 const convertToSubstrateAddress = (body: FollowRequest): FollowRequest => ({
   initiatorAddress: toSubstrateAddress(body.initiatorAddress),
   targetAddress: toSubstrateAddress(body.targetAddress),
+  signature: body.signature,
 })
 
 // API methods
@@ -120,6 +131,7 @@ export const createProfile = async (profileData: CreateProfileRequest) => {
     })
     return response
   } catch (error) {
+    invalidSignatureErrorHandler(error as FetchError)
     throw new Error(
       `[PROFILE::CREATE] ERROR: ${(error as FetchError)?.data?.error?.issues[0]?.message}`,
     )
@@ -137,6 +149,7 @@ export const updateProfile = async (updates: UpdateProfileRequest) => {
     )
     return response
   } catch (error) {
+    invalidSignatureErrorHandler(error as FetchError)
     throw new Error(
       `[PROFILE::UPDATE] ERROR: ${(error as FetchError)?.data?.error?.issues[0]?.message}`,
     )
@@ -151,6 +164,8 @@ export const follow = async (followRequest: FollowRequest) => {
     })
     return response
   } catch (error) {
+    invalidSignatureErrorHandler(error as FetchError)
+
     throw new Error(`[PROFILE::FOLLOW] ERROR: ${(error as FetchError).data}`)
   }
 }
@@ -163,6 +178,8 @@ export const unfollow = async (unFollowRequest: FollowRequest) => {
     })
     return response
   } catch (error) {
+    invalidSignatureErrorHandler(error as FetchError)
+
     throw new Error(`[PROFILE::UNFOLLOW] ERROR: ${(error as FetchError).data}`)
   }
 }

--- a/stores/wallet.ts
+++ b/stores/wallet.ts
@@ -70,7 +70,7 @@ export const useWalletStore = defineStore('wallet', {
         this.setRecentWallet(account.extension)
       }
     },
-    setSignedMessage(message: string) {
+    setSignedMessage(message: string | undefined) {
       if (!this.selected) {
         return
       }

--- a/stores/wallet.ts
+++ b/stores/wallet.ts
@@ -8,6 +8,7 @@ export type WalletAccount = {
   vm: ChainVM
   name?: string
   extension?: string
+  signedMessage?: string
 }
 
 type WalletHistory = { [key: string]: Date }
@@ -39,6 +40,7 @@ export const useWalletStore = defineStore('wallet', {
   getters: {
     getIsSubstrate: (state) => state.selected?.vm === 'SUB',
     getIsEvm: (state) => state.selected?.vm === 'EVM',
+    getSignedMessage: (state) => state.selected?.signedMessage,
     getRecentWallet: (state) => {
       let recent: undefined | { key: string; date: Date }
       let maxDate = new Date(0)
@@ -67,6 +69,12 @@ export const useWalletStore = defineStore('wallet', {
       if (account.extension) {
         this.setRecentWallet(account.extension)
       }
+    },
+    setSignedMessage(message: string) {
+      if (!this.selected) {
+        return
+      }
+      this.selected = { ...this.selected, signedMessage: message }
     },
     setRecentWallet(extensionName: string) {
       // saving only last connected wallet

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -108,5 +108,3 @@ export const NFT_SQUID_SORT_COLLECTIONS: string[] = [
 export const MIN_OFFER_PRICE = 0.01
 
 export const EXTERNAL_LINK_WHITELIST = ['*.kodadot.xyz']
-
-export const SIGNATURE_MESSAGE = 'Verify ownership of this account on Koda'

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -108,3 +108,5 @@ export const NFT_SQUID_SORT_COLLECTIONS: string[] = [
 export const MIN_OFFER_PRICE = 0.01
 
 export const EXTERNAL_LINK_WHITELIST = ['*.kodadot.xyz']
+
+export const SIGNATURE_MESSAGE = 'Verify ownership of this account on Koda'


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [x] Feature


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Related to https://github.com/kodadot/private-workers/issues/180
- [x] Requires deployment https://github.com/kodadot/private-workers/pull/182
- [x] Closes https://github.com/kodadot/nft-gallery/issues/10471

[ Currently, only support Polkadot address ]

Add verified process before the below action: create profile / edit profile / follow / unfollow

It would ask for signing a message on the wallet extension before action. The verified message would be saved on localstorage forever unless you disconnect wallet / switch account.



#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![-](https://github.com/kodadot/nft-gallery/assets/31397967/4d7c56dd-f407-41d0-8dbf-6ec7b8047f90)
