### PR TITLE
fix: hide empty drop calendar section on drops page

### DIFF
--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -39,8 +39,6 @@
       skeleton-key="current-drops-skeleton"
     />
 
-    <hr class="my-14">
-
     <DropsCalendar
       :drops="drops"
       :loaded="loaded"

--- a/components/drops/calendar/DropsCalendar.vue
+++ b/components/drops/calendar/DropsCalendar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <template v-if="grouppedDropCalendars?.length">
+    <hr
+      class="my-14"
+    >
     <h2 class="text-3xl font-semibold mb-7">
       {{ $t('drops.dropCalendar') }}
     </h2>
@@ -78,7 +81,7 @@
       :drop-calendar="previewDropCalendar"
       @close="previewDropCalendar = undefined"
     />
-  </div>
+  </template>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- When there is no oncoming drop calendar, it only shows title and separator line.

![image](https://github.com/user-attachments/assets/9b9f4cac-6ebc-4dbc-a11c-d259d08cc96b)

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

hide empty drop calendar section

![image](https://github.com/user-attachments/assets/b5e345d4-c4ca-4ce1-88c0-0157fc1d2a97)
