### PR TITLE
fix: Wrong size of NFT preview

### DIFF
--- a/components/gallery/useGalleryItem.ts
+++ b/components/gallery/useGalleryItem.ts
@@ -104,13 +104,13 @@ export const useGalleryItem = (nftId?: string): GalleryItem => {
       sanitizeIpfsUrl(metadata.animationUrl || metadata.animation_url) || ''
     nftAnimationMimeType.value =
       metadata.animationUrlMimeType ||
-      (await getMimeType(nftAnimation.value)) ||
+      (nftAnimation.value && (await getMimeType(nftAnimation.value))) ||
       ''
     nftImage.value = sanitizeIpfsUrl(metadata.image) || ''
     nftMimeType.value =
       metadata.imageMimeType ||
       metadata.type ||
-      (await getMimeType(nftImage.value)) ||
+      (nftImage.value && (await getMimeType(nftImage.value))) ||
       ''
 
     // use cf-video & replace the video thumbnail


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix


## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #10558

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.
<img width="1049" alt="image" src="https://github.com/kodadot/nft-gallery/assets/31397967/eb1922ab-5385-46b4-8b79-14d530cab826">
