### PR TITLE
fix: mass mint

### DIFF
--- a/composables/transaction/mintToken/constructDirectoryMeta.ts
+++ b/composables/transaction/mintToken/constructDirectoryMeta.ts
@@ -93,8 +93,8 @@ export const uploadMediaFiles = async (files: File[]): Promise<string[]> => {
 
   return directoryCIDs.flatMap((directoryCid, batchIndex) =>
     fileBatches[batchIndex].map(
-      (file, fileIndex) =>
-        `ipfs://${directoryCid}/${fileIndex}.${getFileSuffix(file.name)}`,
+      file =>
+        `ipfs://${directoryCid}/${file.name}`,
     ),
   )
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Needs QA check

- @kodadot/qa-guild please review

## Context

- [x] Mass mint issue


Before:
check: ttttt_Art_001 ~ ttttt_Art_015

When mass mint reach the chunk size limit, the afterward NFTs will not be able to display anymore.
Here starts from ttttt_Art_015, the uploaded nfts will have the mismatched image URL.
![image](https://github.com/user-attachments/assets/6384f380-5665-404b-ba4d-3cc13a97737d)

After fixed:
[mint_15_correct.csv](https://github.com/user-attachments/files/20893281/mint_15_correct.csv)

range: rrrr_Art_001 ~ rrrr_Art_015
![image](https://github.com/user-attachments/assets/67f693e8-2cdf-435c-bd69-aebee1529a56)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the format of IPFS URIs for uploaded files to use the original file names, making file references clearer and more intuitive for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->