### PR TITLE
fix: Minting NFT - "dancing"

### DIFF
--- a/components/shared/SkeletonLoader.vue
+++ b/components/shared/SkeletonLoader.vue
@@ -86,10 +86,10 @@ const calculateTextContainerWidth = () => {
 
   nextTick(() => {
     const title = titleRef.value?.clientWidth || 0
-    const substitle = subtitleRef.value?.clientWidth || 0
-    const subtitlePlusDots = substitle + DOTS_PLUS_MARGIN_WIDTH
+    const subtitle = subtitleRef.value?.clientWidth || 0
+    const subtitlePlusDots = subtitle + DOTS_PLUS_MARGIN_WIDTH
 
-    if (substitle && subtitlePlusDots > title) {
+    if (subtitle && subtitlePlusDots > title) {
       textContainerWidth.value = `${subtitlePlusDots}px`
     }
   })

--- a/components/shared/SkeletonLoader.vue
+++ b/components/shared/SkeletonLoader.vue
@@ -82,15 +82,16 @@ const calculateTextContainerWidth = () => {
     return
   }
 
+  textContainerWidth.value = undefined
+
   nextTick(() => {
     const title = titleRef.value?.clientWidth || 0
     const substitle = subtitleRef.value?.clientWidth || 0
     const subtitlePlusDots = substitle + DOTS_PLUS_MARGIN_WIDTH
 
-    textContainerWidth.value
-      = substitle && subtitlePlusDots > title
-        ? `${subtitlePlusDots}px`
-        : undefined
+    if (substitle && subtitlePlusDots > title) {
+      textContainerWidth.value = `${subtitlePlusDots}px`
+    }
   })
 }
 


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

if you open the signing modal the **second time**, that section is not fixed starts "dancing"

- [x] Closes #11069


## How to reproduce 

````
<template>
  <SigningModal
    :title="'asd'"
    :is-loading="isLoading"
    :status="status"
  />

  <NeoButton @click="open">
    open
  </NeoButton>
</template>

<script lang="ts" setup>
import { NeoButton } from '@kodadot1/brick'
import type { TransactionStatus } from '@/composables/useTransactionStatus'

definePageMeta({
  layout: 'no-footer',
})

const isLoading = ref(false)
const status = ref(TransactionStatus.Unknown)
const opened = ref(false)

const sleep = (ms: number) => {
  return new Promise(resolve => setTimeout(resolve, ms))
}

const open = async () => {
  isLoading.value = true

  status.value = TransactionStatus.Casting
  await sleep(400)

  status.value = TransactionStatus.Broadcast
  await sleep(1000)

  status.value = TransactionStatus.Block
  await sleep(2000)

  if (opened.value) {
    return
  }

  status.value = TransactionStatus.Finalized
  opened.value = true
}
</script>

````

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

### ❌

https://github.com/user-attachments/assets/8261885e-27b6-4e8b-9436-e612f6f9f28b


### ✅

https://github.com/user-attachments/assets/adde6dca-6c1f-4654-ba08-0c577bf5d1da

