### PR TITLE
fix: rename oruga toast

### DIFF
--- a/components/buy/Buy.vue
+++ b/components/buy/Buy.vue
@@ -48,7 +48,7 @@ const { urlPrefix } = usePrefix()
 const shoppingCartStore = useShoppingCartStore()
 const preferencesStore = usePreferencesStore()
 const fiatStore = useFiatStore()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { $i18n } = useNuxtApp()
 
 const { isTransactionSuccessful } = useTransactionSuccessful({

--- a/components/codeChecker/issueHint/CodeBlock.vue
+++ b/components/codeChecker/issueHint/CodeBlock.vue
@@ -26,7 +26,7 @@ const nw = new Normalizer({
 })
 
 const props = defineProps<{ code: string, lang: string }>()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const normalizedCode = computed(() => nw.normalize(props.code))
 const highlightedCode = computed(() => {
   const html = Prism.highlight(

--- a/components/collection/CollectionHeader.vue
+++ b/components/collection/CollectionHeader.vue
@@ -24,7 +24,7 @@ import CollectionBanner from '@/components/collection/CollectionHeader/Collectio
 
 const collectionInfo = ref()
 
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { $i18n } = useNuxtApp()
 const route = useRoute()
 const collectionId = computed(() => route.params.id.toString())

--- a/components/collection/HeroButtonRefreshMetadata.vue
+++ b/components/collection/HeroButtonRefreshMetadata.vue
@@ -11,7 +11,7 @@ import { NeoDropdownItem } from '@kodadot1/brick'
 import { refreshOdaCollectionTokensMetadata } from '@/services/oda'
 
 const route = useRoute()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
 

--- a/components/collection/HeroButtons.vue
+++ b/components/collection/HeroButtons.vue
@@ -143,7 +143,7 @@ const route = useRoute()
 const { isCurrentAccount } = useAuth()
 const { urlPrefix } = usePrefix()
 const { $i18n } = useNuxtApp()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { shareOnX, shareCollectionOnFarcaster } = useSocialShare()
 
 const collectionId = computed(() => route.params.id.toString())

--- a/components/collection/drop/HolderOfGenerative.vue
+++ b/components/collection/drop/HolderOfGenerative.vue
@@ -66,7 +66,7 @@ import useAutoTeleportModal from '@/composables/autoTeleport/useAutoTeleportModa
 
 const { $i18n, $consola } = useNuxtApp()
 const { urlPrefix } = usePrefix()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { isLogIn } = useAuth()
 const { doAfterLogin } = useDoAfterlogin()
 const {

--- a/components/collection/drop/PaidGenerative.vue
+++ b/components/collection/drop/PaidGenerative.vue
@@ -23,7 +23,7 @@ import { doAfterCheckCurrentChainVM } from '@/components/common/ConnectWallet/op
 const { urlPrefix } = usePrefix()
 const { doAfterLogin } = useDoAfterlogin()
 const { $i18n, $consola } = useNuxtApp()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { isLogIn } = useAuth()
 const { openListingCartModal } = useListingCartModal({
   clearItemsOnBeforeUnmount: true,

--- a/components/collection/drop/RefreshMetadata.vue
+++ b/components/collection/drop/RefreshMetadata.vue
@@ -22,7 +22,7 @@ const props = defineProps<{
   chain: Prefix
 }>()
 
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { $i18n } = useNuxtApp()
 
 const refreshMetadata = () => {

--- a/components/collection/drop/modal/shared/SuccessfulDrop.vue
+++ b/components/collection/drop/modal/shared/SuccessfulDrop.vue
@@ -31,7 +31,7 @@ const props = defineProps<{
 }>()
 
 const { $i18n } = useNuxtApp()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { urlPrefix } = usePrefix()
 const { accountId } = useAuth()
 const { getCollectionFrameUrl } = useSocialShare()

--- a/components/common/ConnectWallet/ConnectSubstrate.vue
+++ b/components/common/ConnectWallet/ConnectSubstrate.vue
@@ -103,7 +103,7 @@ import {
 
 const emits = defineEmits(['select'])
 
-const { toast } = useToast()
+const { toast } = useToastOruga()
 
 const forceWalletSelect = ref(false)
 const wallets = ref<BaseDotsamaWallet[]>([])

--- a/components/common/ConnectWallet/WalletAssetIdentity.vue
+++ b/components/common/ConnectWallet/WalletAssetIdentity.vue
@@ -41,7 +41,7 @@
 <script setup lang="ts">
 import { useIdentityStore } from '@/stores/identity'
 
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { neoModal } = useProgrammatic()
 const { getPrefixByAddress } = useAddress()
 const identityStore = useIdentityStore()

--- a/components/common/ShareDropdown.vue
+++ b/components/common/ShareDropdown.vue
@@ -76,7 +76,7 @@ const props = withDefaults(
 
 const route = useRoute()
 const { $i18n } = useNuxtApp()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { isMobile } = useViewport()
 const { shareOnX } = useSocialShare()
 const propsSharingContent = computed(() => props.sharingContent)

--- a/components/common/successfulModal/ShareSocialsSection.vue
+++ b/components/common/successfulModal/ShareSocialsSection.vue
@@ -91,7 +91,7 @@ const props = withDefaults(
   },
 )
 
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { shareOnX, shareOnTelegram, shareOnFarcaster } = useSocialShare()
 
 const handleShareOnX = () => {

--- a/components/common/successfulModal/TransactionSection.vue
+++ b/components/common/successfulModal/TransactionSection.vue
@@ -63,7 +63,7 @@ const props = defineProps<{
   status: TransactionStatus
 }>()
 
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { getTransactionUrl } = useExplorer()
 const { urlPrefix } = usePrefix()
 

--- a/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
+++ b/components/gallery/GalleryItemButton/GalleryItemMoreActionBtn.vue
@@ -68,7 +68,7 @@ import type { NFT } from '@/types'
 import type { Abi } from '@/composables/transaction/types'
 
 const { $i18n } = useNuxtApp()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { isCurrentAccount } = useAuth()
 const { transaction, isLoading, status } = useTransaction()
 const { listNftByNftWithMetadata } = useListingCartModal()

--- a/components/gallery/GalleryItemToolBar.vue
+++ b/components/gallery/GalleryItemToolBar.vue
@@ -89,7 +89,7 @@ const props = defineProps<{
 const { getNft: nft, getNftImage: nftImage, getNftMetadata: nftMetadata, getNftMimeType: nftMimeType, getNftAnimation: nftAnimation, getNftAnimationMimeType: nftAnimationMimeType } = storeToRefs(useNftStore())
 
 const isLoading = ref(false)
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { $i18n, $consola } = useNuxtApp()
 const imageData = ref()
 

--- a/components/identity/module/IdentityLink.vue
+++ b/components/identity/module/IdentityLink.vue
@@ -39,7 +39,7 @@ const props = defineProps<{
   address?: Address
   showClipboard?: boolean
 }>()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { urlPrefix } = usePrefix()
 
 const explorerLink = computed(() =>

--- a/components/identity/module/IdentityPopoverHeader.vue
+++ b/components/identity/module/IdentityPopoverHeader.vue
@@ -52,6 +52,6 @@ const shortenedAddress = inject('shortenedAddress') as string
 
 const identity = inject<{ [x: string]: string }>('identity')
 const { urlPrefix } = usePrefix()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { accountId } = useAuth()
 </script>

--- a/components/profile/FollowButton.vue
+++ b/components/profile/FollowButton.vue
@@ -19,7 +19,7 @@ const { $i18n } = useNuxtApp()
 const { accountId } = useAuth()
 const { getSignaturePair } = useVerifyAccount()
 const isHovered = useElementHover(buttonRef)
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { doAfterLogin } = useDoAfterlogin()
 
 const emit = defineEmits(['follow:success', 'follow:fail', 'unfollow:success'])

--- a/components/profile/ProfileDetail.vue
+++ b/components/profile/ProfileDetail.vue
@@ -512,7 +512,7 @@ const socials = {
 
 const route = useRoute()
 const { $i18n } = useNuxtApp()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { replaceUrl } = useReplaceUrl()
 const { isCurrentAccount } = useAuth()
 const { urlPrefix, client } = usePrefix()

--- a/components/profile/follow/UserRow.vue
+++ b/components/profile/follow/UserRow.vue
@@ -61,7 +61,7 @@ import shortAddress from '@/utils/shortAddress'
 const { accountId } = useAuth()
 const { $i18n } = useNuxtApp()
 const { doAfterLogin } = useDoAfterlogin()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { getSignaturePair } = useVerifyAccount()
 
 const props = defineProps<{

--- a/components/shared/TransactionLoader.vue
+++ b/components/shared/TransactionLoader.vue
@@ -132,7 +132,7 @@ const emit = defineEmits(['close', 'update:modelValue'])
 const { $i18n } = useNuxtApp()
 const { urlPrefix } = usePrefix()
 const { estimatedTimes } = useBlockTime()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 
 const estimatedTimeLeft = computed(
   () => estimatedTimes.value[props.status] || 'few',

--- a/components/transfer/Transfer.vue
+++ b/components/transfer/Transfer.vue
@@ -445,7 +445,7 @@ const { getBalance } = useBalance()
 const { fetchFiatPrice, getCurrentTokenValue } = useFiatStore()
 const { initTransactionLoader, isLoading, resolveStatus, status }
   = useTransactionStatus()
-const { toast } = useToast()
+const { toast } = useToastOruga()
 const { getTokenIconBySymbol } = useIcon()
 const { tokens } = useToken()
 const { chainExistentialDeposit } = useExistentialDeposit()

--- a/composables/useToastOruga.ts
+++ b/composables/useToastOruga.ts
@@ -1,5 +1,5 @@
 // vue composables api for toast message function
-export default function useToast() {
+export default function useToastOruga() {
   const { neoNotification } = useProgrammatic()
 
   // toast message function

--- a/utils/copyToClipboard.ts
+++ b/utils/copyToClipboard.ts
@@ -6,7 +6,7 @@ export function copyToClipboard(
   },
 ) {
   const { copy } = useClipboard({ legacy: true })
-  const { toast } = useToast()
+  const { toast } = useToastOruga()
 
   // Set default values for options
   const { toast: shouldToast = true, toastMessage = 'Copied to clipboard' }


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

## Context
- [x] rename oruga toast to avoid conflicting with nuxt-ui. ref: https://github.com/kodadot/nft-gallery/pull/11551

<img width="1291" alt="Screenshot 2025-04-30 at 15 39 12" src="https://github.com/user-attachments/assets/0249761e-d6f7-4227-8bfc-cb60a59661a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated toast notifications across multiple components to use a new toast utility for consistent message display without changing notification behavior or other functionality.

- **Chores**
  - Standardized the notification system by switching to a unified toast utility throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->