### PR TITLE
fix: balance fetching bugs

### DIFF
--- a/components/common/ConnectWallet/WalletAsset.vue
+++ b/components/common/ConnectWallet/WalletAsset.vue
@@ -24,12 +24,8 @@ const MultipleBalances = defineAsyncComponent(
 const identityStore = useIdentityStore()
 const { $consola } = useNuxtApp()
 
-onMounted(async () => {
-  if (identityStore.getAuthAddress) {
-    $consola.log('fetching balance...')
-    await identityStore.fetchBalance({
-      address: identityStore.getAuthAddress,
-    })
-  }
-})
+if (identityStore.getAuthAddress) {
+  $consola.log('fetching balance...')
+  identityStore.fetchBalance({ address: identityStore.getAuthAddress })
+}
 </script>

--- a/composables/useBalance.ts
+++ b/composables/useBalance.ts
@@ -17,10 +17,10 @@ export default function () {
 
   const balance = computed(() => getBalance('KSM'))
 
-  const getSubBalance = async (address: string) => {
-    const { apiInstance } = useApi()
+  const getSubBalance = async (address: string, prefix: Prefix) => {
+    const { apiInstanceByPrefix } = useApi()
     try {
-      const api = await apiInstance.value
+      const api = await apiInstanceByPrefix(prefix)
       return await balanceOf(api, address)
     }
     catch (e) {
@@ -57,9 +57,9 @@ export default function () {
     }
 
     return execByVm({
-      SUB: () => getSubBalance(address),
+      SUB: () => getSubBalance(address, prefix),
       EVM: () => getEvmBalance(address, prefix),
-    })
+    }, { prefix })
   }
 
   return {

--- a/composables/useMultipleBalance.ts
+++ b/composables/useMultipleBalance.ts
@@ -63,7 +63,7 @@ export default function (refetchPeriodically: boolean = false) {
   const {
     multiBalances,
     multiBalanceNetwork,
-    getVmAssets: assets,
+    getWalletVmAssets: assets,
   } = storeToRefs(identityStore)
 
   const currentNetwork = computed(() =>
@@ -140,14 +140,14 @@ export default function (refetchPeriodically: boolean = false) {
   }
 
   async function getBalance(chainName: string, token = 'KSM', tokenId = 0) {
+    const prefix = networkToPrefix[chainName] as Prefix
+    const chain = CHAINS[prefix]
     const currentAddress = accountId.value
+
     const defaultAddress = execByVm({
       SUB: () => toDefaultAddress(currentAddress),
       EVM: () => currentAddress,
-    })
-
-    const prefix = networkToPrefix[chainName]
-    const chain = CHAINS[prefix]
+    }, { prefix })
 
     const { balance: nativeBalance, prefixAddress } = (await execByVm({
       SUB: () =>
@@ -158,7 +158,7 @@ export default function (refetchPeriodically: boolean = false) {
           tokenId,
         }),
       EVM: () => getEvmBalance({ address: currentAddress, prefix }),
-    })) as { balance: string, prefixAddress: string }
+    }, { prefix })) as { balance: string, prefixAddress: string }
 
     const currentBalance = format(nativeBalance, chain.tokenDecimals, false)
     const selectedTokenId = String(tokenId)

--- a/composables/useMultipleBalance.ts
+++ b/composables/useMultipleBalance.ts
@@ -168,6 +168,10 @@ export default function (refetchPeriodically: boolean = false) {
       fiatStore.getCurrentTokenValue(token as Token),
     )
 
+    if (!identityStore.getWalletVmChains.includes(chainName)) {
+      return
+    }
+
     identityStore.setMultiBalances({
       address: defaultAddress,
       chains: {

--- a/composables/useToken.ts
+++ b/composables/useToken.ts
@@ -1,6 +1,5 @@
 import { type Prefix } from '@kodadot1/static'
 import { useFiatStore } from '@/stores/fiat'
-import { useIdentityStore } from '@/stores/identity'
 import { defultTokenChain } from '@/utils/config/chain.config'
 
 export interface TokenDetails {
@@ -16,11 +15,11 @@ const getUniqueArrayItems = (items: string[]) => [...new Set(items)]
 export default function useToken() {
   const { getCurrentTokenValue } = useFiatStore()
   const { getTokenIconBySymbol } = useIcon()
-  const { getVmAssets } = storeToRefs(useIdentityStore())
+  const { vm } = useChain()
 
   const availableTokensAcrossAllChains = computed(() =>
     getUniqueArrayItems(
-      Object.values(getVmAssets.value).map(getAssetToken),
+      Object.values(getVmAssets(vm.value)).map(getAssetToken),
     ),
   )
 

--- a/stores/identity.ts
+++ b/stores/identity.ts
@@ -1,9 +1,10 @@
 import { type Registration } from '@polkadot/types/interfaces/identity/types'
 import { defineStore } from 'pinia'
-import { type Prefix, chainList } from '@kodadot1/static'
+import { type ChainVM, DEFAULT_VM_PREFIX, type Prefix, chainList } from '@kodadot1/static'
+import { getChainId } from '@wagmi/core'
 import { emptyObject } from '@/utils/empty'
 import { networkToPrefix } from '@/composables/useMultipleBalance'
-import { vmOf } from '@/utils/config/chain.config'
+import { chainPropListOf, vmOf } from '@/utils/config/chain.config'
 
 const DEFAULT_BALANCE_STATE = {
   ksm: '0',
@@ -24,10 +25,6 @@ export interface IdentityMap {
 
 type Key = Prefix | string | number
 type BalanceMap<T extends Key = string> = Record<T, string>
-type ChangeAddressRequest = {
-  address: string
-  apiUrl?: string
-}
 
 export type ChainType =
   | 'polkadot'
@@ -139,26 +136,9 @@ export const useIdentityStore = defineStore('identity', {
 
       return 0
     },
-    getVmAssets: (): any[] => {
-      const { isTestnet } = usePrefix()
-      const { multiBalanceAssets, multiBalanceAssetsTestnet }
-        = storeToRefs(useIdentityStore())
-      const { vm } = useChain()
-
-      // useChain().availableChainsByVm excludes disabled chains like dot
-      const vmChains = chainList().filter(
-        ({ value: prefix }) => vm.value === vmOf(prefix as Prefix),
-      )
-
-      const assets = isTestnet
-        ? multiBalanceAssetsTestnet.value
-        : multiBalanceAssets.value
-
-      return assets.filter(asset =>
-        vmChains
-          .map(chain => chain.value)
-          .includes(networkToPrefix[asset.chain] as ChainType),
-      )
+    getWalletVmAssets: (): any[] => {
+      const { getWalletVM } = storeToRefs(useWalletStore())
+      return getWalletVM.value ? getVmAssets(getWalletVM.value) : []
     },
     getStatusMultiBalances(state): string {
       let loadedAssets = 0
@@ -169,7 +149,7 @@ export const useIdentityStore = defineStore('identity', {
           loadedAssets += Object.keys(state.multiBalances.chains[key]).length
         }
       }
-      return loadedAssets < this.getVmAssets.length ? 'loading' : 'done'
+      return loadedAssets < this.getWalletVmAssets.length ? 'loading' : 'done'
     },
   },
   actions: {
@@ -200,26 +180,44 @@ export const useIdentityStore = defineStore('identity', {
         this.auth.balance[prefix] = balance
       }
     },
-    setPrefixBalance(balance: string) {
-      const { urlPrefix } = usePrefix()
+    setPrefixBalance(balance: string, prefix: Prefix) {
       if (this.auth.balance) {
-        this.auth.balance[urlPrefix.value] = balance
+        this.auth.balance[prefix] = balance
       }
     },
     setTokenListBalance(request: BalanceMap) {
       this.auth.tokens = request
     },
-    async setCorrectAddressBalance(apiUrl: string) {
-      if (this.auth.address) {
-        const address = this.auth.address
-        await this.fetchBalance({ address, apiUrl })
-      }
-    },
-    async fetchBalance({ address }: ChangeAddressRequest) {
+    async fetchBalance({ address }: { address: string }) {
       const { fetchBalance } = useBalance()
-      const balance = await fetchBalance(address)
+      const { getWalletVM } = useWalletStore()
+      const { vm } = useChain()
+
+      if (!getWalletVM) {
+        return
+      }
+
+      let prefix = usePrefix().urlPrefix.value
+
+      // remove once multiwallet support is added
+      if (vm.value !== getWalletVM) {
+        execByVm({
+          EVM: () => {
+            const { $wagmiConfig } = useNuxtApp()
+            const chainId = getChainId($wagmiConfig)
+            prefix = CHAIN_ID_TO_PREFIX[chainId] ?? ''
+          },
+          SUB: () => {
+            prefix = DEFAULT_VM_PREFIX[getWalletVM]
+            address = formatAddress(address, chainPropListOf(prefix).ss58Format)
+          },
+        }, { vm: getWalletVM })
+      }
+
+      const balance = await fetchBalance(address, prefix)
+
       if (balance) {
-        this.setPrefixBalance(balance)
+        this.setPrefixBalance(balance, prefix)
       }
     },
     setMultiBalances({ address, chains, chainName }) {
@@ -237,3 +235,24 @@ export const useIdentityStore = defineStore('identity', {
     },
   },
 })
+
+export const getVmAssets = (vm: ChainVM) => {
+  const { isTestnet } = usePrefix()
+  const { multiBalanceAssets, multiBalanceAssetsTestnet }
+    = storeToRefs(useIdentityStore())
+
+  // useChain().availableChainsByVm excludes disabled chains like dot
+  const vmChains = chainList().filter(
+    ({ value: prefix }) => vm === vmOf(prefix as Prefix),
+  )
+
+  const assets = isTestnet
+    ? multiBalanceAssetsTestnet.value
+    : multiBalanceAssets.value
+
+  return assets.filter(asset =>
+    vmChains
+      .map(chain => chain.value)
+      .includes(networkToPrefix[asset.chain] as ChainType),
+  )
+}

--- a/stores/identity.ts
+++ b/stores/identity.ts
@@ -140,6 +140,9 @@ export const useIdentityStore = defineStore('identity', {
       const { getWalletVM } = storeToRefs(useWalletStore())
       return getWalletVM.value ? getVmAssets(getWalletVM.value) : []
     },
+    getWalletVmChains(): string[] {
+      return this.getWalletVmAssets.map(asset => asset.chain)
+    },
     getStatusMultiBalances(state): string {
       let loadedAssets = 0
       for (const key in state.multiBalances.chains) {

--- a/stores/wallet.ts
+++ b/stores/wallet.ts
@@ -93,7 +93,7 @@ export const useWalletStore = defineStore('wallet', {
         return
       }
 
-      if (this.getIsSubstrate) {
+      if (this.getIsSubstrate && isSub(prefix)) {
         const address = formatAddress(account.address, ss58Of(prefix))
 
         if (address === account.address) {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #10933
- [x] Fixes: sub wallet malformatted
    - if sub wallet is connected and user lands on `/base` the address is not formatted correctly   
- [x] Fix: on wallet switch balance from others are not cleared

https://github.com/user-attachments/assets/b368d495-7858-4fc5-88bd-c9bcfcdd1865


- [x] Fixes: wallet `vm` and chain `vm` mismatch balance fetch using `identityStore.fetchBalance` 

covers case where wallet vm and current chain's vm do not match, since prefix is unknown at that moment we are resorting to a fallbacks instate of not making a balance fetch

### Example

evm wallet is connected , chain is ahp , navbar makes a balance fetch

this happens in the navbar and sidebar, in these scenarios what prefix should be fetched ?

@kodadot/internal-dev  pls feel free to suggest any other solution.

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/user-attachments/assets/0c8d1f72-a3e4-4653-9c55-5804c6665a4a

