### PR TITLE
fix: Profile picture size crippled 

### DIFF
--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -32,11 +32,21 @@
             :title="'User Avatar'"
             class="md:w-[124px] md:h-[124px] h-[78px] w-[78px] object-cover rounded-full"
           />
-          <Avatar
+          <div
             v-else
-            :value="id"
-            class="md:w-[124px] md:h-[124px] h-[78px] w-[78px] mb-[-7px]"
-          />
+            class="mb-[-7px]"
+          >
+            <Avatar
+              :value="id"
+              :size="78"
+              class="md:hidden"
+            />
+            <Avatar
+              :value="id"
+              :size="124"
+              class="max-md:hidden"
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #10816

## Needs Design check

- @exezbcz please review

## Screenshot 📸

- [ ] My fix has changed **something** on UI; 

## SUB

![CleanShot 2024-08-26 at 11 30 28@2x](https://github.com/user-attachments/assets/dd407437-34ee-4daf-baa6-805b184e326b)

<img src=https://github.com/user-attachments/assets/8d881dcb-645e-4b1a-b1b7-c4c21fbb90ed width=400/>

## EVM

![CleanShot 2024-08-26 at 11 31 47@2x](https://github.com/user-attachments/assets/c2720872-b33d-42c4-a2eb-94737ef9fb30)

<img src=https://github.com/user-attachments/assets/b16b9182-5dbf-490f-8815-52aebb0cd602 width=400/>