### PR TITLE
fix: wrong floor price on top collections landing

### DIFF
--- a/components/landing/topCollections/TopCollectionsCard.vue
+++ b/components/landing/topCollections/TopCollectionsCard.vue
@@ -57,7 +57,7 @@
             class="flex flex-row justify-between items-center md:flex-col md:items-start"
           >
             <p class="capitalize text-k-grey text-xs">
-              <span v-if="collection?.floorPrice || collection?.floor">
+              <span v-if="collection">
                 {{ $t('price') }}
               </span>
               <NeoSkeleton
@@ -70,15 +70,16 @@
             </p>
 
             <div
-              v-if="collection?.floorPrice || collection?.floor"
+              v-if="collection"
               class="flex gap-2 items-center max-md:flex-row-reverse"
             >
               <CommonTokenMoney
-                :value="collection.floorPrice || collection.floor"
+                v-if="collectionFloorPrice"
+                :value="collectionFloorPrice"
                 inline
                 :round="2"
               />
-
+              <span v-else>--</span>
               <div
                 v-if="formattedDiffPercent"
                 :class="color"
@@ -148,6 +149,7 @@ const { urlPrefix } = usePrefix()
 
 const timeRange = computed(() => props.timeRange || 'Month')
 
+const collectionFloorPrice = computed(() => props.collection?.floorPrice[0]?.price || 0)
 const { diffPercent, formattedDiffPercent, volume } = useCollectionVolume(
   props.collection,
   timeRange,

--- a/components/landing/topCollections/utils/types.ts
+++ b/components/landing/topCollections/utils/types.ts
@@ -1,8 +1,8 @@
-import type { Interaction } from '@/types'
+import type { Interaction, CollectionFloorPrice } from '@/types'
 
 export type CollectionEntity = {
   id: string
-  floorPrice: number
+  floorPrice: CollectionFloorPrice
   averagePrice: VolumeType
   image: string
   metadata: string

--- a/queries/subsquid/general/topCollections.graphql
+++ b/queries/subsquid/general/topCollections.graphql
@@ -10,8 +10,13 @@ query topCollections(
     media
     volume
     metadata
-    floor
-    nftCount
-    ownerCount: distribution
+    floorPrice: nfts(
+      where: { burned_eq: false, price_gt: "0" }
+      orderBy: price_ASC
+      limit: 1
+    ) {
+      price
+    }
+    
   }
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] Closes #11591

## Screenshot 📸

- [x] My fix has changed **something** on UI; a screenshot is best to understand changes for others.

![image](https://github.com/user-attachments/assets/6de0cd8d-3561-4898-b9b5-64d72505d445)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic for displaying collection floor prices, ensuring more consistent and accurate rendering of floor price information.
	- Centralized extraction of the floor price value for improved maintainability.

- **Bug Fixes**
	- Resolved issues where floor price placeholders were inconsistently shown by refining the display conditions.

- **Style**
	- Updated UI to show a placeholder (“--”) when no valid floor price is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->