### PR TITLE
fix(ipfs): remove dynamic metadata check from sanitizeIpfsUrl

### DIFF
--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -13,7 +13,6 @@ import {
   getIPFSProvider,
   kodaImage,
 } from './config/ipfs'
-import { DYNAMIC_METADATA } from '@/services/fxart'
 
 export const ipfsUrlPrefix = 'ipfs://ipfs/'
 
@@ -114,10 +113,6 @@ export const sanitizeIpfsUrl = (
 ): string => {
   if (!ipfsUrl) {
     return ''
-  }
-
-  if (ipfsUrl.includes(DYNAMIC_METADATA)) {
-    return ipfsUrl
   }
 
   if (ipfsUrl.includes(kodaImage)) {


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot - One Stop Shop for Polkadot NFTs](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] Closes #10531. we have this endpoint in the image-workers: `/type/endpoint/${any_url}`. it will cache any url and store to cf-images/cf-r2 based on mimeType. similar with `/ipfs/cid` endpoint, but for non-ipfs content
