### PR TITLE
fix: Not recognising links in collection description

### DIFF
--- a/components/shared/Markdown.vue
+++ b/components/shared/Markdown.vue
@@ -15,6 +15,7 @@ defineProps<{
 
 const markdown = new MarkdownIt({
   breaks: true,
+  linkify: true,
   highlight: (code: string, lang: string) => {
     if (lang && Prism.languages[lang]) {
       return `<pre class="language-${lang}"><code>${Prism.highlight(


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #11348

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

`/ahp/collection/244`
<img width="797" alt="image" src="https://github.com/user-attachments/assets/d9a2089f-3304-4990-b4ec-da013f515cbb" />

`/ahp/collection/281`
<img width="761" alt="image" src="https://github.com/user-attachments/assets/31013957-8d3a-4e06-8d47-95911bb0a390" />


