### PR TITLE
fix: profile page `swaps` tab is always visible

### DIFF
--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -594,7 +594,9 @@ const tabs = computed(() => {
     tabs.push(ProfileTab.OFFERS)
   }
 
-  tabs.push(ProfileTab.SWAPS)
+  if (swapVisible(urlPrefix.value)) {
+    tabs.push(ProfileTab.SWAPS)
+  }
 
   return tabs
 })


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

![CleanShot 2024-12-11 at 08 52 02@2x](https://github.com/user-attachments/assets/4c6e9f48-693b-4a85-a6ed-2893be3ed61b)

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2024-12-11 at 09 06 35@2x](https://github.com/user-attachments/assets/81fe9412-1695-40ed-99fb-d32ffc859286)
