### PR TITLE
fix: unity nft mint fee

### DIFF
--- a/components/create/Confirm/PriceItem.vue
+++ b/components/create/Confirm/PriceItem.vue
@@ -71,7 +71,7 @@
           </NeoTooltip>
         </div>
         <div class="flex items-center">
-          {{ nft.kodadotUSDFee }} USD ~
+          {{ nft.kodaUSDFee }} USD ~
           <Money
             :value="kodadotFee"
             :unit-symbol="chainSymbol"

--- a/composables/transaction/mintToken/utils.ts
+++ b/composables/transaction/mintToken/utils.ts
@@ -26,11 +26,14 @@ export const calculateFees = () => {
   const enabledFees: boolean
     = preferences.getHasSupport || preferences.getHasCarbonOffset
 
-  const feeMultiplier
-    = Number(preferences.getHasSupport)
-    + 2 * Number(preferences.getHasCarbonOffset)
+  const kodaUSDFee = Number(preferences.getHasSupport ? BASE_FEE : 0)
+  const carbonlessUSDFee = Number(preferences.getHasCarbonOffset ? BASE_FEE * 2 : 0)
 
-  return { enabledFees, feeMultiplier, token: symbol as SupportTokens }
+  const feeMultiplier
+    = kodaUSDFee
+    + carbonlessUSDFee
+
+  return { enabledFees, kodaUSDFee, carbonlessUSDFee, feeMultiplier, token: symbol as SupportTokens }
 }
 
 export const getNameInNotifications = (item: ActionMintToken) => {


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Related #11488
The mint fees are different in different places. It shows a base fee of 0.5 USD but finally charges 1 USD in the transaction. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mint confirmations now display an enhanced fee breakdown, offering users a clearer view of fee components and conversion details.

- **Refactor**
  - The fee calculation process has been revamped for improved accuracy and consistency, ensuring fees are computed and presented more reliably during token minting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->