### PR TITLE
🔧 ImageMedia object-contain

### DIFF
--- a/libs/ui/src/components/MediaItem/type/ImageMedia.vue
+++ b/libs/ui/src/components/MediaItem/type/ImageMedia.vue
@@ -82,7 +82,7 @@ const loading = computed<'eager' | 'lazy'>(() =>
 
 const className = computed(() =>
   !props.original && !props.isFullscreen
-    ? 'object-cover absolute inset-0 w-full h-full !rounded-none'
+    ? 'object-contain absolute inset-0 w-full h-full !rounded-none'
     : 'block !rounded-none',
 )
 


### PR DESCRIPTION
Here we go again

- close #11102 
- `/ahp/gallery/244-125`

![Screenshot 2024-10-15 at 13-37-19 OG WUD BURN NFT Collection 🔥🔥🔥🔥 One Stop Shop for Polkadot NFTs](https://github.com/user-attachments/assets/fb0981dc-8bec-4dd2-a708-44a93271f55e)

![Screenshot 2024-10-15 at 13-37-29 BRONZE #73 - OG WUD BURN NFT One Stop Shop for Polkadot NFTs](https://github.com/user-attachments/assets/347275b2-f28a-4a59-9710-6dcae4d563c0)
