### PR TITLE
fix: unable to scroll down when there is too many collections

### DIFF
--- a/components/common/ChooseCollectionDropdown.vue
+++ b/components/common/ChooseCollectionDropdown.vue
@@ -9,6 +9,7 @@
     ]"
     :no-shadow="noShadow"
     :disabled="disabled"
+    scrollable
   >
     <template #trigger="{ active }">
       <NeoButton


### PR DESCRIPTION
**Thank you for your contribution** to the [Koda - Generative Art Marketplace](https://kodadot.xyz).

👇 __ Let's make a quick check before the contribution.

## PR Type

- [x] Bugfix

## Context

- [x] unable to scroll down when there are too many collections on the minting page

![image](https://github.com/user-attachments/assets/70962088-b430-4951-be7f-34d0179a6736)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dropdown menus now support scrolling, allowing easier navigation of long lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->