### PR TITLE
refactor: replace neoicon with nuxt icon (4)

### DIFF
--- a/components/collection/drop/requirement/PrivateMintRequirements.vue
+++ b/components/collection/drop/requirement/PrivateMintRequirements.vue
@@ -50,9 +50,8 @@
         root-class="ml-2"
         content-class="capitalize"
       >
-        <NeoIcon
-          icon="fa-info-circle"
-          pack="fa-regular"
+        <KIcon
+          name="i-mdi:information-slab-circle"
           class="text-k-grey"
         />
 
@@ -83,10 +82,10 @@
           {{ mintLabel }}
         </p>
 
-        <NeoIcon
+        <KIcon
           v-if="readyToMint"
           class="ml-1"
-          icon="check"
+          name="i-mdi:check"
         />
       </div>
     </div>
@@ -94,7 +93,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon, NeoTooltip } from '@kodadot1/brick'
+import { NeoTooltip } from '@kodadot1/brick'
 import type { HolderOfCollection } from '../types'
 import { useCollectionMinimal } from '@/components/collection/utils/useCollectionDetails'
 import { useDrop, useDropMinimumFunds } from '@/components/drops/useDrops'

--- a/components/collection/unlockable/UnlockableItemInfo.vue
+++ b/components/collection/unlockable/UnlockableItemInfo.vue
@@ -6,8 +6,8 @@
         class="flex-1 lg:flex-0 lg:w-1/2 flex flex-col justify-center order-1"
       >
         <div class="flex items-center font-bold text-base mb-2">
-          <NeoIcon
-            icon="unlock"
+          <KIcon
+            name="i-mdi:lock-open"
             class="mr-2"
           />
           {{ $t('mint.unlockable.howItemWork') }}
@@ -43,7 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 
 const props = defineProps({
   collectionId: {

--- a/components/common/ChooseCollectionDropdown.vue
+++ b/components/common/ChooseCollectionDropdown.vue
@@ -48,8 +48,8 @@
           class="w-full"
         >
           <div class="w-full">
-            <NeoIcon
-              icon="plus"
+            <KIcon
+              name="i-mdi:plus"
               class="mr-1"
             />
             {{ $t('massmint.createNewCollection') }}
@@ -70,8 +70,8 @@
           class="w-full"
         >
           <div class="w-full">
-            <NeoIcon
-              icon="plus"
+            <KIcon
+              name="i-mdi:plus"
               class="mr-1"
             />
             {{ $t('massmint.createNewCollection') }}
@@ -87,7 +87,6 @@ import {
   NeoButton,
   NeoDropdown,
   NeoDropdownItem,
-  NeoIcon,
 } from '@kodadot1/brick'
 import type { MintedCollection } from '@/composables/transaction/types'
 import { useCollectionForMint } from '@/composables/massmint/useMassMint'

--- a/components/common/ChooseCollectionDropdown.vue
+++ b/components/common/ChooseCollectionDropdown.vue
@@ -25,11 +25,10 @@
         :icon="active ? 'chevron-up' : 'chevron-down'"
       >
         {{ selectedCollection.name || selectedCollection.id }}
-        <NeoIcon
+        <KIcon
           v-if="selectedCollection"
-          icon="circle-check"
-          variant="success"
-          class="ml-3"
+          name="i-mdi:check-circle-outline"
+          class="ml-3 text-k-green"
         />
       </NeoButton>
     </template>

--- a/components/common/ConnectWallet/WalletAssetTrades.vue
+++ b/components/common/ConnectWallet/WalletAssetTrades.vue
@@ -41,9 +41,7 @@
             variant="icon"
             @click="refetch"
           >
-            <NeoIcon
-              icon="refresh"
-            />
+            <KIcon name="i-mdi:refresh" />
           </NeoButton>
         </div>
 
@@ -130,7 +128,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon, NeoButton, NeoSkeleton } from '@kodadot1/brick'
+import { NeoButton, NeoSkeleton } from '@kodadot1/brick'
 import { TradeType, type TradeNftItem } from '@/components/trade/types'
 import { TRADE_TYPE_TO_PROFILE_TAB_MAP } from '@/components/profile/utils'
 import { formatDistanceToNow } from '@/utils/datetime'

--- a/components/common/LoadPreviousPage.vue
+++ b/components/common/LoadPreviousPage.vue
@@ -3,13 +3,11 @@
     class="flex justify-center pb-4"
     @click="onClick"
   >
-    <NeoIcon icon="chevron-up" />
+    <KIcon name="i-mdi:chevron-up" />
   </a>
 </template>
 
 <script lang="ts" setup>
-import { NeoIcon } from '@kodadot1/brick'
-
 const emit = defineEmits(['click'])
 const onClick = (event) => {
   emit('click', event)

--- a/components/common/NonRecommendFieldNotification.vue
+++ b/components/common/NonRecommendFieldNotification.vue
@@ -24,8 +24,8 @@
             class="flex items-center gap-1 text-sm !text-yellow-600 hover:!text-yellow-700 capitalize"
             @click="emit('undo')"
           >
-            <NeoIcon
-              icon="undo"
+            <KIcon
+              name="i-mdi:undo"
               size="small"
             />
             {{ $t('general.undo') }}
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts" setup>
-import { NeoButton, NeoIcon } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 
 defineProps<{
   show: boolean

--- a/components/common/autoTeleport/AutoTeleportModal.vue
+++ b/components/common/autoTeleport/AutoTeleportModal.vue
@@ -28,8 +28,8 @@
         <hr class="my-4">
 
         <div class="flex items-start">
-          <NeoIcon
-            icon="lightbulb"
+          <KIcon
+            name="i-mdi:lightbulb"
             size="small"
             class="mr-2 block"
           />
@@ -65,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon, NeoModal } from '@kodadot1/brick'
+import { NeoButton, NeoModal } from '@kodadot1/brick'
 import type { AutoTeleportInteractions } from './utils'
 import { getActionDetails } from './utils'
 import type { TeleportTransition } from '@/utils/teleport'

--- a/components/common/autoTeleport/AutoTeleportPopover.vue
+++ b/components/common/autoTeleport/AutoTeleportPopover.vue
@@ -3,18 +3,16 @@
     :placement="position"
     :append-to="body"
   >
-    <NeoIcon
-      icon="fa-info-circle"
-      pack="fa-regular"
+    <KIcon
+      name="i-mdi:information-slab-circle"
       class="ml-2 text-k-grey"
     />
 
     <template #content>
       <div class="w-[16rem] bg-background-color text-sm border p-4">
         <div class="flex text-base mb-3">
-          <NeoIcon
-            icon="fa-info-circle"
-            pack="fa-regular"
+          <KIcon
+            name="i-mdi:information-slab-circle"
             class="mr-2"
           />
 
@@ -74,8 +72,6 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
-
 defineProps<{
   transition: TeleportTransition
   position: 'top' | 'left'

--- a/components/common/confirmPurchaseModal/ConfirmPurchaseModal.vue
+++ b/components/common/confirmPurchaseModal/ConfirmPurchaseModal.vue
@@ -40,7 +40,7 @@
               :label="$t('tooltip.supportFee')"
               multiline
             >
-              <NeoIcon icon="circle-question" />
+              <KIcon name="i-mdi:help-circle-outline" />
             </NeoTooltip>
           </div>
           <CommonTokenMoney :value="supportFee" />
@@ -83,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon, NeoModal, NeoTooltip } from '@kodadot1/brick'
+import { NeoModal, NeoTooltip } from '@kodadot1/brick'
 import { totalPriceUsd } from '../shoppingCart/utils'
 import ModalBody from '@/components/shared/modals/ModalBody.vue'
 import { sum } from '@/utils/math'

--- a/components/common/party/Cusor.vue
+++ b/components/common/party/Cusor.vue
@@ -7,10 +7,9 @@
       left: `${connection.cursor?.x}px`,
     }"
   >
-    <NeoIcon
+    <KIcon
       :id="`cursor-${connection.id}`"
-      icon="arrow-pointer"
-      pack="fas"
+      name="i-mdi:cursor-default-outline"
       :class="color"
     />
 
@@ -45,7 +44,6 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
 import type { CursorDetails, CursorLabel } from './CursorParty.vue'
 import type { UserDetails } from '@/composables/party/types'
 

--- a/components/common/successfulModal/TransactionSection.vue
+++ b/components/common/successfulModal/TransactionSection.vue
@@ -10,9 +10,9 @@
           : 'text-k-grey bg-k-grey-light',
       ]"
     >
-      <NeoIcon
+      <KIcon
         v-if="isFinalized"
-        icon="check"
+        name="i-mdi:check-circle-outline"
       />
 
       <p class="text-xs">

--- a/components/common/successfulModal/TransactionSection.vue
+++ b/components/common/successfulModal/TransactionSection.vue
@@ -44,9 +44,8 @@
         data-testid="tx-clipboard"
         @click="toast($t('general.copyToClipboard'))"
       >
-        <NeoIcon
-          icon="copy"
-          pack="fass"
+        <KIcon
+          name="i-mdi:content-copy"
           class="text-k-grey cursor-pointer"
         />
       </NeoButton>
@@ -55,7 +54,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 import { TransactionStatus } from '@/composables/useTransactionStatus'
 
 const props = defineProps<{

--- a/components/create/Confirm/ConfirmMintItem.vue
+++ b/components/create/Confirm/ConfirmMintItem.vue
@@ -43,8 +43,8 @@
       <div class="text-k-grey mr-2">
         {{ $t('mint.nft.modal.intoCollection') }}
       </div>
-      <NeoIcon
-        icon="arrow-right-long"
+      <KIcon
+        name="i-mdi:arrow-right"
         class="text-k-grey mr-4"
       />
       <div>{{ nft.selectedCollection?.name }}</div>
@@ -53,7 +53,6 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
 import type { ExtendedInformation } from './MintConfirmModal.vue'
 import BasicImage from '@/components/shared/view/BasicImage.vue'
 import { CreateComponent } from '@/composables/useCreate'

--- a/components/create/Confirm/PriceItem.vue
+++ b/components/create/Confirm/PriceItem.vue
@@ -45,7 +45,7 @@
             multiline
             :label="depositTooltip"
           >
-            <NeoIcon icon="circle-question" />
+            <KIcon name="i-mdi:help-circle-outline" />
           </NeoTooltip>
         </div>
         <Money
@@ -67,7 +67,7 @@
             :label="$t('mint.nft.modal.kodadotTooltip')"
             multiline
           >
-            <NeoIcon icon="circle-question" />
+            <KIcon name="i-mdi:help-circle-outline" />
           </NeoTooltip>
         </div>
         <div class="flex items-center">
@@ -129,7 +129,7 @@
 </template>
 
 <script lang="ts" setup>
-import { NeoIcon, NeoTooltip } from '@kodadot1/brick'
+import { NeoTooltip } from '@kodadot1/brick'
 import type { ExtendedInformation } from './MintConfirmModal.vue'
 import Money from '@/components/shared/format/Money.vue'
 import formatBalance, {

--- a/components/drops/calendar/DropsCalendar.vue
+++ b/components/drops/calendar/DropsCalendar.vue
@@ -27,9 +27,8 @@
               placement="right"
               :append-to="body"
             >
-              <NeoIcon
-                icon="fa-info-circle"
-                pack="fa-regular"
+              <KIcon
+                name="i-mdi:information-slab-circle"
                 class="text-k-grey"
               />
 
@@ -87,7 +86,7 @@
 </template>
 
 <script lang="ts" setup>
-import { NeoButton, NeoIcon } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 import type { Prefix } from '@kodadot1/static'
 import { addMonths, format } from 'date-fns'
 import groupBy from 'lodash/groupBy'

--- a/components/explore/ExploreSort.vue
+++ b/components/explore/ExploreSort.vue
@@ -45,10 +45,10 @@
             $i18n.t(isItems ? `sort.${option}` : `sort.collection.${option}`)
           }}
         </span>
-        <NeoIcon
+        <KIcon
           v-if="selectedSort.includes(option)"
           class="ml-2"
-          icon="check"
+          name="i-mdi:check-circle-outline"
         />
       </NeoDropdownItem>
     </NeoDropdown>
@@ -60,7 +60,6 @@ import {
   NeoButton,
   NeoDropdown,
   NeoDropdownItem,
-  NeoIcon,
 } from '@kodadot1/brick'
 import ActiveCount from './ActiveCount.vue'
 

--- a/components/gallery/GalleryCard.vue
+++ b/components/gallery/GalleryCard.vue
@@ -12,7 +12,7 @@
           v-if="emoteCount"
           class="card-image__emotes"
         >
-          <NeoIcon icon="heart" />
+          <KIcon name="i-mdi:heart" />
           <span class="align-text-bottom">{{ emoteCount }}</span>
         </span>
         <BaseMediaItem
@@ -55,7 +55,6 @@
 </template>
 
 <script lang="ts" setup>
-import { NeoIcon } from '@kodadot1/brick'
 import { processSingleMetadata } from '@/utils/cachingStrategy'
 import { getMimeType } from '@/utils/gallery/media'
 import { sanitizeIpfsUrl } from '@/utils/ipfs'

--- a/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemTrade.vue
+++ b/components/gallery/GalleryItemAction/GalleryItemActionType/GalleryItemTrade.vue
@@ -22,8 +22,8 @@
         @click="onSwapClick"
       >
         <div class="flex gap-2">
-          <NeoIcon
-            icon="arrow-right-arrow-left"
+          <KIcon
+            name="i-mdi:swap-horizontal"
           />
           <span> {{ $t('swap.swap') }}</span>
         </div>
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 import type { NFT } from '@/types'
 import { nftToOfferItem } from '@/components/common/shoppingCart/utils'
 import { usePreferencesStore } from '@/stores/preferences'

--- a/components/gallery/GalleryItemHolderOf.vue
+++ b/components/gallery/GalleryItemHolderOf.vue
@@ -4,8 +4,8 @@
     variant="warning"
   >
     <div class="flex items-center">
-      <NeoIcon
-        icon="triangle-exclamation"
+      <KIcon
+        name="i-mdi:alert"
         class="mr-2"
       />
       <span> {{ $t('drops.holderOfClaimed', [exclusiveDrop?.name]) }}</span>
@@ -14,7 +14,6 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
 import { useDrop, useHolderOfCollectionDrop } from '../drops/useDrops'
 import type { NFT } from '@/types'
 import {

--- a/components/identity/module/IdentityPopoverHeader.vue
+++ b/components/identity/module/IdentityPopoverHeader.vue
@@ -30,9 +30,9 @@
           class="text-neutral-7"
         >
           {{ shortenedAddress }}</span>
-        <NeoIcon
+        <KIcon
           v-clipboard:copy="address"
-          icon="copy"
+          name="i-mdi:content-copy"
           class="hover:text-k-blue-hover cursor-pointer text-neutral-7 hover:text-text-color"
           data-testid="identity-clipboard"
           @click="toast($t('general.copyAddressToClipboard'))"
@@ -43,8 +43,6 @@
 </template>
 
 <script lang="ts" setup>
-import { NeoIcon } from '@kodadot1/brick'
-
 defineEmits(['refresh'])
 
 const address = inject('address') as string

--- a/components/massmint/modals/MintingModal.vue
+++ b/components/massmint/modals/MintingModal.vue
@@ -19,8 +19,8 @@
         v-else
         class="flex flex-col items-center"
       >
-        <NeoIcon
-          icon="circle-check"
+        <KIcon
+          name="i-mdi:check-circle-outline"
           class="text-[2.5rem] text-k-green"
         />
         <span class="mt-4">{{ $t('massmint.mintDone') }}</span>
@@ -39,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon, NeoModal } from '@kodadot1/brick'
+import { NeoButton, NeoModal } from '@kodadot1/brick'
 
 const props = defineProps<{
   modelValue: boolean

--- a/components/massmint/modals/MobileDisclaimerModal.vue
+++ b/components/massmint/modals/MobileDisclaimerModal.vue
@@ -7,9 +7,8 @@
   >
     <div class="px-6 py-5 w-[unset] lg:w-[25rem]">
       <div class="flex text-xl mb-4 items-center">
-        <NeoIcon
-          icon="triangle-exclamation"
-          pack="fasr"
+        <KIcon
+          name="i-mdi:alert"
           class="mr-3"
         />
         <span class="font-bold">
@@ -42,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon, NeoModal } from '@kodadot1/brick'
+import { NeoButton, NeoModal } from '@kodadot1/brick'
 
 const props = defineProps<{
   modelValue: boolean

--- a/components/massmint/uploadCompressedMedia/UploadCompressedMedia.vue
+++ b/components/massmint/uploadCompressedMedia/UploadCompressedMedia.vue
@@ -3,11 +3,10 @@
     <NeoCollapsible :disabled="disabled">
       <div class="flex">
         {{ $t('massmint.uploadPics') }}
-        <NeoIcon
+        <KIcon
           v-if="showCheckmark"
-          icon="circle-check"
-          variant="success"
-          class="ml-3"
+          name="i-mdi:check-circle-outline"
+          class="ml-3 text-k-green"
         />
       </div>
       <template #content>
@@ -30,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoCollapsible, NeoIcon } from '@kodadot1/brick'
+import { NeoCollapsible } from '@kodadot1/brick'
 import DragDrop from '@/components/shared/DragDrop.vue'
 import {
   useZipFileValidator,

--- a/components/massmint/uploadDescription/UploadDescription.vue
+++ b/components/massmint/uploadDescription/UploadDescription.vue
@@ -3,11 +3,10 @@
     <NeoCollapsible :disabled="disabled">
       <div class="flex">
         {{ $t('massmint.uploadDesc') }}
-        <NeoIcon
+        <KIcon
           v-if="showCheckmark"
-          icon="circle-check"
-          variant="success"
-          class="ml-3"
+          name="i-mdi:check-circle-outline"
+          class="ml-3 text-k-green"
         />
       </div>
       <template #content>
@@ -30,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoCollapsible, NeoIcon } from '@kodadot1/brick'
+import { NeoCollapsible } from '@kodadot1/brick'
 import DragDrop from '@/components/shared/DragDrop.vue'
 import { useParseDescriptionFile } from '@/composables/massmint/useParseDescriptionFile'
 

--- a/components/profile/OrderByDropdown.vue
+++ b/components/profile/OrderByDropdown.vue
@@ -48,10 +48,10 @@
             )
           }}
         </span>
-        <NeoIcon
+        <KIcon
           v-if="selectedSort.includes(option)"
           class="ml-2"
-          icon="check"
+          name="i-mdi:check-circle-outline"
         />
       </NeoDropdownItem>
     </NeoDropdown>
@@ -65,7 +65,6 @@ import {
   NeoButton,
   NeoDropdown,
   NeoDropdownItem,
-  NeoIcon,
 } from '@kodadot1/brick'
 import {
   NFT_SQUID_SORT_COLLECTIONS,

--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -211,9 +211,8 @@
               @click="toast(String($t('toast.urlCopy')))"
             >
               <div class="flex text-nowrap w-max items-center">
-                <NeoIcon
-                  icon="copy"
-                  pack="fas"
+                <KIcon
+                  name="i-mdi:content-copy"
                   class="mr-3"
                 />
                 {{ $t('share.copyLink') }}

--- a/components/shared/DragDrop.vue
+++ b/components/shared/DragDrop.vue
@@ -37,8 +37,8 @@
           class="flex items-center"
         >
           <div class="flex flex-col justify-between">
-            <NeoIcon
-              icon="circle-check"
+            <KIcon
+              name="i-mdi:check-circle-outline"
               class="check-icon text-k-green"
             />
             <div class="flex items-center mt-6 flex-col">

--- a/components/shared/ScrollTopButton.vue
+++ b/components/shared/ScrollTopButton.vue
@@ -4,12 +4,11 @@
     class="scroll-top-button button justify-center"
     @click="scrollToTop"
   >
-    <NeoIcon icon="chevron-up" />
+    <KIcon name="i-mdi:chevron-up" />
   </button>
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
 import { useEventListener } from '@vueuse/core'
 import { SHOW_SCROLL_TOP_BUTTON_HEIGHT } from '@/utils/constants'
 

--- a/components/shared/SigningModal/SigningModalBody.vue
+++ b/components/shared/SigningModal/SigningModalBody.vue
@@ -5,8 +5,8 @@
 
   <slot>
     <div class="py-5 flex items-start">
-      <NeoIcon
-        icon="lightbulb"
+      <KIcon
+        name="i-mdi:lightbulb"
         size="small"
         class="mr-2 !block"
       />

--- a/components/shared/TransactionSteps/TransactionStepsItem.vue
+++ b/components/shared/TransactionSteps/TransactionStepsItem.vue
@@ -40,9 +40,8 @@
         >
           <p class="capitalize font-bold">
             {{ step.title }}
-            <NeoIcon
-              icon="fa-info-circle"
-              pack="fa-regular"
+            <KIcon
+              name="i-mdi:information-slab-circle"
               class="ml-2 text-k-grey"
             />
           </p>

--- a/components/shared/TransactionSteps/TransactionStepsItem.vue
+++ b/components/shared/TransactionSteps/TransactionStepsItem.vue
@@ -8,10 +8,10 @@
         :size="iconSize"
       />
 
-      <NeoIcon
+      <KIcon
         v-else-if="isCompleted"
         class="text-k-green"
-        icon="check"
+        name="i-mdi:check-circle-outline"
         :size="iconSize"
       />
 

--- a/components/swap/banner/accounts.vue
+++ b/components/swap/banner/accounts.vue
@@ -12,9 +12,9 @@
       <Auth v-else />
     </div>
     <div>
-      <NeoIcon
+      <KIcon
         class="pt-8 px-4"
-        icon="arrow-right-arrow-left"
+        name="i-mdi:swap-horizontal"
         size="large"
       />
     </div>
@@ -36,8 +36,6 @@
 </template>
 
 <script lang="ts" setup>
-import { NeoIcon } from '@kodadot1/brick'
-
 defineProps<{
   creator?: string
   counterparty: string

--- a/components/swap/review.vue
+++ b/components/swap/review.vue
@@ -34,9 +34,9 @@
         </div>
 
         <div class="hidden md:flex md:items-center">
-          <NeoIcon
+          <KIcon
             class="pt-8 px-4"
-            icon="arrow-right-arrow-left"
+            name="i-mdi:swap-horizontal"
             size="large"
           />
         </div>
@@ -113,7 +113,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon, NeoButton } from '@kodadot1/brick'
+import { NeoButton } from '@kodadot1/brick'
 import { successMessage } from '@/utils/notification'
 import { SwapStep } from '@/components/swap/types'
 

--- a/components/teleport/EDWarningModal.vue
+++ b/components/teleport/EDWarningModal.vue
@@ -7,9 +7,8 @@
   >
     <div class="px-6 py-5 max-w-[350px]">
       <div class="flex mb-4 items-center">
-        <NeoIcon
-          icon="triangle-exclamation"
-          pack="fasr"
+        <KIcon
+          name="i-mdi:alert"
           class="mr-3"
           size="medium"
         />
@@ -43,7 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoButton, NeoIcon, NeoModal } from '@kodadot1/brick'
+import { NeoButton, NeoModal } from '@kodadot1/brick'
 
 const props = defineProps<{
   modelValue: boolean

--- a/components/teleport/FundsAtRiskWarning.vue
+++ b/components/teleport/FundsAtRiskWarning.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="text-k-red flex items-center cursor-default">
-    <NeoIcon
-      icon="triangle-exclamation"
-      pack="fasr"
+    <KIcon
+      name="i-mdi:alert"
       class="mr-3"
       size="medium"
     />
@@ -43,7 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon, NeoTooltip } from '@kodadot1/brick'
+import { NeoTooltip } from '@kodadot1/brick'
 
 defineProps<{
   targetExistentialDeposit: number | string

--- a/components/trade/TradeActivityTableRow.vue
+++ b/components/trade/TradeActivityTableRow.vue
@@ -18,8 +18,8 @@
       class="flex-auto max-w-10"
     >
       <div class="flex items-center justify-start h-full">
-        <NeoIcon
-          icon="arrow-right-arrow-left"
+        <KIcon
+          name="i-mdi:swap-horizontal"
           class="text-k-grey"
         />
       </div>
@@ -127,8 +127,8 @@
             />
           </div>
 
-          <NeoIcon
-            icon="arrow-right-arrow-left"
+          <KIcon
+            name="i-mdi:swap-horizontal"
             class="text-k-grey"
           />
         </template>
@@ -221,7 +221,6 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
 import { blank } from '@/components/collection/activity/events/eventRow/common'
 import type { TradeNftItem, TradeConsidered, TradeToken } from '@/components/trade/types'
 import type { SwapSurcharge } from '@/composables/transaction/types'

--- a/components/trade/overviewModal/Content.vue
+++ b/components/trade/overviewModal/Content.vue
@@ -26,9 +26,9 @@
       />
 
       <template v-if="isSwap">
-        <NeoIcon
+        <KIcon
           class="rotate-90 text-k-grey"
-          icon="arrow-right-arrow-left"
+          name="i-mdi:swap-horizontal"
         />
 
         <!-- Offered -->
@@ -51,7 +51,6 @@
 </template>
 
 <script setup lang="ts">
-import { NeoIcon } from '@kodadot1/brick'
 import { useIsTradeOverview } from './utils'
 import TokenItemDetails from './TokenItemDetails.vue'
 import TokenInCollection from './TokenInCollection.vue'

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -114,7 +114,7 @@
               data-testid="transfer-copy-sender-address"
               @click="toast($t('general.copyAddressToClipboard'))"
             >
-              <NeoIcon icon="copy" />
+              <KIcon name="i-mdi:content-copy" />
             </a>
           </div>
           <Auth v-else />

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -269,9 +269,9 @@
         @click="addAddress"
       >
         {{ $t('transfers.addAddress') }}
-        <NeoIcon
+        <KIcon
+          name="i-mdi:plus"
           class="ml-2"
-          icon="plus"
         />
       </div>
       <div class="flex justify-between items-center mb-5">

--- a/pages/drop-checker/[chain]/[collection-id].vue
+++ b/pages/drop-checker/[chain]/[collection-id].vue
@@ -40,9 +40,9 @@
         </tr>
         <tr>
           <td>
-            <neo-icon
+            <KIcon
               v-if="collectionConfig?.maxSupply === drops.max?.toString()"
-              icon="check"
+              name="i-mdi:check-circle-outline"
               class="text-k-green"
             />
             <neo-icon
@@ -60,9 +60,9 @@
         </tr>
         <tr>
           <td>
-            <neo-icon
+            <KIcon
               v-if="collectionConfig?.mintSettings.price === drops.price"
-              icon="check"
+              name="i-mdi:check-circle-outline"
               class="text-k-green"
             />
             <neo-icon


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context
- [x] part of #796

---

updated keywords:
- icon="fa-info-circle"
- icon="unlock"
- icon="circle-check"
- icon="plus"
- icon="chevron-up"
- icon="undo"
- icon="lightbulb"
- icon="circle-question"
- icon="refresh"
- icon="arrow-pointer"
- icon="check"
- icon="copy"
- icon="arrow-right-long"
- icon="heart"
- icon="triangle-exclamation"
- icon="arrow-right-arrow-left"