### PR TITLE
fix: The default avatars of EVM addresses would overlap each other

### DIFF
--- a/components/shared/Avatar.vue
+++ b/components/shared/Avatar.vue
@@ -24,7 +24,7 @@ import { isEthereumAddress } from '@polkadot/util-crypto'
 import Identicon from '@polkadot/vue-identicon'
 import { toSvg } from 'jdenticon'
 
-const WRAPPER_CLASS = 'border border-border-color rounded-full overflow-hidden'
+const WRAPPER_CLASS = 'border border-border-color rounded-full overflow-hidden bg-background-color'
 
 const props = withDefaults(
   defineProps<{


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #10722

#### Did your issue had any of the "$" label on it?

- [x] My DOT address: [Payout](https://canary.kodadot.xyz/dot/transfer/?target=16SjUbGKSdjCdWTy3NNT3JxbRVGGqD4mwkHpc6BD9U2Rp29Z)

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

`/base/drops/quadz`
![image](https://github.com/user-attachments/assets/2cb91158-908d-4280-bc65-1a653fa38857)
![image](https://github.com/user-attachments/assets/27ff3972-9251-4a67-95b4-76dda93fb7d8)
