### PR TITLE
:nail_care: show date only when it is defined

### DIFF
--- a/components/collection/CollectionInfo.vue
+++ b/components/collection/CollectionInfo.vue
@@ -55,7 +55,7 @@
           </tippy>
           <span class="text-neutral-5 mx-2">•</span>
         </span>
-        <span>
+        <span v-if="createdAt">
           <span class="capitalize text-neutral-7">{{ $t('created') }}</span>&nbsp;{{ new Date(createdAt).toLocaleDateString() }}
           <span class="text-neutral-5 mx-2">•</span>
         </span>


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

I was trying to find out why do we have 'Invalid Date' on collections, as this info is passed from the server I do not see why is it failing.

This PR hides the date when date is undefined

```bash
> createdAt = '2024-08-01T11:09:48.000000Z'
'2024-08-01T11:09:48.000000Z'
> new Date(createdAt).toLocaleDateString()
'8/1/2024'
> new Date(undefined).toLocaleDateString()
'Invalid Date'
```

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![Screenshot 2024-10-06 at 13 42 53](https://github.com/user-attachments/assets/1ff05b72-87c6-4c56-9fda-9f92c4d16854)

![Screenshot 2024-10-06 at 13 52 32](https://github.com/user-attachments/assets/325171d2-9364-4c29-b612-d082a0f9f4dd)
