### PR TITLE
fix: base `/drops` grid not loading

### DIFF
--- a/components/drops/Drops.vue
+++ b/components/drops/Drops.vue
@@ -36,7 +36,7 @@
       :drops="currentDrops"
       :loaded="loaded"
       :default-skeleton-count="DEFAULT_SKELETON_COUNT"
-      :async-skeleton-count="Math.round((count/2) - currentDrops.length)"
+      :async-skeleton-count="asyncSkeletonCountOf(currentDrops.length)"
       skeleton-key="current-drops-skeleton"
     />
 
@@ -56,7 +56,7 @@
       :drops="pastDrops"
       :loaded="loaded"
       :default-skeleton-count="DEFAULT_SKELETON_COUNT"
-      :async-skeleton-count="Math.round((count/2) - pastDrops.length)"
+      :async-skeleton-count="asyncSkeletonCountOf(pastDrops.length)"
       skeleton-key="skeleton"
     />
 
@@ -95,6 +95,8 @@ const currentDrops = computed(() =>
 const pastDrops = computed(() =>
   filter(drops.value, { status: DropStatus.MINTING_ENDED }),
 )
+
+const asyncSkeletonCountOf = (amount: number) => count.value ? Math.max(0, Math.round((count.value) / 2) - amount) : DEFAULT_SKELETON_COUNT
 
 const checkRouteAvailability = () => {
   if (!dropsVisible(urlPrefix.value)) {

--- a/components/drops/DropsGrid.vue
+++ b/components/drops/DropsGrid.vue
@@ -5,7 +5,7 @@
     persist
   >
     <template
-      v-if="isAsync ? true : loaded"
+      v-if="isAsync || loaded"
     >
       <div
         v-for="(drop, index) in drops"

--- a/components/drops/DropsGrid.vue
+++ b/components/drops/DropsGrid.vue
@@ -5,7 +5,7 @@
     persist
   >
     <template
-      v-if="asyncSkeletonCount ? true : loaded"
+      v-if="isAsync ? true : loaded"
     >
       <div
         v-for="(drop, index) in drops"
@@ -23,7 +23,7 @@
     </template>
     <template v-if="!loaded">
       <DropsDropCardSkeleton
-        v-for="x in asyncSkeletonCount || defaultSkeletonCount"
+        v-for="x in isAsync ? asyncSkeletonCount : defaultSkeletonCount"
         :key="`${skeletonKey}-${x}`"
       />
     </template>
@@ -41,7 +41,7 @@ const GRID_DEFAULT_WIDTH = {
   large: 0,
 }
 
-defineProps<{
+const props = defineProps<{
   drops: Drop[] | InternalDropCalendar[]
   loaded: boolean
   defaultSkeletonCount: number
@@ -49,6 +49,8 @@ defineProps<{
   skeletonKey: string
   clickable?: boolean
 }>()
+
+const isAsync = computed(() => typeof props.asyncSkeletonCount === 'number')
 
 const isDrop = (item: Drop | InternalDropCalendar): item is Drop =>
   (item as Drop).collection !== undefined


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

negative skeleton count was breaking the grid

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 


https://github.com/user-attachments/assets/e145e315-2d37-4d17-adcd-a1efad2a0532

