### PR TITLE
fix: drops alignment

### DIFF
--- a/components/collection/drop/GenerativePreview.vue
+++ b/components/collection/drop/GenerativePreview.vue
@@ -61,15 +61,14 @@
         </div>
         <div
           v-if="!getIsLoadingMaxCount"
-          class="font-bold flex gap-2"
+          class="font-bold flex items-center gap-2"
         >
           <span>{{ drop.minted }}</span>
           <span>/</span>
-          <span v-if="isUnlimited">
-            <KIcon
-              name="i-mdi:infinity"
-            />
-          </span>
+          <KIcon
+            v-if="isUnlimited"
+            name="i-mdi:infinity"
+          />
           <span v-else>{{ drop.max }}</span>
           <span>{{ $t('statsOverview.minted') }}</span>
         </div>

--- a/components/drops/BasicDropCard.vue
+++ b/components/drops/BasicDropCard.vue
@@ -49,13 +49,13 @@
               class="flex shrink-0 gap-4"
             >
               <slot name="supply">
-                <div>
-                  <span>{{ minted }}</span><span class="text-k-grey text-xs">/
-                    <span v-if="isUnlimited">
-                      <KIcon
-                        name="i-mdi:infinity"
-                      />
-                    </span>
+                <div class="flex items-baseline">
+                  <span>{{ minted }}</span>
+                  <span class="flex items-center text-k-grey text-xs">/
+                    <KIcon
+                      v-if="isUnlimited"
+                      name="i-mdi:infinity"
+                    />
                     <span v-else>{{ dropMax }}</span>
                   </span>
                 </div>


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] The total amount of drops is not aligned

![image](https://github.com/user-attachments/assets/b1df1d05-a07d-427e-9b71-2279f1b7c483)
![image](https://github.com/user-attachments/assets/ba87da4f-b4c6-4d20-90ee-7cb7688217bd)


## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://github.com/user-attachments/assets/f13ee26a-5fcf-4663-97bd-03801627ca57)

![image](https://github.com/user-attachments/assets/c63a2994-81ec-46a1-8ad7-e428a9f3c642)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved alignment and visual consistency of minted and supply counts for drops, ensuring better vertical alignment and grouping using flexbox.
  - Simplified the display of the infinity icon for unlimited drops for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->