### PR TITLE
fix: Broken style on nft details page

### DIFF
--- a/layouts/gallery-item-layout.vue
+++ b/layouts/gallery-item-layout.vue
@@ -3,8 +3,8 @@
     <Navbar />
     <main class="flex-grow py-8">
       <div
-        class="grow relative mx-auto my-0 max-lg:!px-0 items-stretch flex min-h-[3.25rem] w-full"
-        :class="{ 'w-full max-w-none md:!px-10 !px-5': !isTouch }"
+        class="relative mx-auto my-0 max-lg:!px-0 min-h-[3.25rem] w-full"
+        :class="{ 'max-w-none md:!px-10 !px-5': !isTouch }"
       >
         <Error
           v-if="$nuxt.isOffline"

--- a/libs/ui/src/scss/tailwind.scss
+++ b/libs/ui/src/scss/tailwind.scss
@@ -148,6 +148,6 @@
   }
 
   .container-fluid {
-    @apply grow relative w-full max-w-none mx-auto my-0 md:px-10 px-5 #{!important};
+    @apply grow relative w-full max-w-none mx-auto my-0 md:px-10 px-5;
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #11460

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/708806c6-7298-48e1-8c3f-adba250c809e" />


<img width="1262" alt="image" src="https://github.com/user-attachments/assets/3b35dee0-fde6-48a4-9822-4a5688d79059" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Refined the gallery item layout for a cleaner, more consistent display with improved spacing and alignment.
	- Adjusted CSS rules for the `.container-fluid` class to enhance style prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->