### PR TITLE
fix: Error createCanvas function not found

### DIFF
--- a/components/codeChecker/validate.ts
+++ b/components/codeChecker/validate.ts
@@ -38,7 +38,8 @@ const constants = {
 const validateCanvasCreation = (
   sketchFileContent: string,
 ): Result<RegExpExecArray> => {
-  const canvasMatch = constants.canvasRegex.exec(sketchFileContent)
+  // Create a new regex instance to avoid issues with lastIndex when using the global flag.
+  const canvasMatch = new RegExp(constants.canvasRegex).exec(sketchFileContent)
   if (!canvasMatch) {
     return { isSuccess: false, error: 'createCanvas function not found.' }
   }


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

### Issue
`canvasRegex` uses the global flag (`g`), which causes the regex's `lastIndex` to be updated after each match. This results in returning `null` on alternating calls, leading to show `Error createCanvas function not found`

either this solution or remove the global flag `g`  

- [x] Closes #11169

## Screenshot 📸

- [] My fix has changed **something** on UI; 
