### PR TITLE
fix: Change link to hello in swap page

### DIFF
--- a/components/swap/landing.vue
+++ b/components/swap/landing.vue
@@ -15,6 +15,14 @@
         <p class="mb-2">
           {{ $t('swap.landingSubtitle') }}
         </p>
+        <a
+          class="text-k-blue hover:text-k-blue-hover"
+          href="https://hello.kodadot.xyz/tutorial/swap-nft-for-nft"
+          target="_blank"
+          rel="nofollow noopener noreferrer"
+        >
+          {{ $t('swap.learnMoreAboutSwaps') }}
+        </a>
       </div>
 
       <div>


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Closes #11496

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

<img width="834" alt="image" src="https://github.com/user-attachments/assets/139850b0-1261-4646-9fb8-2c820d4703dc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new tutorial link on the NFT swap landing page. This link directs you to a comprehensive guide on swapping NFTs, opens in a new tab, and includes enhanced security and SEO attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->