### PR TITLE
fix: Listing popup displayed with listing modal

### DIFF
--- a/components/collection/drop/ItemsGrid.vue
+++ b/components/collection/drop/ItemsGrid.vue
@@ -28,6 +28,7 @@
       :grid-size="'medium'"
       display-name-with-sn
       collection-popover-hide
+      hide-listing
       show-timestamp
       :reset-search-query-params="['sort']"
     />

--- a/components/items/ItemsGrid/ItemsGrid.vue
+++ b/components/items/ItemsGrid/ItemsGrid.vue
@@ -28,6 +28,7 @@
           :display-name-with-sn="displayNameWithSn"
           :show-timestamp="showTimestamp"
           :collection-popover-hide="collectionPopoverHide"
+          :hide-listing="hideListing"
           :lazy-loading="
             shouldLazyLoad({
               cols: slotProps.cols,
@@ -49,6 +50,7 @@
           :entity="entity"
           :hide-media-info="hideMediaInfo"
           :hide-action="hideNFTHoverAction"
+          :hide-listing="hideListing"
           :display-name-with-sn="displayNameWithSn"
           hide-video-controls
           :lazy-loading="
@@ -146,6 +148,7 @@ const props = defineProps<{
   showTimestamp?: boolean
   hideHoverAction?: boolean
   collectionPopoverHide?: boolean
+  hideListing?: boolean
 }>()
 
 const emit = defineEmits(['total', 'loading'])

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -60,7 +60,7 @@
         </NeoButton>
       </div>
       <div
-        v-else-if="isOwner && listVisible(urlPrefix)"
+        v-else-if="isOwner && listVisible(urlPrefix) && !hideListing"
         class="flex"
       >
         <NeoButton
@@ -113,6 +113,7 @@ const props = defineProps<{
   hideMediaInfo?: boolean
   hideAction?: boolean
   hideVideoControls?: boolean
+  hideListing?: boolean
   displayNameWithSn?: boolean
   showTimestamp?: boolean
   collectionPopoverHide?: boolean

--- a/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
+++ b/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
@@ -59,7 +59,7 @@
         </NeoButton>
       </div>
       <div
-        v-else-if="isOwner"
+        v-else-if="isOwner && !hideListing"
         class="flex"
       >
         <template v-if="isStack">
@@ -129,6 +129,7 @@ const props = defineProps<{
   displayNameWithSn?: boolean
   lazyLoading?: boolean
   skeletonVariant: string
+  hideListing?: boolean
 }>()
 
 const {

--- a/layouts/unlockable-mint-layout.vue
+++ b/layouts/unlockable-mint-layout.vue
@@ -8,7 +8,6 @@
     <LazyCookieBanner />
     <KeyboardShortcutsModal />
     <Buy />
-    <ListingCartMini />
     <ListingCartModal />
   </div>
 </template>


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- listing from the nft grid should not be possible in the drop page 
- removed listing cart mini in the drop page


<img src=https://github.com/user-attachments/assets/50404985-67f4-4af1-96ae-4f06fea0e102 width=400 />


- [x] Closes #10646


## Needs Design check

- @exezbcz please review

## Screenshot 📸

- [x] My fix has changed **something** on UI; 


https://github.com/user-attachments/assets/b580e3ad-7e09-4cad-b317-062ba5ad8eae

