### PR TITLE
fix: check balance before creating swap

### DIFF
--- a/components/swap/Preview.vue
+++ b/components/swap/Preview.vue
@@ -87,9 +87,21 @@
               icon-left="plus"
               no-shadow
               :label="$t('add')"
-              :disabled="surchargeDisabled || !amount"
+              :disabled="surchargeDisabled || !amount || insufficientBalance"
               @click="addSurcharge"
             />
+          </div>
+          <div
+            v-if="isOfferedSwapStep"
+            class="flex align-center text-xs"
+            :class="{ 'text-k-red': insufficientBalance }"
+          >
+            <div class="flex gap-1">
+              {{ $t('general.balance') }}:
+              <span>
+                {{ balance }} {{ chainSymbol }}
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -146,6 +158,8 @@ const { decimals } = useChain()
 const { urlPrefix } = usePrefix()
 const { getChainIcon } = useIcon()
 const isCollectionSwap = computed(() => swap.value.isCollectionSwap)
+const { chainSymbol } = useChain()
+const { balance } = useDeposit(urlPrefix)
 
 const stepDetailsMap: ComputedRef<Partial<Record<SwapStep, StepDetails>>> = computed(() => ({
   [SwapStep.DESIRED]: {
@@ -178,6 +192,8 @@ const stepHasSurcharge = computed(() => swap.value.surcharge?.direction === step
 const count = computed(() => stepItems.value.length + (stepHasSurcharge.value ? 1 : 0))
 const isOverOneToOneSwap = computed(() => swap.value.offered.length > swap.value.desired.length && props.step === SwapStep.OFFERED)
 const isCollectionSwapDesired = computed(() => isCollectionSwap.value && props.step === SwapStep.DESIRED)
+const isOfferedSwapStep = computed(() => props.step === SwapStep.OFFERED)
+const insufficientBalance = computed(() => isOfferedSwapStep.value && balance.value <= Number(amount.value))
 
 const disabled = computed(() => {
   if ((!accountId.value && props.step === SwapStep.OFFERED) || isOverOneToOneSwap.value) {

--- a/components/swap/Preview.vue
+++ b/components/swap/Preview.vue
@@ -134,6 +134,7 @@
 <script setup lang="ts">
 import { NeoButton } from '@kodadot1/brick'
 import { useElementVisibility } from '@vueuse/core'
+import { teleportExistentialDeposit } from '@kodadot1/static'
 import { sanitizeIpfsUrl } from '@/utils/ipfs'
 import { type SwapSurchargeDirection } from '@/composables/transaction/types'
 import { SwapStep } from '@/components/swap/types'
@@ -154,11 +155,10 @@ const swapStore = useAtomicSwapStore()
 const { swap } = storeToRefs(swapStore)
 const { $i18n } = useNuxtApp()
 const { accountId } = useAuth()
-const { decimals } = useChain()
+const { decimals, chainSymbol } = useChain()
 const { urlPrefix } = usePrefix()
 const { getChainIcon } = useIcon()
 const isCollectionSwap = computed(() => swap.value.isCollectionSwap)
-const { chainSymbol } = useChain()
 const { balance } = useDeposit(urlPrefix)
 
 const stepDetailsMap: ComputedRef<Partial<Record<SwapStep, StepDetails>>> = computed(() => ({
@@ -193,7 +193,7 @@ const count = computed(() => stepItems.value.length + (stepHasSurcharge.value ? 
 const isOverOneToOneSwap = computed(() => swap.value.offered.length > swap.value.desired.length && props.step === SwapStep.OFFERED)
 const isCollectionSwapDesired = computed(() => isCollectionSwap.value && props.step === SwapStep.DESIRED)
 const isOfferedSwapStep = computed(() => props.step === SwapStep.OFFERED)
-const insufficientBalance = computed(() => isOfferedSwapStep.value && balance.value <= Number(amount.value))
+const insufficientBalance = computed(() => isOfferedSwapStep.value && balance.value < Number(amount.value) + teleportExistentialDeposit[urlPrefix.value] / Math.pow(10, decimals.value))
 
 const disabled = computed(() => {
   if ((!accountId.value && props.step === SwapStep.OFFERED) || isOverOneToOneSwap.value) {


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs Design check

- @exezbcz please review

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #11479
Display current balance and check if he has enough balance to add additional fund

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="411" alt="image" src="https://github.com/user-attachments/assets/4a67a7e6-053a-417a-9f54-0e6265ec6518" />
<img width="411" alt="image" src="https://github.com/user-attachments/assets/184753b0-efae-48ca-aeb6-521eb1db84ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the preview for swap transactions by displaying the current balance and chain symbol during the process.
  - Enhanced action button behavior by automatically disabling it when your balance is insufficient, with visual cues (red text) to indicate low funds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->