### PR TITLE
fix: incorrect redirect swap link

### DIFF
--- a/components/common/ConnectWallet/WalletAssetTrades.vue
+++ b/components/common/ConnectWallet/WalletAssetTrades.vue
@@ -66,7 +66,7 @@
                 <div class="flex items-center gap-2 text-sm truncate">
                   <nuxt-link
                     v-if="trade.type === TradeType.SWAP"
-                    :to="`${urlPrefix}/gallery/${trade.offered.id}`"
+                    :to="`/${urlPrefix}/gallery/${trade.offered.id}`"
                   >
                     <span>
                       {{ trade.offered.name }}
@@ -84,7 +84,7 @@
 
                   <nuxt-link
                     v-if="trade.desired"
-                    :to="`${urlPrefix}/gallery/${trade.desired.id}`"
+                    :to="`/${urlPrefix}/gallery/${trade.desired.id}`"
                   >
                     <span>
                       {{ trade.desired.name }}
@@ -92,7 +92,7 @@
                   </nuxt-link>
                   <nuxt-link
                     v-else
-                    :to="`${urlPrefix}/collection/${trade.considered.id}`"
+                    :to="`/${urlPrefix}/collection/${trade.considered.id}`"
                   >
                     <span>
                       {{ trade.considered.name }}


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Context: wrong relative paths are showing on the sidebar `incoming Offers/Trades`
`href="/ahk/gallery/ahk/gallery/379-4228294367"`

canary:
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/ecdbe620-30c2-41ce-b0e7-afa6d0b28138" />


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/e647b294-bb68-49e7-8747-e184a7caf18c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved navigation in the wallet asset trades section by ensuring that all links now resolve correctly, leading to a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->