### PR TITLE
ci: adjust assethub endpoint

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shardTotal: [10]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/libs/static/src/endpoints.ts
+++ b/libs/static/src/endpoints.ts
@@ -21,6 +21,7 @@ const POLKADOT_ENDPOINTS: WS_URL[] = [
 ]
 
 const AHP_ENDPOINTS: WS_URL[] = [
+  'wss://statemint.api.onfinality.io/public-ws',
   'wss://polkadot-asset-hub-rpc.polkadot.io',
   'wss://sys.ibp.network/statemint',
   'wss://statemint-rpc.dwellir.com',


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context
- [x] based on e2e error on main branch https://github.com/kodadot/nft-gallery/actions/runs/12430119135/job/34704922979 fails on assethub endpoint instance. lets use another endpoint at the moment for ahp
- [x] increase playwright sharding. i assume 1 instance on github actions have 1 ip. increase the sharding to reduce too many request on same instance