### PR TITLE
fix: Can't close Delete Collection Modal

### DIFF
--- a/components/common/autoTeleport/AutoTeleportActionButton.vue
+++ b/components/common/autoTeleport/AutoTeleportActionButton.vue
@@ -230,10 +230,9 @@ const hasNoFundsAtAll = computed(
 )
 
 const confirmButtonTitle = computed<string>(() => {
-  const interaction
-    = props.interaction || transactions.value.actions[0].interaction
+  const interaction = props.interaction || transactions.value.actions[0]?.interaction
 
-  return getActionDetails(interaction).confirm
+  return interaction ? getActionDetails(interaction).confirm : ''
 })
 
 const showAddFunds = computed(() => isReady.value && hasNoFundsAtAll.value)


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring


## Context

- [x] Closes #11485

## Screenshot 📸

- [x] My fix has changed **something** on UI; 

https://github.com/user-attachments/assets/8eeea66f-b91b-4fae-88a6-a8010d1c132b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of the teleport action button so it now handles missing information gracefully, ensuring a smoother interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->