### PR TITLE
fix: Clicking on `edit existing profile` opens  wrong modal state

### DIFF
--- a/components/profile/create/Modal.vue
+++ b/components/profile/create/Modal.vue
@@ -200,6 +200,7 @@ const loginWithFarcaster = async () => {
 
 useModalIsOpenTracker({
   isOpen: computed(() => props.modelValue),
+  onClose: false,
   onChange: () => {
     stage.value = initialStep.value
   },

--- a/composables/useModalIsOpenTracker.ts
+++ b/composables/useModalIsOpenTracker.ts
@@ -1,25 +1,21 @@
+import { debounce } from 'lodash'
+
 export const NEO_MODAL_ANIMATION_DURATION = 200
 
 export default ({
   onChange,
   isOpen,
   and = [],
-  onAnimationEnded = true,
   onClose = true,
 }: {
   onChange: () => void
   isOpen: Ref<boolean>
   and?: Ref<boolean>[]
-  onAnimationEnded?: boolean
   onClose?: boolean
 }) => {
-  watchDebounced(
-    [isOpen, () => and],
-    ([isOpen, and]) => {
-      if (!isOpen === onClose && and.every(Boolean)) {
-        onChange()
-      }
-    },
-    { debounce: onAnimationEnded ? NEO_MODAL_ANIMATION_DURATION : 0 },
-  )
+  watch([isOpen, () => and], ([isOpen, and]) => {
+    if (!isOpen === onClose && and.every(Boolean)) {
+      ;(onClose ? debounce(onChange, NEO_MODAL_ANIMATION_DURATION) : onChange)()
+    }
+  })
 }


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

issue: initial step was being set on modal close on not when opening the modal

- [x] Closes #10586

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [ ] My fix has changed **something** on UI; 


https://github.com/kodadot/nft-gallery/assets/44554284/de16b582-7c1d-454c-bb25-9d4a1993af38


