### PR TITLE
fix: Empty swap table with valid swaps

### DIFF
--- a/components/common/EditNftModal.vue
+++ b/components/common/EditNftModal.vue
@@ -139,7 +139,7 @@ watch(isModalActive, (value) => {
     initImage()
     name.value = props.metadata?.name
     description.value = props.metadata?.description
-    attributes.value = structuredClone(toRaw(props.metadata?.attributes || []))
+    attributes.value = cloneRawObject(props.metadata?.attributes || [])
   }
 })
 </script>

--- a/components/gallery/useGalleryItem.ts
+++ b/components/gallery/useGalleryItem.ts
@@ -64,8 +64,12 @@ export const useGalleryItem = (nftId?: string): GalleryItem => {
     },
   })
 
-  const refreshToken = async () => {
+  const getIndexerToken = () => {
     refetch({ id })
+  }
+
+  const refreshToken = async () => {
+    getIndexerToken()
     getOdaToken()
   }
 
@@ -120,7 +124,8 @@ export const useGalleryItem = (nftId?: string): GalleryItem => {
         id
       }
     }`,
-    onChange: refetch,
+    onChange: getIndexerToken,
+    immediate: false,
   })
 
   useSubscriptionGraphql({

--- a/components/trade/TradeActivityTable.vue
+++ b/components/trade/TradeActivityTable.vue
@@ -135,7 +135,7 @@ const where = computed(() => {
   return { id_in: id_in.flat() }
 })
 
-const { items: trades, loading: loadingTrades } = useTrades({ where, disabled: computed(() => !tradeIds.value), type: props.type })
+const { items: trades, loading: loadingTrades } = useTrades({ where, disabled: computed(() => !Object.keys(where.value).length), type: props.type })
 
 watch(activeTab, value => replaceUrl({ filter: value }))
 

--- a/components/trade/TradeActivityTable.vue
+++ b/components/trade/TradeActivityTable.vue
@@ -135,7 +135,7 @@ const where = computed(() => {
   return { id_in: id_in.flat() }
 })
 
-const { items: trades, loading: loadingTrades, refetch } = useTrades({ where, disabled: computed(() => !tradeIds.value), type: props.type })
+const { items: trades, loading: loadingTrades } = useTrades({ where, disabled: computed(() => !tradeIds.value), type: props.type })
 
 watch(activeTab, value => replaceUrl({ filter: value }))
 
@@ -155,13 +155,6 @@ useSubscriptionGraphql({
     }
   `,
   onChange: ({ data }) => {
-    if (tradeIds.value && (
-      (isIncomingActive.value && tradeIds.value.incoming.length !== data.incoming.length)
-      || (isOutgoingActive.value && tradeIds.value.outgoing.length !== data.outgoing.length))
-    ) {
-      refetch({ where: where.value })
-    }
-
     tradeIds.value = {
       incoming: data.incoming.map(item => item.id),
       outgoing: data.outgoing.map(item => item.id),

--- a/composables/transaction/mintCollection/useNewCollectionId.ts
+++ b/composables/transaction/mintCollection/useNewCollectionId.ts
@@ -1,36 +1,3 @@
-import { getRandomValues } from '@/components/unique/utils'
-import { mapToId } from '@/utils/mappers'
-import { unwrapSafe } from '@/utils/uniquery'
-
-export function useNewCollectionId() {
-  const newCollectionId = ref<number>()
-  const randomNumbers = getRandomValues(10).map(String)
-
-  const { data, error, loading, refetch } = useGraphql({
-    queryName: 'existingCollectionList',
-    variables: {
-      ids: randomNumbers,
-    },
-  })
-
-  watch(data, () => {
-    if (data.value) {
-      const collectionEntities = data.value.collectionEntities
-      const collectionList = unwrapSafe(collectionEntities)
-      const existingIds = collectionList.map(mapToId)
-      const newId = randomNumbers.find(id => !existingIds.includes(id))
-      newCollectionId.value = Number(newId)
-    }
-  })
-
-  return {
-    newCollectionId,
-    loading,
-    error,
-    refetch,
-  }
-}
-
 export function useStatemineNewCollectionId() {
   const { apiInstance } = useApi()
   const { $consola } = useNuxtApp()

--- a/composables/useGraphql.ts
+++ b/composables/useGraphql.ts
@@ -17,6 +17,7 @@ export default function<T = unknown>({
   variables = {},
   disabled = computed(() => false),
 }: UseGraphqlParams) {
+  const currentRequestId = ref(0) // simple solution to ensure only the latest query result updates the state.
   const loading = ref(true)
   const data = ref()
 
@@ -29,13 +30,18 @@ export default function<T = unknown>({
   const doFetch = async (variables: Variables) => {
     try {
       loading.value = true
+      const requestId = ++currentRequestId.value
+
       const response = await useAsyncGraphql<T>({
         query: queryName,
         variables,
         clientId: clientName ? unref(clientName) : undefined,
         prefix: prefix,
       })
-      data.value = response.data.value
+
+      if (currentRequestId.value === requestId) {
+        data.value = response.data.value
+      }
     }
     catch (err) {
       dangerMessage(`${err as string}`)

--- a/composables/useGraphql.ts
+++ b/composables/useGraphql.ts
@@ -23,7 +23,7 @@ export default function<T = unknown>({
   const { client: clientPrefix } = usePrefix()
   const { $consola } = useNuxtApp()
   const prefix = queryPrefix || clientPrefix.value
-  const queryKey = computed(() => [prefix, queryName, JSON.stringify(variables.value)].join('-'))
+  const queryKey = computed(() => [prefix, queryName, JSON.stringify(cloneRawObject(variables))].join('-'))
   const enabled = computed(() => !unref(disabled))
 
   const doFetch = async (variables: Variables) => {

--- a/composables/useGraphql.ts
+++ b/composables/useGraphql.ts
@@ -49,14 +49,12 @@ export default function<T = unknown>({
     enabled,
   })
 
-  async function doFetch({
-    variables: extraVariables = {},
-  }: DoFetchParams = {}) {
+  const doFetch = async ({ variables: extraVariables }: DoFetchParams = {}) => {
     queryVariables.value = { ...unref(variables), ...extraVariables }
     refetchQuery()
   }
 
-  async function refetch(variables: Record<string, unknown> = {}) {
+  const refetch = async (variables?: Variables) => {
     await doFetch({ variables })
   }
 

--- a/composables/useGraphql.ts
+++ b/composables/useGraphql.ts
@@ -1,100 +1,73 @@
 import type { ComputedRef } from 'vue'
-import resolveQueryPath from '@/utils/queryPathResolver'
+import { useQuery } from '@tanstack/vue-query'
+
+type Variables = Record<string, unknown>
 
 interface DoFetchParams {
-  variables?: Record<string, unknown>
+  variables?: Variables
 }
 
-type UseGraphqlParams<T> = {
+type UseGraphqlParams = {
   queryPrefix?: string
   queryName: string
-  clientName?: string | ComputedRef<string>
-  variables?: MaybeRef<Record<string, unknown>>
+  clientName?: MaybeRef<string>
+  variables?: MaybeRef<Variables>
   disabled?: ComputedRef<boolean>
-  data?: Ref<T | undefined>
-  error?: Ref<unknown>
-  loading?: Ref<boolean>
 }
 
 export default function<T = unknown>({
-  queryPrefix = '',
   queryName,
-  clientName = '',
+  queryPrefix = undefined,
+  clientName = undefined,
   variables = {},
   disabled = computed(() => false),
-  data = ref<T>(),
-  error = ref(),
-  loading = ref(true),
-}: UseGraphqlParams<T>) {
-  const dynamicVariablesWatcher = ref()
-  const fetched = ref(false)
-
+}: UseGraphqlParams) {
   const { client: clientPrefix } = usePrefix()
   const { $consola } = useNuxtApp()
 
   const prefix = queryPrefix || clientPrefix.value
-  const client = clientName || clientPrefix.value
+
+  const queryVariables = ref()
+  const enabled = computed(() => !unref(disabled) && Boolean(queryVariables.value))
+
+  const { data, refetch: refetchQuery, isLoading: loading } = useQuery({
+    queryKey: [prefix, queryName, computed(() => JSON.stringify(queryVariables.value))],
+    queryFn: async () => {
+      try {
+        return (await useAsyncGraphql<T>({
+          query: queryName,
+          variables: queryVariables.value,
+          clientId: clientName ? unref(clientName) : undefined,
+          prefix: prefix,
+        })).data.value
+      }
+      catch (err) {
+        dangerMessage(`${err as string}`)
+        $consola.error(err)
+      }
+    },
+    enabled,
+  })
 
   async function doFetch({
     variables: extraVariables = {},
   }: DoFetchParams = {}) {
-    const query = await resolveQueryPath(prefix, queryName)
-
-    try {
-      loading.value = true
-      const { data: result } = await useAsyncQuery<T>({
-        query: query.default,
-        variables: {
-          ...unref(variables),
-          ...extraVariables,
-        },
-        clientId: unref(client),
-      })
-      data.value = result.value
-      fetched.value = true
-    }
-    catch (err) {
-      ;(error.value as unknown) = err
-      dangerMessage(`${err as string}`)
-      $consola.error(err)
-    }
-    finally {
-      loading.value = false
-    }
+    queryVariables.value = { ...unref(variables), ...extraVariables }
+    refetchQuery()
   }
 
   async function refetch(variables: Record<string, unknown> = {}) {
-    await doFetch({
-      variables,
-    })
+    await doFetch({ variables })
   }
 
-  const watchRefVariables = () => {
-    if (!dynamicVariablesWatcher.value) {
-      dynamicVariablesWatcher.value = watchEffect(() => {
-        if (!disabled.value) {
-          refetch(unref(variables))
-        }
-      })
-    }
-  }
-
-  const fetchWatcher = watchEffect(() => {
-    if (fetched.value) {
-      return fetchWatcher()
-    }
-
-    if (isRef(variables)) {
-      watchRefVariables()
-    }
-    else if (!disabled.value) {
-      doFetch()
+  watchEffect(() => {
+    if (!disabled.value) {
+      queryVariables.value = structuredClone(toRaw(unref(variables)))
     }
   })
 
   return {
     data,
-    error,
     refetch,
     loading,
   }

--- a/composables/useTrades.ts
+++ b/composables/useTrades.ts
@@ -62,7 +62,7 @@ export type TradeNftItem<T = Trade> = T & {
   isEntireCollectionDesired: boolean
 }
 
-export const TRADES_QUERY_MAP: Record<TradeType, { queryName: string, dataKey: string }> = {
+export const TRADES_QUERY_MAP: Record<TradeType, { queryName: string, dataKey: 'swaps' | 'offers' }> = {
   [TradeType.SWAP]: {
     queryName: 'swapsList',
     dataKey: 'swaps',
@@ -92,10 +92,9 @@ export default function ({ where = {}, limit = 100, disabled = computed(() => fa
   const {
     data,
     loading: fetching,
-    refetch,
-  } = useGraphql<{ offers: BaseTrade[] }>({
+  } = useGraphql<{ offers: Offer[] } | { swpas: Swap[] }>({
     queryName,
-    variables: variables.value,
+    variables,
     disabled,
   })
 
@@ -126,17 +125,8 @@ export default function ({ where = {}, limit = 100, disabled = computed(() => fa
     getCurrentBlock().then(b => currentBlock.value = b)
   }
 
-  if (isRef(where)) {
-    watch([where, disabled], () => {
-      if (!disabled.value) {
-        refetch(variables.value)
-      }
-    })
-  }
-
   return {
     items,
-    refetch,
     loading,
   }
 }

--- a/queries/subsquid/general/existingCollectionList.graphql
+++ b/queries/subsquid/general/existingCollectionList.graphql
@@ -1,5 +1,0 @@
-query existingCollectionList($ids: [String!]) {
-  collectionEntities(where: {id_in: $ids}) {
-    id
-  }
-}

--- a/utils/mappers.ts
+++ b/utils/mappers.ts
@@ -24,7 +24,3 @@ export const logError = (
     cb(error.message)
   }
 }
-
-export function mapToId(value: { id: string }): string {
-  return value.id
-}

--- a/utils/objects.ts
+++ b/utils/objects.ts
@@ -24,3 +24,5 @@ export const getMovedItemToFront = (
 
   return newArr
 }
+
+export const cloneRawObject = <T>(obj: MaybeRef<T>) => structuredClone(toRaw(unref(obj)))


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

## Context

Adds the ability to pass `variables` as `ref` to `useGraphql`

reviewers kindly also test , tyvm

- removed: unsued code `useNewCollectionId ` 
- fix: gallery item refetch with wrong params
- [x] Closes #11296

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

![CleanShot 2024-12-26 at 13 23 40](https://github.com/user-attachments/assets/3b2df58b-a829-4865-aa16-c418b6040ae8)
