### PR TITLE
fix: initial data load in useSubscriptionGraphql

### DIFF
--- a/composables/useSubscriptionGraphql.ts
+++ b/composables/useSubscriptionGraphql.ts
@@ -44,8 +44,10 @@ export default function ({
       const newResult = response.data as any
 
       if (!isEqual(newResult, lastQueryResult)) {
-        $consola.log(`[Graphql Subscription] New changes: ${JSON.stringify(newResult)}`)
-        onChange({ data: newResult })
+        if (lastQueryResult !== null) {
+          $consola.log(`[Graphql Subscription] New changes: ${JSON.stringify(newResult)}`)
+          onChange({ data: newResult })
+        }
         lastQueryResult = newResult
       }
     }


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

For the composable `useSubscriptionGraphql`, the initial data fetching should not trigger `onChange` callback

