### PR TITLE
fix: remove useRoute warning

### DIFF
--- a/components/common/ChainDropdown.vue
+++ b/components/common/ChainDropdown.vue
@@ -6,7 +6,7 @@
           class="chain-dropdown-text"
           :variant="variant"
           :label="
-            isMobile || !showNetworkLabel
+            isMobileDevice || !showNetworkLabel
               ? label || selected?.text
               : `Network: ${selected?.text}`
           "
@@ -31,6 +31,7 @@
 <script setup lang="ts">
 import { NeoButton, NeoDropdown, NeoDropdownItem, type NeoButtonVariant } from '@kodadot1/brick'
 import { type Prefix } from '@kodadot1/static'
+import { isMobileDevice } from '@/utils/extension'
 
 const props = withDefaults(
   defineProps<{
@@ -57,7 +58,6 @@ const route = useReactiveRoute()
 const { setUrlPrefix, urlPrefix } = usePrefix()
 const { availableChains: allChains, availableChainsByVm: allChainInVm } = useChain()
 const { redirectAfterChainChange } = useChainRedirect()
-const { isMobile } = useViewport()
 
 const prefix = computed(() => route.params.prefix || urlPrefix.value)
 

--- a/composables/usePrefix.ts
+++ b/composables/usePrefix.ts
@@ -2,26 +2,16 @@ import { DEFAULT_PREFIX } from '@kodadot1/static'
 import type { Prefix } from '@kodadot1/static'
 import { useWalletStore } from '@/stores/wallet'
 import { useAssetsStore } from '@/stores/assets'
-import { getAvailablePrefix } from '@/utils/chain'
 
 const sharedPrefix = ref<Prefix>()
 
 export default function () {
-  const route = useRoute()
   const storage = useLocalStorage('urlPrefix', { selected: DEFAULT_PREFIX })
-  const initialPrefixFromPath = getAvailablePrefix(route.path.split('/')[1])
   const walletStore = useWalletStore()
-
-  const validPrefixFromRoute = computed(() =>
-    getAvailablePrefix(route.params.prefix),
-  )
 
   const prefix = computed<Prefix>(
     () =>
-      (sharedPrefix.value
-        || validPrefixFromRoute.value
-        || storage.value.selected
-        || initialPrefixFromPath) as Prefix,
+      (sharedPrefix.value || storage.value.selected) as Prefix,
   )
 
   const handlePrefixChange = (value: Prefix) => {

--- a/tests/e2e/redirect.spec.ts
+++ b/tests/e2e/redirect.spec.ts
@@ -6,13 +6,13 @@ test('Redirections', async ({ page }) => {
   // Collection
   await test.step('Expect collection url to be properly redirected', async () => {
     await page.goto('/ahk/explore/gallery')
-    await expect(page).toHaveURL('/ahk/explore/items')
+    await expect(page).toHaveURL('/ahk/explore/items?listed=true')
   })
 
   // Statemine
   await test.step('Expect url with stmn to be properly redirected', async () => {
     await page.goto('/stmn/explore/items')
-    await expect(page).toHaveURL('/ahk/explore/items')
+    await expect(page).toHaveURL('/ahk/explore/items?listed=true')
   })
 
   // Transfer

--- a/utils/chain.ts
+++ b/utils/chain.ts
@@ -48,12 +48,6 @@ export const isPrefixVmOf = (prefix: Prefix, vm: ChainVM) =>
     .map(({ value }) => value)
     .includes(prefix)
 
-export const getAvailablePrefix = (prefix: string): string => {
-  return availablePrefixes().some(chain => chain.value === prefix)
-    ? prefix
-    : ''
-}
-
 export const chainIcons = {
   ahk: '/token/kusama_asset_hub.svg',
   ahp: '/token/polkadot_asset_hub.svg',


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context
- [x] fix useRoute warning on homepage

<img width="712" alt="Screenshot 2024-12-15 at 18 49 57" src="https://github.com/user-attachments/assets/d16be19d-0f83-4984-93ab-9e191ccc097e" />

I can't recall what `useRoute` does on `usePrefix`. Did I break something with these changes?
