### PR TITLE
fix: No polkadot accounts found

### DIFF
--- a/components/common/ConnectWallet/WalletMenuItem.vue
+++ b/components/common/ConnectWallet/WalletMenuItem.vue
@@ -109,7 +109,7 @@
     </div>
 
     <div
-      v-if="walletAccountsWithProfile.length === 0 && showAccountList"
+      v-if="!isAuth && walletAccountsWithProfile.length === 0 && showAccountList"
       class="account-list"
     >
       <div class="account-item">


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #11465

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/user-attachments/assets/9758fe14-d240-42c2-ade6-1e7801ea1354



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the wallet menu's account list display so it now appears only for non-authenticated users, ensuring clearer visibility of account options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->