### PR TITLE
fix: Rift: Minting 4 items - error

### DIFF
--- a/composables/autoTeleport/useAutoTeleportTransitionDetails.ts
+++ b/composables/autoTeleport/useAutoTeleportTransitionDetails.ts
@@ -15,7 +15,7 @@ import {
   getChainExistentialDeposit,
 } from './utils'
 
-const BUFFER_FEE_PERCENT = 0.4
+const BUFFER_FEE_PERCENT = 0.7
 const BUFFER_AMOUNT_PERCENT = 0.02
 
 const DEFAULT_AUTO_TELEPORT_FEE_PARAMS = {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

There is a small difference of amount arriving , seems some extra fee was added , increasing the buffer percent fee fixed the issue.

@dudo50 any idea , is this related to the delivery fee that we were talking about a couple of month ago?

[failed tx](https://assethub-polkadot.subscan.io/extrinsic/0xc26ed36a3139f7bcd5338275c60315eeae2512a5773bb8ae3574b915e315bf8d)

- [x] Closes #10582


#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/kodadot/nft-gallery/assets/44554284/85e49933-471a-4bf8-9f51-a5e02b7e4dfa

https://github.com/kodadot/nft-gallery/assets/44554284/314b396d-6f0f-4f78-a368-4e4fa25f683a

