### PR TITLE
fix: Wrong sub address format is used when evm chain is selected

### DIFF
--- a/components/common/ConnectWallet/ConnectWalletModal.vue
+++ b/components/common/ConnectWallet/ConnectWalletModal.vue
@@ -67,16 +67,11 @@ const selectedTab = ref<ChainVM>(props.preselected ?? 'SUB')
 
 const showAccount = computed(() => Boolean(account.value))
 
-const isCurrentPrefixAvailableForVm = (vm: ChainVM) =>
-  getAvailableChainsByVM(vm)
-    .map(({ value }) => value)
-    .includes(urlPrefix.value)
-
 const setAccount = (account: WalletAccount) => {
   walletStore.setWallet(account)
   identityStore.setAuth({ address: account.address })
 
-  if (!isCurrentPrefixAvailableForVm(account.vm)) {
+  if (!isPrefixVmOf(urlPrefix.value, account.vm)) {
     const newChain = DEFAULT_VM_PREFIX[account.vm]
     setUrlPrefix(newChain)
     redirectAfterChainChange(newChain)

--- a/components/common/ConnectWallet/WalletMenuItem.vue
+++ b/components/common/ConnectWallet/WalletMenuItem.vue
@@ -112,6 +112,8 @@
 
 <script lang="ts" setup>
 import { NeoIcon, NeoSkeleton } from '@kodadot1/brick'
+import { DEFAULT_VM_PREFIX } from '@kodadot1/static'
+import { chainPropListOf } from '@/utils/config/chain.config'
 import type { WalletAccount } from '@/utils/config/wallets'
 import type { BaseDotsamaWallet } from '@/utils/config/wallets/BaseDotsamaWallet'
 import shouldUpdate from '@/utils/shouldUpdate'
@@ -128,6 +130,7 @@ defineProps<{
 
 const { chainProperties } = useChain()
 const { $consola } = useNuxtApp()
+const { urlPrefix } = usePrefix()
 const hasWalletProviderExtension = ref(false)
 const walletAccounts = ref<WalletAccount[]>([])
 const showAccountList = ref(false)
@@ -166,7 +169,7 @@ const { data: existingProfiles, isLoading: isProfilesLoading } = useProfiles('ac
 const formatAccount = (account: WalletAccount): WalletAccount => {
   return {
     ...account,
-    address: formatAddress(account.address, ss58Format.value),
+    address: formatAddress(account.address, !isPrefixVmOf(urlPrefix.value, 'SUB') ? chainPropListOf(DEFAULT_VM_PREFIX['SUB']).ss58Format : ss58Format.value),
   }
 }
 

--- a/utils/chain.ts
+++ b/utils/chain.ts
@@ -40,6 +40,11 @@ export const getAvailableChainsByVM = (vm: ChainVM) =>
     ({ value: prefix }) => vm === chainPropListOf(prefix as Prefix).vm,
   )
 
+export const isPrefixVmOf = (prefix: Prefix, vm: ChainVM) =>
+  getAvailableChainsByVM(vm)
+    .map(({ value }) => value)
+    .includes(prefix)
+
 export const getAvailablePrefix = (prefix: string): string => {
   return availablePrefixes().some(chain => chain.value === prefix)
     ? prefix


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #10892

#### Did your issue had any of the "$" label on it?

- [x] Fill up your DOT address: [Payout](https://kodadot.xyz/dot/transfer?target=16faLfsywwNATaEfbH2ah75dn6ZmctQWpMS5G4KFhbmj5hnD)


## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/user-attachments/assets/0bb7762a-ef43-4940-87d4-f8317dd2b7cb

