### PR TITLE
fix: Collection Explorer details not loading when going back

### DIFF
--- a/components/collection/utils/useCollectionDetails.ts
+++ b/components/collection/utils/useCollectionDetails.ts
@@ -145,6 +145,7 @@ export const useCollectionMinimal = ({
 
       collection.value = collectionData
     },
+    { immediate: true },
   )
 
   watchEffect(async () => {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #11121

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/user-attachments/assets/f2d657a2-2767-4aad-9930-ba5deb7e5fa4


