### PR TITLE
feat: code checker more validation

### DIFF
--- a/components/codeChecker/CodeChecker.vue
+++ b/components/codeChecker/CodeChecker.vue
@@ -279,8 +279,7 @@ const onFileSelected = async (file: File) => {
   clear()
   startClock()
   selectedFile.value = file
-  const { indexFile, sketchFile, entries }
-    = await extractAssetsFromZip(file)
+  const { indexFile, sketchFile, p5File, entries } = await extractAssetsFromZip(file)
 
   if (!indexFile) {
     errorMessage.value = `Index file not found: Please make sure that “index.html” is in the root directory`
@@ -291,6 +290,12 @@ const onFileSelected = async (file: File) => {
     errorMessage.value = `Sketch file not found: ${config.sketchFile}`
     return
   }
+
+  if (!p5File) {
+    errorMessage.value = `p5 file not found: Please make sure that “p5.min.js” is in the root directory`
+    return
+  }
+
   const valid = validate(indexFile.content, sketchFile.content)
   if (!valid.isSuccess) {
     errorMessage.value = valid.error ?? 'Unknown error'

--- a/components/codeChecker/codechecker.config.js
+++ b/components/codeChecker/codechecker.config.js
@@ -1,6 +1,7 @@
 export default {
   iframeId: 'sketch-iframe',
   sketchFile: 'sketch.js',
+  p5File: 'p5.min.js',
   p5: 'p5',
   maxAllowedLoadTime: 3000, // in ms
   varaitionsOptions: [1, 3, 5, 10, 15, 20],

--- a/components/codeChecker/validate.ts
+++ b/components/codeChecker/validate.ts
@@ -30,6 +30,7 @@ const constants = {
   localP5JsRegex: /<script.*src="(?!http)([^"]*p5[^"]*\.js)"/,
   titleTagRegex: /<title>(.*?)<\/title>/,
   kodaRendererRegex: /kodahash\/render\/completed/,
+  kodaRendererCalledRegex: /(?<!function\s)postMessageKoda\s*\(/,
   resizerRegex: /resizeCanvas\(/,
   disallowedTitle: 'KodaHash',
 }
@@ -141,7 +142,7 @@ const validateSketchContent = (
     canvasSize,
     localP5jsUsed: false, // This will be set based on HTML content checks
     validTitle: false, // This will be updated after HTML content checks
-    kodaRendererUsed: constants.kodaRendererRegex.test(sketchFileContent),
+    kodaRendererUsed: constants.kodaRendererRegex.test(sketchFileContent) && constants.kodaRendererCalledRegex.test(sketchFileContent),
     resizerUsed: constants.resizerRegex.test(sketchFileContent),
     usesHashParam: validateURLParamsUsage(sketchFileContent).isSuccess,
   }


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring


## Context

Arkain faced some issues doing his drop 

<img src=https://github.com/user-attachments/assets/ec91f3f1-85e8-48f6-a7c9-c79f9ba832c0 width=200 />

- add: check if `p5.min.js` file is present, will show 
![CleanShot 2024-10-19 at 10 25 03@2x](https://github.com/user-attachments/assets/46906c68-6c78-4730-b8a2-496ca0fac5a2)
- add: check if `postMessageKoda` is called , will show 

![CleanShot 2024-10-19 at 10 30 25@2x](https://github.com/user-attachments/assets/eb2b1084-a375-460b-bada-b852b0295830)

@JustLuuuu would you want a separate check ? or is this clear enough? or we can change the copy to include 


postMessageKoda() is not called at the end of the draw() function

````
function draw() {
  background(bg)
  // Once the drawing is done, we can send the image to the parent window
  postMessageKoda()
}
````




