### PR TITLE
fix: clicking on item in atomic swap should open new tab

### DIFF
--- a/components/items/ItemsGrid/ItemsGrid.vue
+++ b/components/items/ItemsGrid/ItemsGrid.vue
@@ -43,6 +43,7 @@
               ? 'minimal'
               : 'primary'
           "
+          :link-target="linkTarget"
         />
         <ItemsGridImageTokenEntity
           v-else
@@ -51,6 +52,7 @@
           :hide-action="hideNFTHoverAction"
           :hide-listing="hideListing"
           hide-video-controls
+          :link-target="linkTarget"
           :lazy-loading="
             shouldLazyLoad({
               cols: slotProps.cols,
@@ -148,6 +150,7 @@ const props = defineProps<{
   hideHoverAction?: boolean
   collectionPopoverHide?: boolean
   hideListing?: boolean
+  linkTarget?: string
 }>()
 
 const emit = defineEmits(['total', 'loading'])

--- a/components/items/ItemsGrid/ItemsGridImage.vue
+++ b/components/items/ItemsGrid/ItemsGridImage.vue
@@ -16,6 +16,7 @@
     bind-key="to"
     :media-static-video="hideVideoControls"
     media-hover-on-cover-play
+    :link-target="linkTarget"
   >
     <template
       v-if="!hideAction"
@@ -106,6 +107,7 @@ const props = defineProps<{
   collectionPopoverHide?: boolean
   lazyLoading?: boolean
   skeletonVariant: string
+  linkTarget?: string
 }>()
 
 const {

--- a/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
+++ b/components/items/ItemsGrid/ItemsGridImageTokenEntity.vue
@@ -20,6 +20,7 @@
     :media-static-video="hideVideoControls"
     :lazy-loading="lazyLoading"
     media-hover-on-cover-play
+    :link-target="linkTarget"
   >
     <template
       v-if="!hideAction"
@@ -123,6 +124,7 @@ const props = defineProps<{
   lazyLoading?: boolean
   skeletonVariant: string
   hideListing?: boolean
+  linkTarget?: string
 }>()
 
 const {

--- a/components/shared/nftCard/NftCard.vue
+++ b/components/shared/nftCard/NftCard.vue
@@ -6,6 +6,7 @@
     <component
       :is="link"
       v-if="!isLoading && nft"
+      :target="linkTarget"
       :[bindKey]="href"
     >
       <img
@@ -142,6 +143,7 @@ const props = withDefaults(
     hideMediaInfo?: boolean
     linkTo?: string
     lazyLoading?: boolean
+    linkTarget?: string
   }>(),
   {
     collectionPopoverShowDelay: 500,

--- a/components/swap/GridList.vue
+++ b/components/swap/GridList.vue
@@ -10,6 +10,7 @@
       :search="query"
       grid-size="medium"
       :grid-section="gridSection"
+      link-target="_blank"
       :hide-hover-action="!selectable"
     >
       <template


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #11324

Click nft would open new tab on these pages
1. select others swap items
2. select my swap items
3. review swap
