### PR TITLE
feat: offer fees displayed in the modal

### DIFF
--- a/components/offer/MakeOffer.vue
+++ b/components/offer/MakeOffer.vue
@@ -28,6 +28,15 @@
           <MakingOfferSingleItem v-if="offerStore.items.length === 1" />
         </div>
 
+        <div class="border-t pt-5 pb-4 px-6">
+          <div
+            class="flex justify-between text-k-grey border-b-k-shade"
+          >
+            <span>{{ $t('offer.offerFees') }}</span>
+            <span class="ml-2">{{ teleportTransitionTxFees }}</span>
+          </div>
+        </div>
+
         <div class="flex justify-between px-6">
           <AutoTeleportActionButton
             ref="autoTeleportButton"
@@ -55,7 +64,7 @@ import ModalBody from '@/components/shared/modals/ModalBody.vue'
 import { usePreferencesStore } from '@/stores/preferences'
 import type { Actions, TokenToOffer } from '@/composables/transaction/types'
 import { useMakingOfferStore } from '@/stores/makeOffer'
-import { calculateBalance } from '@/utils/format/balance'
+import format, { calculateBalance } from '@/utils/format/balance'
 import { warningMessage } from '@/utils/notification'
 import ModalIdentityItem from '@/components/shared/ModalIdentityItem.vue'
 import AutoTeleportActionButton, {
@@ -87,7 +96,7 @@ const {
 const { notification, lastSessionId, updateSession } = useLoadingNotfication()
 const { itemsInChain, hasInvalidOfferPrices, count } = storeToRefs(offerStore)
 
-const { decimals } = useChain()
+const { decimals, chainSymbol } = useChain()
 const { $i18n } = useNuxtApp()
 const items = ref<MakingOfferItem[]>([])
 
@@ -103,6 +112,14 @@ const getAction = (items: MakingOfferItem[]): Actions => {
     } as TokenToOffer)),
   }
 }
+
+const teleportTransitionTxFees = computed(() =>
+  format(
+    (autoTeleportButton.value?.optimalTransition.txFees || 0) + OFFER_MINT_PRICE,
+    decimals.value,
+    chainSymbol.value,
+  ),
+)
 
 const { action, autoTeleport, autoTeleportButton, autoTeleportLoaded } = useAutoTeleportActionButton({
   getActionFn: () => getAction(itemsInChain.value),

--- a/locales/en.json
+++ b/locales/en.json
@@ -1485,6 +1485,7 @@
     "newOffer": "New Offer",
     "offerAccept": "Accepting Offer",
     "offerCreation": "Offer Creation",
+    "offerFees": "Offer Fee",
     "offerWithdrawl": "Offer Cancelation",
     "typeOffer": "Type An Offer",
     "yourOffer": "Your Offer",


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Feature

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #11040

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

  
<img width="528" alt="image" src="https://github.com/user-attachments/assets/c0a47a22-7f91-4f6f-b0e5-83c87965e7ee">

0.05dot + tx fee  
  
<img width="411" alt="image" src="https://github.com/user-attachments/assets/afc127d7-461a-405d-b2e5-58f839ece7f6">

0.0005 KSM + tx fee