### PR TITLE
fix: evm nft missing `animationUrl`

### DIFF
--- a/composables/useNft.ts
+++ b/composables/useNft.ts
@@ -92,7 +92,7 @@ async function getGeneralMetadata<T extends NFTWithMetadata>(nft: T) {
   )
   let type = nft.meta.type
 
-  if (nft.metadata !== nft.meta.id && nft.metadata) {
+  if (nft.metadata !== nft.meta.id && nft.metadata && !nft.id.startsWith('0x')) {
     const metadataUrl = sanitizeIpfsUrl(nft.metadata)
     const res = await getMetadata(metadataUrl)
 


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #10875
- [x] Closes #10736

--------

https://github.com/kodadot/nft-gallery/pull/9990 added code that fetches the `nft.metadata` if `nft.metadata !== nft.meta.id`

@preschian @vikiival  did we solve the [main issue](https://github.com/kodadot/nft-gallery/pull/9990#issuecomment-2039928296)? can this be removed , or any other solution?

this on `evm` will always be triggered, unnecessarily refetching the same data

![CleanShot 2024-08-21 at 11 35 13@2x](https://github.com/user-attachments/assets/a4c74876-0685-492b-969f-2dec39a5c7c2)


### Bug, where?

`animationUrl` is correctly assigned first and the assigned to ''

![CleanShot 2024-08-21 at 11 36 22@2x](https://github.com/user-attachments/assets/6340b1aa-5929-4d42-84eb-639eefa42899)

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2024-08-21 at 11 24 48](https://github.com/user-attachments/assets/2fdc0323-7c5f-439b-a447-fbfd7c7ab0f2)

![CleanShot Aug 21 ](https://github.com/user-attachments/assets/76f93ec9-3a18-4680-a608-1361faf6a3e9)

