### PR TITLE
fix: Landing create modal still appearing with a profile

### DIFF
--- a/composables/useProfile.ts
+++ b/composables/useProfile.ts
@@ -15,7 +15,7 @@ export default function useUserProfile() {
   } = useFetchProfile(params?.id as string || accountId.value)
 
   return {
-    hasProfile: computed(() => isLoading.value || !!profile.value),
+    hasProfile: computed(() => !!profile.value),
     userProfile: profile,
     fetchProfile,
     isFetchingProfile: isLoading,


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

if all requirements are met (interacting with landing carousel and sidebar) and then we connect a wallet (with a profile), once we start fetching the profile the modal is shown

@Jarsen136  what case is having `isLoading` inside `hasProfile`  covering. don't wanna break something else, asking since this was added here #10707

- [x] Closes #10828

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [ ] My fix has changed **something** on UI; 
