### PR TITLE
🔧 gallery item back button

### DIFF
--- a/components/gallery/GalleryItem.vue
+++ b/components/gallery/GalleryItem.vue
@@ -13,9 +13,9 @@
           <NeoButton
             v-if="isFullscreen"
             class="back-button z-20"
+            icon-left="chevron-left"
             @click="toggleFullscreen"
           >
-            <KIcon name="i-mdi:chevron-left" />
             {{ $t('go back') }}
           </NeoButton>
           <BaseMediaItem


### PR DESCRIPTION
**before**

![Screenshot 2025-06-05 at 11-39-15 Trading Card #91 - DOOM One Stop Shop for Polkadot NFTs](https://github.com/user-attachments/assets/d519ac28-a217-49a4-90ab-bc51c64cbafd)

**after**

![Screenshot 2025-06-05 at 11-43-20 Trading Card #91 - DOOM One Stop Shop for Polkadot NFTs](https://github.com/user-attachments/assets/b08be150-4720-41b3-95b4-4e1741578977)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of the fullscreen back button in the gallery by changing how the left chevron icon is displayed. The button's functionality and label remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->