### PR TITLE
:wrench: Remove people from AssetHub deny list 

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -19,6 +19,7 @@ export const ksmHubDenyList = [
 export const dotHubDenyList = [
   '128qRiVjxU3TuT37tg7AX99zwqfPtj2t4nDKUv9Dvi5wzxuF', // RMRK test
   '155HWw3J9jyYphMm5is4vp9Bzj7ZRRd6HEzCPdWd8cq97KfT', // Very old unreacheable IPFS
+  '16aWyT5Xa2wogTARQxk8LnQqi5nquy3Xrc4YcgJrmjEWrduq', // Market Manipulation
 ]
 
 export const IPFS_KODADOT_IMAGE_PLACEHOLDER =

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -19,8 +19,6 @@ export const ksmHubDenyList = [
 export const dotHubDenyList = [
   '128qRiVjxU3TuT37tg7AX99zwqfPtj2t4nDKUv9Dvi5wzxuF', // RMRK test
   '155HWw3J9jyYphMm5is4vp9Bzj7ZRRd6HEzCPdWd8cq97KfT', // Very old unreacheable IPFS
-  '16aWyT5Xa2wogTARQxk8LnQqi5nquy3Xrc4YcgJrmjEWrduq', // Market Manipulation
-  '1HzwKkNGv4gdWq4ds1C5k63u8hvmjC6ULneAaZbwUBZEauF', // Dead collection
 ]
 
 export const IPFS_KODADOT_IMAGE_PLACEHOLDER =


### PR DESCRIPTION
### What is deny list

Deny list is for entities that did not accepted ToC of Koda.
Currently on the deny list are entities that:
- Manipulated market
- Were unable to provide correct metadata - minting outside of KodaDot
- Minting NSFW content

### This PR

This removes @AshutoshSingh00001 from the deny list as we were finally noticed that he fixed metadata for the Polkadot Punks :)

Related issues:
- https://github.com/kodadot/nft-gallery/issues?q=is%3Aissue+author%3AAshutoshSingh00001+is%3Aclosed


## Original

Original comes from commit - https://github.com/kodadot/nft-gallery/commit/14cc741ba120a310754bfc3e4e56322b87de741f
PR - #9110

- **Revert ":wrench: add new bad boyz to deny list"**
- **:wrench: return market manipulator to deny list**
