### PR TITLE
fix: remove old wallet detection

### DIFF
--- a/stores/wallet.ts
+++ b/stores/wallet.ts
@@ -20,21 +20,11 @@ interface State {
   disconnecting: boolean
 }
 
-const getOldWallet = (): WalletAccount | undefined =>
-  localStorage.getItem('kodaauth')
-    ? ({
-        vm: 'SUB',
-        address: localStorage.getItem('kodaauth') as string,
-        name: localStorage.getItem('walletname') as string,
-        extension: localStorage.getItem('wallet') as string,
-      } as WalletAccount)
-    : undefined
-
 const RECENT_WALLET_DAYS_PERIOD = 30
 
 export const useWalletStore = defineStore('wallet', {
   state: (): State => ({
-    selected: getOldWallet(),
+    selected: undefined,
     history: undefined,
     disconnecting: false,
   }),


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context
- [x] Probably fix #11328

---

Since we are not using `localStorage.clear()` anymore, old keys still remain. Some keys might conflict with our current implementation. What if we remove the old keys detection?

how to reproduce on canary:
1. run `localStorage.setItem('kodaauth', "1xjvRADwdJcnmUCLWerEHR4iGCT5EBTm4D4fzLLg4LcAC9p")` in the browser console
2. reload the page, and then logout
3. reload the page, start to mint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the wallet initialization process by removing the automatic restoration of previously saved wallet data. The wallet now starts with a cleared state, ensuring a more streamlined setup process for new sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->