### PR TITLE
fix: Party kit popup does not remember the state

### DIFF
--- a/components/collection/drop/PartyModal.vue
+++ b/components/collection/drop/PartyModal.vue
@@ -1,7 +1,7 @@
 <template>
   <transition name="fade">
     <div
-      v-if="isPartyModalOpen"
+      v-if="getHasUserNotSetPartyMode"
       class="fixed top-20 md:top-24 left-4 z-[1000] w-[calc(100%-32px)] md:w-[31.25rem] h-fit shadow-primary bg-background-color !p-6 gap-6 flex border items-center"
     >
       <div class="max-md:hidden relative h-full w-fit flex-shrink-0">
@@ -37,7 +37,7 @@
               size="large"
               no-shadow
               class="!h-fit"
-              @click="isPartyModalOpen = false"
+              @click="partyMode = true"
             />
           </div>
         </div>
@@ -71,12 +71,4 @@ import { usePreferencesStore } from '@/stores/preferences'
 const { partyMode, getHasUserNotSetPartyMode } = storeToRefs(
   usePreferencesStore(),
 )
-
-const isPartyModalOpen = ref(getHasUserNotSetPartyMode.value)
-
-if (getHasUserNotSetPartyMode.value) {
-  watch(getHasUserNotSetPartyMode, () => {
-    isPartyModalOpen.value = getHasUserNotSetPartyMode.value
-  })
-}
 </script>

--- a/composables/useWallet.ts
+++ b/composables/useWallet.ts
@@ -1,4 +1,4 @@
-const PERSISTED_STORES = ['preferences', 'wallet']
+const KEYS_TO_REMOVE = ['wallet']
 
 export default function () {
   const { disconnect: disconnectWeb3Modal } = useWagmi()
@@ -13,7 +13,7 @@ export default function () {
     sessionStorage.clear()
     // don't use localStorage.clear(), web3modal uses localstorage to save data
     // there's no way to regerate those values unless hard reload is made
-    PERSISTED_STORES.forEach(store => localStorage.removeItem(store))
+    KEYS_TO_REMOVE.forEach(store => localStorage.removeItem(store))
     shoppingCartStore.clear()
 
     walletStore.setDisconnecting(true)


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

1. modal close did not accept `party mode`
2. chatted with @exezbcz  and preferences should be kept between sessions

- [x] Closes #10744

## Needs Design check

- @exezbcz please review

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/user-attachments/assets/78105e9e-785c-43d6-87b3-ad50944d399a

