### PR TITLE
fix: Mass mint with one nft would lead to wrong metadata

### DIFF
--- a/composables/transaction/mintToken/transactionMintStatemine.ts
+++ b/composables/transaction/mintToken/transactionMintStatemine.ts
@@ -125,7 +125,9 @@ const getArgs = async (item: ActionMintToken, api: ApiPromise) => {
     tokenSymbol,
   )
 
-  const tokenTxsArgs = Array.isArray(item.token)
+  const isMultipleTokens = Array.isArray(item.token) && item.token.length > 1
+
+  const tokenTxsArgs = isMultipleTokens
     ? await handleMultipleTokens(item, api)
     : await handleSingleToken(item, api)
 


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #11263
