### PR TITLE
fix: use lucide icon on code checker

### DIFF
--- a/components/codeChecker/TestItem.vue
+++ b/components/codeChecker/TestItem.vue
@@ -61,7 +61,7 @@ const icon = computed(() => {
   }
 
   return {
-    name: props.passed ? 'i-mdi:check' : 'i-mdi:close',
+    name: props.passed ? 'i-lucide-check' : 'i-lucide-x',
     class: props.passed ? 'text-k-green' : 'text-k-red',
   }
 })


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

## Context

- [x] use lucide icon instead on code checker page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated icons for pass/fail status to use Lucide icons for a refreshed appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->