### PR TITLE
fix: reduce upload batch size

### DIFF
--- a/composables/transaction/mintToken/constructDirectoryMeta.ts
+++ b/composables/transaction/mintToken/constructDirectoryMeta.ts
@@ -81,11 +81,15 @@ const batchFiles = (files: File[], maxBatchSize: number): File[][] => {
 }
 
 export const uploadMediaFiles = async (files: File[]): Promise<string[]> => {
-  const MAX_BATCH_SIZE = 100 * 1024 * 1024 // 100 MB in bytes
+  const MAX_BATCH_SIZE = 50 * 1024 * 1024 // 50 MB in bytes
   const serialFiles = mapToSerial(files)
   const fileBatches = batchFiles(serialFiles, MAX_BATCH_SIZE)
 
-  const directoryCIDs = await Promise.all(fileBatches.map(pinDirectory))
+  const directoryCIDs: string[] = []
+  for (const batch of fileBatches) {
+    const directoryCid = await pinDirectory(batch)
+    directoryCIDs.push(directoryCid)
+  }
 
   return directoryCIDs.flatMap((directoryCid, batchIndex) =>
     fileBatches[batchIndex].map(


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context
- [x] reduce upload batch size from 100mb to 50mb
- [x] not using `Promise.all` in the batch upload to avoid exceed memory from worker side

```json
  "exceptions": [
    {
      "name": "Error",
      "message": "Worker has exceeded memory limit.",
      "timestamp": 1746491207401
    }
  ],
```