### PR TITLE
fix: nfts order with mass mint

### DIFF
--- a/components/items/ItemsGrid/useItemsGrid.ts
+++ b/components/items/ItemsGrid/useItemsGrid.ts
@@ -184,7 +184,10 @@ export function useFetchSearch({
 
     const queryVariables = useTokens.value
       ? { ...defaultSearchVariables, ...tokenQueryVariables }
-      : { ...defaultSearchVariables, ...nftQueryVariables }
+      : { ...defaultSearchVariables, ...nftQueryVariables, orderBy: getRouteQueryOrderByDefault(route.query.sort, [
+          'blockNumber_DESC',
+          'sn_DESC',
+        ]) }
 
     const { $apolloClient } = useNuxtApp()
     const { data: result } = await $apolloClient.query({

--- a/components/massmint/Massmint.vue
+++ b/components/massmint/Massmint.vue
@@ -249,10 +249,11 @@ const toOnborading = () => {
     .catch($consola.warn)
 }
 
+const convertNftsToMap = (nfts: FileObject[]) => nfts.map((file, i) => ({ ...file, id: i + 1 }))
+  .reduce((acc, nft) => ({ ...acc, [nft.id]: nft }), {})
+
 const onMediaZipLoaded = ({ validFiles }: { validFiles: FileObject[] }) => {
-  NFTS.value = validFiles
-    .map((file, i) => ({ ...file, id: i + 1 }))
-    .reduce((acc, nft) => ({ ...acc, [nft.id]: nft }), {})
+  NFTS.value = convertNftsToMap(validFiles)
   mediaLoaded.value = true
 }
 const onDescriptionLoaded = (entries: Record<string, Entry>) => {
@@ -261,7 +262,8 @@ const onDescriptionLoaded = (entries: Record<string, Entry>) => {
     (acc, nft) => ({ ...acc, [nft.file.name]: nft.id }),
     {},
   )
-  Object.values(entries).forEach((entry) => {
+
+  Object.values(entries).forEach((entry, idx) => {
     if (!entry.valid) {
       return
     }
@@ -274,8 +276,14 @@ const onDescriptionLoaded = (entries: Record<string, Entry>) => {
     NFTS.value[nftId] = {
       ...NFTS.value[nftId],
       ...restOfEntry,
+      sortedIndex: idx,
     }
   })
+
+  // sort the NFTS by sortedIndex
+  const sortedNfts = Object.values(NFTS.value).sort((a, b) => (a.sortedIndex || 0) - (b.sortedIndex || 0))
+
+  NFTS.value = convertNftsToMap(sortedNfts)
 }
 
 onMounted(() => {

--- a/components/massmint/types.ts
+++ b/components/massmint/types.ts
@@ -17,6 +17,7 @@ export type NFT = {
   price?: number
   status?: Status
   attributes?: OpenSeaAttribute[]
+  sortedIndex?: number
 }
 
 export type NFTToMint = {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1102,7 +1102,7 @@
         },
         "1": {
           "codeStructure": "Code Structure",
-          "instructions": "Please ensure that the file field corresponds to the image file name (e.g., set \"file\": img1.jpg in the file field if the image has a file name of \"img1.jpg\").",
+          "instructions": "Please ensure that the file field corresponds to the image file name (e.g., set \"file\": img1.jpg in the file field if the image has a file name of \"img1.jpg\"). Note that the order of items in the description file determines the order during mass minting.",
           "subtitle": "Instructions",
           "title": "How to Name your NFTs"
         },


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] During mass mint, the order of nfts could not be controlled.

- [x] Solution: 
1. The minting order will be determined by the item's order in the description file.
2. The nfts in the collection page will be ordered by both `created date` and `sn` by default.


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://github.com/user-attachments/assets/c93030f1-dd2a-4f5e-ba13-91977d99a8f9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - NFTs in mass minting are now ordered according to the order of entries in the description file.
- **Enhancements**
  - Clarified onboarding instructions to inform users that the order of items in the description file determines the minting order.
- **Refactor**
  - Centralized logic for converting NFT arrays to maps, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->